### PR TITLE
Deprecate upgrade-nix command

### DIFF
--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -1217,11 +1217,12 @@ public:
 
     Setting<std::string> upgradeNixStorePathUrl{
         this,
-        "https://github.com/NixOS/nixpkgs/raw/master/nixos/modules/installer/tools/nix-fallback-paths.nix",
+        "",
         "upgrade-nix-store-path-url",
         R"(
-          Used by `nix upgrade-nix`, the URL of the file that contains the
-          store paths of the latest Nix release.
+          Deprecated. This option was used to configure how `nix upgrade-nix` operated.
+
+          Using this setting has no effect. It will be removed in a future release of Determinate Nix.
         )"
     };
 

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -24,7 +24,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
 
     std::string description() override
     {
-        return "(deprecated) upgrade Nix to the latest stable version";
+        return "deprecated in favor of determinate-nixd upgrade";
     }
 
     std::string doc() override

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -14,26 +14,6 @@ using namespace nix;
 
 struct CmdUpgradeNix : MixDryRun, StoreCommand
 {
-    std::filesystem::path profileDir;
-
-    CmdUpgradeNix()
-    {
-        addFlag({
-            .longName = "profile",
-            .shortName = 'p',
-            .description = "The path to the Nix profile to upgrade.",
-            .labels = {"profile-dir"},
-            .handler = {&profileDir},
-        });
-
-        addFlag({
-            .longName = "nix-store-paths-url",
-            .description = "The URL of the file that contains the store paths of the latest Nix release.",
-            .labels = {"url"},
-            .handler = {&(std::string&) settings.upgradeNixStorePathUrl},
-        });
-    }
-
     /**
      * This command is stable before the others
      */
@@ -44,7 +24,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
 
     std::string description() override
     {
-        return "upgrade Nix to the latest stable version";
+        return "(deprecated) upgrade Nix to the latest stable version";
     }
 
     std::string doc() override
@@ -58,101 +38,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
 
     void run(ref<Store> store) override
     {
-        evalSettings.pureEval = true;
-
-        if (profileDir == "")
-            profileDir = getProfileDir(store);
-
-        printInfo("upgrading Nix in profile %s", profileDir);
-
-        auto storePath = getLatestNix(store);
-
-        auto version = DrvName(storePath.name()).version;
-
-        if (dryRun) {
-            logger->stop();
-            warn("would upgrade to version %s", version);
-            return;
-        }
-
-        {
-            Activity act(*logger, lvlInfo, actUnknown, fmt("downloading '%s'...", store->printStorePath(storePath)));
-            store->ensurePath(storePath);
-        }
-
-        {
-            Activity act(*logger, lvlInfo, actUnknown, fmt("verifying that '%s' works...", store->printStorePath(storePath)));
-            auto program = store->printStorePath(storePath) + "/bin/nix-env";
-            auto s = runProgram(program, false, {"--version"});
-            if (s.find("Nix") == std::string::npos)
-                throw Error("could not verify that '%s' works", program);
-        }
-
-        logger->stop();
-
-        {
-            Activity act(*logger, lvlInfo, actUnknown,
-                fmt("installing '%s' into profile %s...", store->printStorePath(storePath), profileDir));
-
-            // FIXME: don't call an external process.
-            runProgram(getNixBin("nix-env").string(), false,
-                {"--profile", profileDir.string(), "-i", store->printStorePath(storePath), "--no-sandbox"});
-        }
-
-        printInfo(ANSI_GREEN "upgrade to version %s done" ANSI_NORMAL, version);
-    }
-
-    /* Return the profile in which Nix is installed. */
-    std::filesystem::path getProfileDir(ref<Store> store)
-    {
-        auto whereOpt = ExecutablePath::load().findName(OS_STR("nix-env"));
-        if (!whereOpt)
-            throw Error("couldn't figure out how Nix is installed, so I can't upgrade it");
-        const auto & where = whereOpt->parent_path();
-
-        printInfo("found Nix in %s", where);
-
-        if (hasPrefix(where.string(), "/run/current-system"))
-            throw Error("Nix on NixOS must be upgraded via 'nixos-rebuild'");
-
-        auto profileDir = where.parent_path();
-
-        // Resolve profile to /nix/var/nix/profiles/<name> link.
-        while (canonPath(profileDir.string()).find("/profiles/") == std::string::npos && std::filesystem::is_symlink(profileDir))
-            profileDir = readLink(profileDir.string());
-
-        printInfo("found profile %s", profileDir);
-
-        Path userEnv = canonPath(profileDir.string(), true);
-
-        if (std::filesystem::exists(profileDir / "manifest.json"))
-            throw Error("directory %s is managed by 'nix profile' and currently cannot be upgraded by 'nix upgrade-nix'", profileDir);
-
-        if (!std::filesystem::exists(profileDir / "manifest.nix"))
-            throw Error("directory %s does not appear to be part of a Nix profile", profileDir);
-
-        if (!store->isValidPath(store->parseStorePath(userEnv)))
-            throw Error("directory '%s' is not in the Nix store", userEnv);
-
-        return profileDir;
-    }
-
-    /* Return the store path of the latest stable Nix. */
-    StorePath getLatestNix(ref<Store> store)
-    {
-        Activity act(*logger, lvlInfo, actUnknown, "querying latest Nix version");
-
-        // FIXME: use nixos.org?
-        auto req = FileTransferRequest((std::string&) settings.upgradeNixStorePathUrl);
-        auto res = getFileTransfer()->download(req);
-
-        auto state = std::make_unique<EvalState>(LookupPath{}, store, fetchSettings, evalSettings);
-        auto v = state->allocValue();
-        state->eval(state->parseExprFromString(res.data, state->rootPath(CanonPath("/no-such-path"))), *v);
-        Bindings & bindings(*state->allocBindings(0));
-        auto v2 = findAlongAttrPath(*state, settings.thisSystem, bindings, *v).first;
-
-        return store->parseStorePath(state->forceString(*v2, noPos, "while evaluating the path tho latest nix version"));
+        throw Error("The upgrade-nix command isn't available in Determinate Nix; use %s instead", "sudo determinate-nixd upgrade");
     }
 };
 

--- a/src/nix/upgrade-nix.md
+++ b/src/nix/upgrade-nix.md
@@ -1,33 +1,12 @@
 R""(
 
-# Examples
-
-* Upgrade Nix to the stable version declared in Nixpkgs:
-
-  ```console
-  # nix upgrade-nix
-  ```
-
-* Upgrade Nix in a specific profile:
-
-  ```console
-  # nix upgrade-nix --profile ~alice/.local/state/nix/profiles/profile
-  ```
-
 # Description
 
-This command upgrades Nix to the stable version.
+This command isn't available in Determinate Nix but is present in order to guide
+users to the new upgrade path.
 
-By default, the latest stable version is defined by Nixpkgs, in
-[nix-fallback-paths.nix](https://github.com/NixOS/nixpkgs/raw/master/nixos/modules/installer/tools/nix-fallback-paths.nix)
-and updated manually. It may not always be the latest tagged release.
-
-By default, it locates the directory containing the `nix` binary in the `$PATH`
-environment variable. If that directory is a Nix profile, it will
-upgrade the `nix` package in that profile to the latest stable binary
-release.
-
-You cannot use this command to upgrade Nix in the system profile of a
-NixOS system (that is, if `nix` is found in `/run/current-system`).
+Use `sudo determinate-nixd upgrade` to upgrade Determinate Nix on systems that
+manage it imperatively. In practice, this is any system that isn't running
+NixOS.
 
 )""

--- a/src/nix/upgrade-nix.md
+++ b/src/nix/upgrade-nix.md
@@ -5,8 +5,7 @@ R""(
 This command isn't available in Determinate Nix but is present in order to guide
 users to the new upgrade path.
 
-Use `sudo determinate-nixd upgrade` to upgrade Determinate Nix on systems that
-manage it imperatively. In practice, this is any system that isn't running
-NixOS.
+Use `sudo determinate-nixd upgrade` to upgrade Determinate Nix on systems that manage it imperatively.
+In practice, this is any system that isn't running NixOS.
 
 )""


### PR DESCRIPTION
This PR deprecates the `nix upgrade-nix` command. Under Determinate Nix, users should use `sudo determinate-nixd upgrade` (or bump their Determinate flake input) to upgrade.