### PR TITLE
Dispatch release notes with a gh token

### DIFF
--- a/.github/release-notes.sh
+++ b/.github/release-notes.sh
@@ -24,7 +24,7 @@ gh api "/repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
 trim_trailing_newlines() {
     local text
     text="$(cat)"
-    echo -n "${text//$'\n'}"
+    echo -n "${text}"
 }
 
 linkify_gh() {

--- a/.github/workflows/propose-release.yml
+++ b/.github/workflows/propose-release.yml
@@ -26,6 +26,7 @@ jobs:
       extra-commands-early: |
         echo ${{ inputs.version }} > .version-determinate
         git add .version-determinate
+        git commit -m "Set .version-determinate to ${{ inputs.version }}" || true
         ./.github/release-notes.sh
         git add doc
-        git commit -m "Set .version-determinate to ${{ inputs.version }}" || true
+        git commit -m "Generare release notes for ${{ inputs.version }}" || true


### PR DESCRIPTION
## Motivation

The propose release workflow is failing to produce release notes, because the GH_TOKEN isn't set.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
