### PR TITLE
Make platform checks throw BuildError like other failures

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -862,17 +862,22 @@ void DerivationBuilderImpl::startBuilder()
 
     /* Right platform? */
     if (!drvOptions.canBuildLocally(store, drv)) {
+        auto msg = fmt(
+            "Cannot build '%s'.\n"
+            "Reason: " ANSI_RED "unmet system or feature dependency" ANSI_NORMAL "\n"
+            "Required system: '%s' with features {%s}\n"
+            "Current system: '%s' with features {%s}",
+            Magenta(store.printStorePath(drvPath)),
+            Magenta(drv.platform),
+            concatStringsSep(", ", drvOptions.getRequiredSystemFeatures(drv)),
+            Magenta(settings.thisSystem),
+            concatStringsSep<StringSet>(", ", store.config.systemFeatures));
+
         // since aarch64-darwin has Rosetta 2, this user can actually run x86_64-darwin on their hardware - we should tell them to run the command to install Darwin 2
-        if (drv.platform == "x86_64-darwin" && settings.thisSystem == "aarch64-darwin") {
-            throw Error("run `/usr/sbin/softwareupdate --install-rosetta` to enable your %s to run programs for %s", settings.thisSystem, drv.platform);
-        } else {
-            throw Error("a '%s' with features {%s} is required to build '%s', but I am a '%s' with features {%s}",
-                drv.platform,
-                concatStringsSep(", ", drvOptions.getRequiredSystemFeatures(drv)),
-                store.printStorePath(drvPath),
-                settings.thisSystem,
-                concatStringsSep<StringSet>(", ", store.config.systemFeatures));
-        }
+        if (drv.platform == "x86_64-darwin" && settings.thisSystem == "aarch64-darwin")
+          msg += fmt("\nNote: run `%s` to run programs for x86_64-darwin", Magenta("/usr/sbin/softwareupdate --install-rosetta"));
+
+        throw BuildError(msg);
     }
 
     /* Create a temporary directory where the build will take


### PR DESCRIPTION
## Motivation

Some complex derivations can depend on multiple systems. In cases where these aren't already cached (or locally buildable), Nix throws an error indicating that a derivation cannot be built. However, this does not behave the same with respect to other build errors. This PR changes the error to throw `BuildError`, allowing Nix to report the dependency tree that led to the build error, if any.

In the examples below, `needs-*` depends on a derivation that fails for the various scenarios I've tested locally.

###  Mismatched system

Before:
```
$ nix build .#needs-system
error: a 'bogus' with features {} is required to build '/nix/store/1aj7zljmh3zwff9z0pcan940kghql87c-bad-system.drv', but I am a 'x86_64-linux' with features {benchmark, big-parallel, kvm, nixos-test, uid-range}
```

After: 
```
$ nix build .#needs-system
error: Cannot build '/nix/store/1aj7zljmh3zwff9z0pcan940kghql87c-bad-system.drv'.
       Reason: unmet system or feature dependency
       Required system: 'bogus' with features {}
       Current system: 'x86_64-linux' with features {benchmark, big-parallel, kvm, nixos-test, uid-range}
error: Cannot build '/nix/store/xw31yf7yldxk163858vb8n51j9zbwnz7-needs-system.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/9qralxw4zvb5s9cii2lv04l66nygr95r-needs-system
```

### Missing required feature

Before:
```
$ nix build .#needs-feature
error: a 'x86_64-linux' with features {bogus} is required to build '/nix/store/cny1i79kcnj8cbzm17bzmnn6f74jl0rr-bad-feature.drv', but I am a 'x86_64-linux' with features {benchmark, big-parallel, kvm, nixos-test, uid-range}
```

After:
```
$ nix build .#needs-feature
error: Cannot build '/nix/store/cny1i79kcnj8cbzm17bzmnn6f74jl0rr-bad-feature.drv'.
       Reason: unmet system or feature dependency
       Required system: 'x86_64-linux' with features {bogus}
       Current system: 'x86_64-linux' with features {benchmark, big-parallel, kvm, nixos-test, uid-range}
error: Cannot build '/nix/store/ki2sn6hb4mkv0sg6c676lllmzs2alzxd-needs-feature.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/q8mp4h0s6g0qq6z72kwidlp5a7m7a9qx-needs-feature
```

### Rosetta not installed

(Note that I don't have a Mac to test on, but I've used `--system` passed to `sudo nix build` to generate this error.)

Before:
```
$ nix build .#mac-system
error: run `/usr/sbin/softwareupdate --install-rosetta` to enable your aarch64-darwin to run programs for x86_64-darwin
```

After:
```
$ nix build .#mac-system
error: Cannot build '/nix/store/2iq7bj3zgsggbn1q6vdn79fk1wiksldy-mac-system.drv'.
       Reason: unmet system or feature dependency
       Required system: 'x86_64-darwin' with features {}
       Current system: 'aarch64-darwin' with features {benchmark, big-parallel, kvm, nixos-test, uid-range}
       Note: run `/usr/sbin/softwareupdate --install-rosetta` to run programs for x86_64-darwin
```