### PR TITLE
Include the derivation's output path in the "dependency failed" error

### DIFF
--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -179,12 +179,12 @@ test "$(<<<"$out" grep -cE '^error:')" = 4
 out="$(nix build -f fod-failing.nix -L x4 2>&1)" && status=0 || status=$?
 test "$status" = 1
 test "$(<<<"$out" grep -cE '^error:')" = 2
-<<<"$out" grepQuiet -E "error: 1 dependency of derivation '.*-x4\\.drv' failed to build"
+<<<"$out" grepQuiet -E "error: 1 dependency of /nix/store/.*-x4 \\(derivation '.*-x4\\.drv'\\) failed to build"
 <<<"$out" grepQuiet -E "hash mismatch in fixed-output derivation '.*-x2\\.drv'"
 
 out="$(nix build -f fod-failing.nix -L x4 --keep-going 2>&1)" && status=0 || status=$?
 test "$status" = 1
 test "$(<<<"$out" grep -cE '^error:')" = 3
-<<<"$out" grepQuiet -E "error: 2 dependencies of derivation '.*-x4\\.drv' failed to build"
+<<<"$out" grepQuiet -E "error: 2 dependencies of /nix/store/.*-x4 \\(derivation '.*-x4\\.drv'\\) failed to build"
 <<<"$out" grepQuiet -vE "hash mismatch in fixed-output derivation '.*-x3\\.drv'"
 <<<"$out" grepQuiet -vE "hash mismatch in fixed-output derivation '.*-x2\\.drv'"


### PR DESCRIPTION
ref: https://linear.app/detsys/issue/FH-783/improve-the-build-failure-message

## Motivation

Semi-regularly we have folks (internal and external) get frustrated by this error message:

```
error: 1 dependencies of derivation '/nix/store/storepath-xxxxx.drv' failed to build
```

...especially when that path is expected to be substitutable, and knowing the output path would let you check binary caches.

This patch does a couple things:

1. Makes the error feel a touch more polished by properly pluralizing "dependency" / "dependencies",
2. includes the first output path of the derivation if possible, and uses the derivation name if it is not possible.

Here's what the new error looks like:

```
error: hash mismatch in fixed-output derivation '/nix/store/9kj4ljvvzz0qzqgqk46a3zg02pjffmvh-x2.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-ce9j/VcjC18vmZgcaMAqZg/qH/WibuYfiyiOYHNI5pk=
error: 1 dependency of /nix/store/glh5ni12yk22h8naf5ydzmix15ssqi9q-x4 (derivation '/nix/store/6nr7k44hwkncbp5pq46grzqa8vcjnrm4-x4.drv') failed to build
```