### PR TITLE
Improve 'cannot read file from tarball' error

### DIFF
--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -219,7 +219,7 @@ time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & 
                     std::vector<unsigned char> buf(128 * 1024);
                     auto n = archive_read_data(archive.archive, buf.data(), buf.size());
                     if (n < 0)
-                        throw Error("cannot read file '%s' from tarball", path);
+                        checkLibArchive(archive.archive, n, "cannot read file from tarball: %s");
                     if (n == 0)
                         break;
                     crf(std::string_view{


### PR DESCRIPTION

## Motivation

It now says e.g.
```
error: cannot read file from tarball: Truncated tar archive detected while reading data
```

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
