### PR TITLE
Improve lazy trees backward compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,14 @@ jobs:
                 | ".#hydraJobs.tests." + .')
 
   flake_regressions:
-    #if: github.event_name == 'merge_group'
+    if: |
+      github.event_name == 'merge_group'
+      || (
+        github.event.pull_request.head.repo.full_name == 'DeterminateSystems/nix-src'
+        && (
+          (github.event.action == 'labeled' && github.event.label.name == 'flake-regression-test')
+          || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'flake-regression-test'))
+        )
     needs: build_x86_64-linux
     runs-on: namespace-profile-x86-32cpu-64gb
     steps:
@@ -112,7 +119,14 @@ jobs:
       - run: nix build -L --out-link ./new-nix && PATH=$(pwd)/new-nix/bin:$PATH PARALLEL="-P 50%" flake-regressions/eval-all.sh
 
   flake_regressions_lazy:
-    #if: github.event_name == 'merge_group'
+    if: |
+      github.event_name == 'merge_group'
+      || (
+        github.event.pull_request.head.repo.full_name == 'DeterminateSystems/nix-src'
+        && (
+          (github.event.action == 'labeled' && github.event.label.name == 'flake-regression-test')
+          || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'flake-regression-test'))
+        )
     needs: build_x86_64-linux
     runs-on: namespace-profile-x86-32cpu-64gb
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           (github.event.action == 'labeled' && github.event.label.name == 'flake-regression-test')
           || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'flake-regression-test'))
         )
+      )
     needs: build_x86_64-linux
     runs-on: namespace-profile-x86-32cpu-64gb
     steps:
@@ -127,6 +128,7 @@ jobs:
           (github.event.action == 'labeled' && github.event.label.name == 'flake-regression-test')
           || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'flake-regression-test'))
         )
+      )
     needs: build_x86_64-linux
     runs-on: namespace-profile-x86-32cpu-64gb
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
                 | ".#hydraJobs.tests." + .')
 
   flake_regressions:
-    if: github.event_name == 'merge_group'
+    #if: github.event_name == 'merge_group'
     needs: build_x86_64-linux
     runs-on: namespace-profile-x86-32cpu-64gb
     steps:
@@ -112,7 +112,7 @@ jobs:
       - run: nix build -L --out-link ./new-nix && PATH=$(pwd)/new-nix/bin:$PATH PARALLEL="-P 50%" flake-regressions/eval-all.sh
 
   flake_regressions_lazy:
-    if: github.event_name == 'merge_group'
+    #if: github.event_name == 'merge_group'
     needs: build_x86_64-linux
     runs-on: namespace-profile-x86-32cpu-64gb
     steps:

--- a/src/libexpr-test-support/include/nix/expr/tests/value/context.hh
+++ b/src/libexpr-test-support/include/nix/expr/tests/value/context.hh
@@ -24,6 +24,11 @@ struct Arbitrary<NixStringContextElem::DrvDeep> {
 };
 
 template<>
+struct Arbitrary<NixStringContextElem::Path> {
+    static Gen<NixStringContextElem::Path> arbitrary();
+};
+
+template<>
 struct Arbitrary<NixStringContextElem> {
     static Gen<NixStringContextElem> arbitrary();
 };

--- a/src/libexpr-test-support/tests/value/context.cc
+++ b/src/libexpr-test-support/tests/value/context.cc
@@ -15,6 +15,15 @@ Gen<NixStringContextElem::DrvDeep> Arbitrary<NixStringContextElem::DrvDeep>::arb
     });
 }
 
+Gen<NixStringContextElem::Path> Arbitrary<NixStringContextElem::Path>::arbitrary()
+{
+    return gen::map(gen::arbitrary<StorePath>(), [](StorePath storePath) {
+        return NixStringContextElem::Path{
+            .storePath = storePath,
+        };
+    });
+}
+
 Gen<NixStringContextElem> Arbitrary<NixStringContextElem>::arbitrary()
 {
     return gen::mapcat(
@@ -30,6 +39,9 @@ Gen<NixStringContextElem> Arbitrary<NixStringContextElem>::arbitrary()
             case 2:
                 return gen::map(
                     gen::arbitrary<NixStringContextElem::Built>(), [](NixStringContextElem a) { return a; });
+            case 3:
+                return gen::map(
+                    gen::arbitrary<NixStringContextElem::Path>(), [](NixStringContextElem a) { return a; });
             default:
                 assert(false);
             }

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -618,21 +618,21 @@ string_t AttrCursor::getStringWithContext()
             if (auto s = std::get_if<string_t>(&cachedValue->second)) {
                 bool valid = true;
                 for (auto & c : s->second) {
-                    const StorePath & path = std::visit(overloaded {
-                        [&](const NixStringContextElem::DrvDeep & d) -> const StorePath & {
-                            return d.drvPath;
+                    const StorePath * path = std::visit(overloaded {
+                        [&](const NixStringContextElem::DrvDeep & d) -> const StorePath * {
+                            return &d.drvPath;
                         },
-                        [&](const NixStringContextElem::Built & b) -> const StorePath & {
-                            return b.drvPath->getBaseStorePath();
+                        [&](const NixStringContextElem::Built & b) -> const StorePath * {
+                            return &b.drvPath->getBaseStorePath();
                         },
-                        [&](const NixStringContextElem::Opaque & o) -> const StorePath & {
-                            return o.path;
+                        [&](const NixStringContextElem::Opaque & o) -> const StorePath * {
+                            return &o.path;
                         },
-                        [&](const NixStringContextElem::Path & p) -> const StorePath & {
-                            abort(); // FIXME
+                        [&](const NixStringContextElem::Path & p) -> const StorePath * {
+                            return nullptr;
                         },
                     }, c.raw);
-                    if (!root->state.store->isValidPath(path)) {
+                    if (!path || !root->state.store->isValidPath(*path)) {
                         valid = false;
                         break;
                     }

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -628,6 +628,9 @@ string_t AttrCursor::getStringWithContext()
                         [&](const NixStringContextElem::Opaque & o) -> const StorePath & {
                             return o.path;
                         },
+                        [&](const NixStringContextElem::Path & p) -> const StorePath & {
+                            abort(); // FIXME
+                        },
                     }, c.raw);
                     if (!root->state.store->isValidPath(path)) {
                         valid = false;

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2078,7 +2078,7 @@ void ExprConcatStrings::eval(EvalState & state, Env & env, Value & v)
     else if (firstType == nFloat)
         v.mkFloat(nf);
     else if (firstType == nPath) {
-        if (!context.empty())
+        if (hasContext(context))
             state.error<EvalError>("a string that refers to a store path cannot be appended to a path").atPos(pos).withFrame(env, *this).debugThrow();
         v.mkPath(state.rootPath(CanonPath(str())));
     } else

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2512,7 +2512,9 @@ std::pair<SingleDerivedPath, std::string_view> EvalState::coerceToSingleDerivedP
             return std::move(b);
         },
         [&](NixStringContextElem::Path && p) -> SingleDerivedPath {
-            abort(); // FIXME
+            error<EvalError>(
+                "string '%s' has no context",
+                s).withTrace(pos, errorCtx).debugThrow();
         },
     }, ((NixStringContextElem &&) *context.begin()).raw);
     return {

--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -7,9 +7,15 @@ namespace nix {
 
 static void prim_unsafeDiscardStringContext(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
-    NixStringContext context;
+    NixStringContext context, filtered;
+
     auto s = state.coerceToString(pos, *args[0], context, "while evaluating the argument passed to builtins.unsafeDiscardStringContext");
-    v.mkString(*s);
+
+    for (auto & c : context)
+        if (auto * p = std::get_if<NixStringContextElem::Path>(&c.raw))
+            filtered.insert(*p);
+
+    v.mkString(*s, filtered);
 }
 
 static RegisterPrimOp primop_unsafeDiscardStringContext({
@@ -21,12 +27,19 @@ static RegisterPrimOp primop_unsafeDiscardStringContext({
     .fun = prim_unsafeDiscardStringContext,
 });
 
+bool hasContext(const NixStringContext & context)
+{
+    for (auto & c : context)
+        if (!std::get_if<NixStringContextElem::Path>(&c.raw))
+            return true;
+    return false;
+}
 
 static void prim_hasContext(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
     NixStringContext context;
     state.forceString(*args[0], context, pos, "while evaluating the argument passed to builtins.hasContext");
-    v.mkBool(!context.empty());
+    v.mkBool(hasContext(context));
 }
 
 static RegisterPrimOp primop_hasContext({
@@ -103,7 +116,7 @@ static void prim_addDrvOutputDependencies(EvalState & state, const PosIdx pos, V
     NixStringContext context;
     auto s = state.coerceToString(pos, *args[0], context, "while evaluating the argument passed to builtins.addDrvOutputDependencies");
 
-	auto contextSize = context.size();
+    auto contextSize = context.size();
     if (contextSize != 1) {
         state.error<EvalError>(
             "context of string '%s' must have exactly one element, but has %d",
@@ -135,6 +148,10 @@ static void prim_addDrvOutputDependencies(EvalState & state, const PosIdx pos, V
                 /* FIXME: Suspicious move out of const. This is actually a copy, so the comment
                  above does not make much sense. */
                 return std::move(c);
+            },
+            [&](const NixStringContextElem::Path & p) -> NixStringContextElem::DrvDeep {
+                // FIXME: don't know what to do here.
+                abort();
             },
         }, context.begin()->raw) }),
     };
@@ -205,6 +222,8 @@ static void prim_getContext(EvalState & state, const PosIdx pos, Value * * args,
             },
             [&](NixStringContextElem::Opaque && o) {
                 contextInfos[std::move(o.path)].path = true;
+            },
+            [&](NixStringContextElem::Path && p) {
             },
         }, ((NixStringContextElem &&) i).raw);
     }

--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -150,8 +150,9 @@ static void prim_addDrvOutputDependencies(EvalState & state, const PosIdx pos, V
                 return std::move(c);
             },
             [&](const NixStringContextElem::Path & p) -> NixStringContextElem::DrvDeep {
-                // FIXME: don't know what to do here.
-                abort();
+                state.error<EvalError>(
+                    "`addDrvOutputDependencies` does not work on a string without context"
+                ).atPos(pos).debugThrow();
             },
         }, context.begin()->raw) }),
     };

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -249,7 +249,11 @@ private:
 
     void printString(Value & v)
     {
-        printLiteralString(output, v.string_view(), options.maxStringLength, options.ansiColors);
+        NixStringContext context;
+        copyContext(v, context);
+        std::ostringstream s;
+        printLiteralString(s, v.string_view(), options.maxStringLength, options.ansiColors);
+        output << state.devirtualize(s.str(), context);
     }
 
     void printPath(Value & v)

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -7,9 +7,10 @@
 #include <iomanip>
 #include <nlohmann/json.hpp>
 
-
 namespace nix {
+
 using json = nlohmann::json;
+
 json printValueAsJSON(EvalState & state, bool strict,
     Value & v, const PosIdx pos, NixStringContext & context, bool copyToStore)
 {
@@ -33,6 +34,8 @@ json printValueAsJSON(EvalState & state, bool strict,
             copyContext(v, context);
             // FIXME: only use the context from `v`.
             // FIXME: make devirtualization configurable?
+            // FIXME: don't devirtualize here? It's redundant if
+            // 'toFile' or 'derivation' also do it.
             out = state.devirtualize(v.c_str(), context);
             break;
 

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -32,11 +32,7 @@ json printValueAsJSON(EvalState & state, bool strict,
 
         case nString:
             copyContext(v, context);
-            // FIXME: only use the context from `v`.
-            // FIXME: make devirtualization configurable?
-            // FIXME: don't devirtualize here? It's redundant if
-            // 'toFile' or 'derivation' also do it.
-            out = state.devirtualize(v.c_str(), context);
+            out = v.c_str();
             break;
 
         case nPath:

--- a/src/libexpr/value/context.cc
+++ b/src/libexpr/value/context.cc
@@ -57,6 +57,11 @@ NixStringContextElem NixStringContextElem::parse(
             .drvPath = StorePath { s.substr(1) },
         };
     }
+    case '@': {
+        return NixStringContextElem::Path {
+            .storePath = StorePath { s.substr(1) },
+        };
+    }
     default: {
         // Ensure no '!'
         if (s.find("!") != std::string_view::npos) {
@@ -99,6 +104,10 @@ std::string NixStringContextElem::to_string() const
         [&](const NixStringContextElem::DrvDeep & d) {
             res += '=';
             res += d.drvPath.to_string();
+        },
+        [&](const NixStringContextElem::Path & p) {
+            res += '@';
+            res += p.storePath.to_string();
         },
     }, raw);
 

--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -92,6 +92,9 @@ UnresolvedApp InstallableValue::toApp(EvalState & state)
                         .path = o.path,
                     };
                 },
+                [&](const NixStringContextElem::Path & p) -> DerivedPath {
+                    abort(); // FIXME
+                },
             }, c.raw));
         }
 

--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -93,7 +93,7 @@ UnresolvedApp InstallableValue::toApp(EvalState & state)
                     };
                 },
                 [&](const NixStringContextElem::Path & p) -> DerivedPath {
-                    abort(); // FIXME
+                    throw Error("'program' attribute of an 'app' output cannot have no context");
                 },
             }, c.raw));
         }

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -122,7 +122,10 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
         }
 
         else if (json) {
-            logger->cout("%s", printValueAsJSON(*state, true, *v, pos, context, false));
+            logger->cout("%s",
+                state->devirtualize(
+                    printValueAsJSON(*state, true, *v, pos, context, false).dump(),
+                    context));
         }
 
         else {


### PR DESCRIPTION
## Motivation

When you apply `builtins.toString` to a path value representing a path in the Nix store (as is the case with flake inputs), historically you got a string without context (e.g. `/nix/store/...-source`). This is broken, since it allows you to pass a store path to a derivation/toFile without a proper store reference. This is especially a problem with lazy trees, since the store path is a virtual path that doesn't exist and can be different every time.
    
For backwards compatibility, and to warn users about this unsafe use of `toString`, we now keep track of such strings as a special type of context.

(The original lazy trees branch had [something similar](https://github.com/NixOS/nix/pull/6530/files#diff-d5f8268f423733bdb3457141e7014b3c4559d1a979d6b49b60a8468ba9ff31c6), but there the context was keeping track of `SourcePaths` rather than virtual `StorePaths`.)

This makes Nix with `--lazy-trees` pass the entire flake-regressions test suite.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
