### PR TITLE
Emit warnings when using import-from-derivation by setting the `trace-import-from-derivation` option to `true`

### DIFF
--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -151,6 +151,16 @@ struct EvalSettings : Config
         )"
         };
 
+    Setting<bool> traceImportFromDerivation{
+        this, false, "trace-import-from-derivation",
+        R"(
+          By default, Nix allows [Import from Derivation](@docroot@/language/import-from-derivation.md).
+
+          When this setting is `true`, Nix will log a warning indicating that it performed such an import.
+          The `allow-import-from-derivation` setting takes precedence, and no warnings will be logged if that setting is also enabled.
+        )"
+        };
+
     Setting<bool> enableImportFromDerivation{
         this, true, "allow-import-from-derivation",
         R"(

--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -157,7 +157,7 @@ struct EvalSettings : Config
           By default, Nix allows [Import from Derivation](@docroot@/language/import-from-derivation.md).
 
           When this setting is `true`, Nix will log a warning indicating that it performed such an import.
-          The `allow-import-from-derivation` setting takes precedence, and no warnings will be logged if that setting is also enabled.
+          This option has no effect if `allow-import-from-derivation` is disabled.
         )"
         };
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -97,11 +97,19 @@ StringMap EvalState::realiseContext(const NixStringContext & context, StorePathS
 
     if (drvs.empty()) return {};
 
-    if (isIFD && !settings.enableImportFromDerivation)
-        error<IFDError>(
-            "cannot build '%1%' during evaluation because the option 'allow-import-from-derivation' is disabled",
-            drvs.begin()->to_string(*store)
-        ).debugThrow();
+    if (isIFD) {
+        if (!settings.enableImportFromDerivation)
+            error<IFDError>(
+                "cannot build '%1%' during evaluation because the option 'allow-import-from-derivation' is disabled",
+                drvs.begin()->to_string(*store)
+            ).debugThrow();
+
+        if (settings.traceImportFromDerivation)
+            warn(
+                "built '%1%' during evaluation due to an import from derivation",
+                drvs.begin()->to_string(*store)
+            );
+    }
 
     /* Build/substitute the context. */
     std::vector<DerivedPath> buildReqs;

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -33,6 +33,7 @@ suites += {
     'debugger.sh',
     'source-paths.sh',
     'old-lockfiles.sh',
+    'trace-ifd.sh',
   ],
   'workdir': meson.current_source_dir(),
 }

--- a/tests/functional/flakes/trace-ifd.sh
+++ b/tests/functional/flakes/trace-ifd.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source ./common.sh
+
+requireGit
+
+flake1Dir="$TEST_ROOT/flake"
+
+createGitRepo "$flake1Dir"
+createSimpleGitFlake "$flake1Dir"
+
+cat > "$flake1Dir/flake.nix" <<'EOF'
+{
+  outputs = { self }: let inherit (import ./config.nix) mkDerivation; in {
+    drv = mkDerivation {
+      name = "drv";
+      buildCommand = ''
+        echo drv >$out
+      '';
+    };
+
+    ifd = mkDerivation {
+      name = "ifd";
+      buildCommand = ''
+        echo ${builtins.readFile self.drv} >$out
+      '';
+    };
+  };
+}
+EOF
+
+nix build "$flake1Dir#ifd" --option trace-import-from-derivation true 2>&1 \
+  | grepQuiet 'warning: built .* during evaluation due to an import from derivation'


### PR DESCRIPTION
## Motivation

While we have the `allow-import-from-derivation` option to deny IFDs, sometimes users would like to observe IFDs during CI processes to gradually phase the idiom out. This PR adds a `trace-import-from-derivation` option that, when set, logs a simple warning to the console.

