### PR TITLE
Warn against the use of indirect flakerefs in flake inputs

### DIFF
--- a/src/libflake/flake/flake.cc
+++ b/src/libflake/flake/flake.cc
@@ -751,10 +751,12 @@ LockedFlake lockFlake(
                                 printLiteralString(s, resolvedRef.to_string());
                                 warn(
                                     "Flake input '%1%' uses the flake registry. "
-                                    "Using the registry in flake inputs is deprecated. "
+                                    "Using the registry in flake inputs is deprecated in Determinate Nix. "
                                     "To make your flake future-proof, add the following to '%2%':\n"
                                     "\n"
-                                    "  inputs.%1%.url = %3%;",
+                                    "  inputs.%1%.url = %3%;\n"
+                                    "\n"
+                                    "For more information, see: https://github.com/DeterminateSystems/nix-src/issues/37",
                                     inputAttrPathS,
                                     flake.path,
                                     s.str());

--- a/src/libflake/flake/flake.cc
+++ b/src/libflake/flake/flake.cc
@@ -740,6 +740,27 @@ LockedFlake lockFlake(
                             use --no-write-lock-file. */
                         auto ref = (input2.ref && explicitCliOverrides.contains(inputAttrPath)) ? *input2.ref : *input.ref;
 
+                        /* Warn against the use of indirect flakerefs
+                           (but only at top-level since we don't want
+                           to annoy users about flakes that are not
+                           under their control). */
+                        auto warnRegistry = [&](const FlakeRef & resolvedRef)
+                        {
+                            if (inputAttrPath.size() == 1 && !input.ref->input.isDirect()) {
+                                std::ostringstream s;
+                                printLiteralString(s, resolvedRef.to_string());
+                                warn(
+                                    "Flake input '%1%' uses the flake registry. "
+                                    "Using the registry in flake inputs is deprecated. "
+                                    "To make your flake future-proof, add the following to '%2%':\n"
+                                    "\n"
+                                    "  inputs.%1%.url = %3%;",
+                                    inputAttrPathS,
+                                    flake.path,
+                                    s.str());
+                            }
+                        };
+
                         if (input.isFlake) {
                             auto inputFlake = getInputFlake(*input.ref);
 
@@ -771,6 +792,8 @@ LockedFlake lockFlake(
                                 oldLock ? followsPrefix : inputAttrPath,
                                 inputFlake.path,
                                 false);
+
+                            warnRegistry(inputFlake.resolvedRef);
                         }
 
                         else {
@@ -782,6 +805,8 @@ LockedFlake lockFlake(
                                 } else {
                                     auto [accessor, resolvedRef, lockedRef] = fetchOrSubstituteTree(
                                         state, *input.ref, useRegistries, flakeCache);
+
+                                    warnRegistry(resolvedRef);
 
                                     // FIXME: allow input to be lazy.
                                     auto storePath = copyInputToStore(state, lockedRef.input, input.ref->input, accessor);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

We want to discourage the use of indirect flakerefs (i.e. registry lookups) in `flake.nix`. This PR causes such inputs to print a warning like this:

```
warning: Flake input 'nixpkgs' uses the flake registry. Using the registry in flake inputs is deprecated. To make your flake future-proof, add the following to '/home/eelco/Dev/patchelf/flake.nix':

  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
```

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
