### PR TITLE
Only run the test step after build completes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
           path: ./tarball/*.xz
   test:
     if: ${{ inputs.if && inputs.run_tests}}
+    needs: build
     strategy:
       fail-fast: false
     runs-on: ${{ inputs.os }}


### PR DESCRIPTION
This prevents the test step from duplicating work from the build step. This minimizes contention on our macOS build infra most significantly, but the others too.
