### PR TITLE
Move nix-channel under deprecated commands

### DIFF
--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -101,7 +101,6 @@
     - [Profiles](command-ref/files/profiles.md)
       - [manifest.nix](command-ref/files/manifest.nix.md)
       - [manifest.json](command-ref/files/manifest.json.md)
-    - [Default Nix expression](command-ref/files/default-nix-expression.md)
 - [Architecture and Design](architecture/architecture.md)
 - [Formats and Protocols](protocols/index.md)
   - [JSON Formats](protocols/json/index.md)

--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -54,6 +54,7 @@
 {{#include ./command-ref/new-cli/SUMMARY.md}}
   - [Deprecated Commands](command-ref/main-commands.md)
     - [nix-build](command-ref/nix-build.md)
+    - [nix-channel](command-ref/nix-channel.md)
     - [nix-shell](command-ref/nix-shell.md)
     - [nix-store](command-ref/nix-store.md)
       - [nix-store --add-fixed](command-ref/nix-store/add-fixed.md)
@@ -89,7 +90,6 @@
       - [nix-env --uninstall](command-ref/nix-env/uninstall.md)
       - [nix-env --upgrade](command-ref/nix-env/upgrade.md)
   - [Utilities](command-ref/utilities.md)
-    - [nix-channel](command-ref/nix-channel.md)
     - [nix-collect-garbage](command-ref/nix-collect-garbage.md)
     - [nix-copy-closure](command-ref/nix-copy-closure.md)
     - [nix-daemon](command-ref/nix-daemon.md)

--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -101,7 +101,6 @@
     - [Profiles](command-ref/files/profiles.md)
       - [manifest.nix](command-ref/files/manifest.nix.md)
       - [manifest.json](command-ref/files/manifest.json.md)
-    - [Channels](command-ref/files/channels.md)
     - [Default Nix expression](command-ref/files/default-nix-expression.md)
 - [Architecture and Design](architecture/architecture.md)
 - [Formats and Protocols](protocols/index.md)

--- a/doc/manual/source/command-ref/files/default-nix-expression.md
+++ b/doc/manual/source/command-ref/files/default-nix-expression.md
@@ -31,12 +31,12 @@ Then, the resulting expression is interpreted like this:
 
 The file [`manifest.nix`](@docroot@/command-ref/files/manifest.nix.md) is always ignored.
 
-The command [`nix-channel`] places a symlink to the current user's [channels] in this directory, the [user channel link](#user-channel-link).
+The command [`nix-channel`] places a symlink to the current user's channels in this directory, the [user channel link](#user-channel-link).
 This makes all subscribed channels available as attributes in the default expression.
 
 ## User channel link
 
-A symlink that ensures that [`nix-env`] can find the current user's [channels]:
+A symlink that ensures that [`nix-env`] can find the current user's channels:
 
 - `~/.nix-defexpr/channels`
 - `$XDG_STATE_HOME/defexpr/channels` if [`use-xdg-base-directories`] is set to `true`.
@@ -51,4 +51,3 @@ In a multi-user installation, you may also have `~/.nix-defexpr/channels_root`, 
 [`nix-channel`]: @docroot@/command-ref/nix-channel.md
 [`nix-env`]: @docroot@/command-ref/nix-env.md
 [`use-xdg-base-directories`]: @docroot@/command-ref/conf-file.md#conf-use-xdg-base-directories
-[channels]: @docroot@/command-ref/files/channels.md

--- a/doc/manual/source/command-ref/nix-env.md
+++ b/doc/manual/source/command-ref/nix-env.md
@@ -52,7 +52,7 @@ These pages can be viewed offline:
 `nix-env` can obtain packages from multiple sources:
 
 - An attribute set of derivations from:
-  - The [default Nix expression](@docroot@/command-ref/files/default-nix-expression.md) (by default)
+  - The default Nix expression (by default)
   - A Nix file, specified via `--file`
   - A [profile](@docroot@/command-ref/files/profiles.md), specified via `--from-profile`
   - A Nix expression that is a function which takes default expression as argument, specified via `--from-expression`

--- a/doc/manual/source/command-ref/nix-env/install.md
+++ b/doc/manual/source/command-ref/nix-env/install.md
@@ -22,12 +22,11 @@ It is based on the current generation of the active [profile](@docroot@/command-
 
 The arguments *args* map to store paths in a number of possible ways:
 
-- By default, *args* is a set of [derivation] names denoting derivations in the [default Nix expression].
+- By default, *args* is a set of [derivation] names denoting derivations in the default Nix expression.
   These are [realised], and the resulting output paths are installed.
   Currently installed derivations with a name equal to the name of a derivation being added are removed unless the option `--preserve-installed` is specified.
 
   [derivation]: @docroot@/glossary.md#gloss-derivation
-  [default Nix expression]: @docroot@/command-ref/files/default-nix-expression.md
   [realised]: @docroot@/glossary.md#gloss-realise
 
   If there are multiple derivations matching a name in *args* that
@@ -45,7 +44,7 @@ The arguments *args* map to store paths in a number of possible ways:
   gcc-3.3.6 gcc-4.1.1` will install both version of GCC (and will
   probably cause a user environment conflict\!).
 
-- If [`--attr`](#opt-attr) / `-A` is specified, the arguments are *attribute paths* that select attributes from the [default Nix expression].
+- If [`--attr`](#opt-attr) / `-A` is specified, the arguments are *attribute paths* that select attributes from the default Nix expression.
   This is faster than using derivation names and unambiguous.
   Show the attribute paths of available packages with [`nix-env --query`](./query.md):
 
@@ -58,7 +57,7 @@ The arguments *args* map to store paths in a number of possible ways:
   easy way to copy user environment elements from one profile to
   another.
 
-- If `--from-expression` is given, *args* are [Nix language functions](@docroot@/language/syntax.md#functions) that are called with the [default Nix expression] as their single argument.
+- If `--from-expression` is given, *args* are [Nix language functions](@docroot@/language/syntax.md#functions) that are called with the default Nix expression as their single argument.
   The derivations returned by those function calls are installed.
   This allows derivations to be specified in an unambiguous way, which is necessary if there are multiple derivations with the same name.
 

--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -86,7 +86,7 @@ struct EvalSettings : Config
 
           - `$HOME/.nix-defexpr/channels`
 
-            The [user channel link](@docroot@/command-ref/files/default-nix-expression.md#user-channel-link), pointing to the current state of [channels](@docroot@/command-ref/files/channels.md) for the current user.
+            The user channel link pointing to the current state of channels for the current user.
 
           - `nixpkgs=$NIX_STATE_DIR/profiles/per-user/root/channels/nixpkgs`
 


### PR DESCRIPTION
Eventually we'd like to have all of the `nix-*` commands here but this is a good start.