### PR TITLE
Hide the "dirty" notice when running nix develop

### DIFF
--- a/src/libcmd/include/nix/cmd/command.hh
+++ b/src/libcmd/include/nix/cmd/command.hh
@@ -214,6 +214,8 @@ struct InstallableCommand : virtual Args, SourceExprCommand
 {
     InstallableCommand();
 
+    virtual void preRun(ref<Store> store);
+
     virtual void run(ref<Store> store, ref<Installable> installable) = 0;
 
     void run(ref<Store> store) override;

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -903,8 +903,13 @@ InstallableCommand::InstallableCommand()
     });
 }
 
+void InstallableCommand::preRun(ref<Store> store)
+{
+}
+
 void InstallableCommand::run(ref<Store> store)
 {
+    preRun(store);
     auto installable = parseInstallable(store, _installable);
     run(store, std::move(installable));
 }

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -1,5 +1,6 @@
 #include "nix/util/config-global.hh"
 #include "nix/expr/eval.hh"
+#include "nix/fetchers/fetch-settings.hh"
 #include "nix/cmd/installable-flake.hh"
 #include "nix/cmd/command-installable-value.hh"
 #include "nix/main/common-args.hh"
@@ -581,6 +582,11 @@ struct CmdDevelop : Common, MixEnvironment
         return
           #include "develop.md"
           ;
+    }
+
+    void preRun(ref<Store> store) override
+    {
+        fetchSettings.warnDirty = false;
     }
 
     void run(ref<Store> store, ref<Installable> installable) override


### PR DESCRIPTION
In the common case, nix develop is running against a dirty checkout of a project. This patch removes the warning about a dirty tree on nix develop only.

Close FH-736