### PR TITLE
Improve build failure error messages

### DIFF
--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -179,12 +179,14 @@ test "$(<<<"$out" grep -cE '^error:')" = 4
 out="$(nix build -f fod-failing.nix -L x4 2>&1)" && status=0 || status=$?
 test "$status" = 1
 test "$(<<<"$out" grep -cE '^error:')" = 2
-<<<"$out" grepQuiet -E "error: 1 dependencies of derivation '.*-x4\\.drv' failed to build"
+<<<"$out" grepQuiet -E "error: Cannot build '.*-x4\\.drv'"
+<<<"$out" grepQuiet -E "Reason: 1 dependency failed."
 <<<"$out" grepQuiet -E "hash mismatch in fixed-output derivation '.*-x2\\.drv'"
 
 out="$(nix build -f fod-failing.nix -L x4 --keep-going 2>&1)" && status=0 || status=$?
 test "$status" = 1
 test "$(<<<"$out" grep -cE '^error:')" = 3
-<<<"$out" grepQuiet -E "error: 2 dependencies of derivation '.*-x4\\.drv' failed to build"
+<<<"$out" grepQuiet -E "error: Cannot build '.*-x4\\.drv'"
+<<<"$out" grepQuiet -E "Reason: 2 dependencies failed."
 <<<"$out" grepQuiet -vE "hash mismatch in fixed-output derivation '.*-x3\\.drv'"
 <<<"$out" grepQuiet -vE "hash mismatch in fixed-output derivation '.*-x2\\.drv'"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Example output:

![image](https://github.com/user-attachments/assets/56efe605-7905-4993-a2a9-6a243c1bf126)

Compared to the existing:

![CleanShot 2025-05-09 at 09 23 41@2x](https://github.com/user-attachments/assets/0c654dcb-4e82-4164-b78b-2f6b909fad09)


```
% nix build .#nestedFailures
warning: Git tree '/Users/grahamc/src/github.com/DeterminateSystems/samples' has uncommitted changes
error: builder for '/nix/store/w37gflm9wz9dcnsgy3sfrmnlvm8qigaj-nested-failure-bottom.drv' failed with exit code 1
error: 1 dependencies of derivation '/nix/store/00gr5hlxfc03x2675w6nn3pwfrz2fr62-nested-failure-middle.drv' failed to build
error: 1 dependencies of derivation '/nix/store/8am0ng1gyx8sbzyr0yx6jd5ix3yy5szc-nested-failure-top.drv' failed to build
```

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
