### PR TITLE
Publish the flake as public, every time

### DIFF
--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -100,5 +100,5 @@ jobs:
       - uses: "DeterminateSystems/flakehub-push@main"
         with:
           rolling: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-          visibility: "private"
+          visibility: "public"
           tag: "${{ github.ref_name }}"


### PR DESCRIPTION
This exposed a bug in FlakeHub's private toggling, where the public 3.0.0 release followed by an accidentally private 0.1.x release, managed to cause the flake to be shunted closed.

This should not be possible, so let's dig into how that came to be and make sure to create a test case against this should-be-impossible transition.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
