### PR TITLE
Fix trace-ifd test failure in dev shell

### DIFF
--- a/tests/functional/flakes/trace-ifd.sh
+++ b/tests/functional/flakes/trace-ifd.sh
@@ -29,5 +29,5 @@ cat > "$flake1Dir/flake.nix" <<'EOF'
 }
 EOF
 
-nix build "$flake1Dir#ifd" --option trace-import-from-derivation true 2>&1 \
+nix build --no-link "$flake1Dir#ifd" --option trace-import-from-derivation true 2>&1 \
   | grepQuiet 'warning: built .* during evaluation due to an import from derivation'


### PR DESCRIPTION

## Motivation

Fixes

```
error: cannot create symlink '/home/eelco/Dev/nix/tests/functional/flakes/result'; already exists
```

running the test multiple times in a dev shell.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
