### PR TITLE
Call out that `--keep-failed` with remote builders will keep the failed build directory on that builder

### DIFF
--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -329,8 +329,15 @@ connected:
                 drv.inputSrcs = store->parseStorePathSet(inputs);
             optResult = sshStore->buildDerivation(*drvPath, (const BasicDerivation &) drv);
             auto & result = *optResult;
-            if (!result.success())
+            if (!result.success()) {
+                if (settings.keepFailed) {
+                    warn(
+                        "The failed build directory was kept on the remote builder due to `--keep-failed`. "
+                        "If the build's architecture matches your host, you can re-run the command with `--builders ''` to disable remote building for this invocation."
+                    );
+                }
                 throw Error("build of '%s' on '%s' failed: %s", store->printStorePath(*drvPath), storeUri, result.errorMsg);
+            }
         } else {
             copyClosure(*store, *sshStore, StorePathSet {*drvPath}, NoRepair, NoCheckSigs, substitute);
             auto res = sshStore->buildPathsWithResults({

--- a/tests/functional/build-remote.sh
+++ b/tests/functional/build-remote.sh
@@ -85,6 +85,7 @@ out="$(nix-build 2>&1 failing.nix \
   --arg busybox "$busybox")" || true
 
 [[ "$out" =~ .*"note: keeping build directory".* ]]
+[[ "$out" =~ .*"The failed build directory was kept on the remote builder due to".* ]]
 
 build_dir="$(grep "note: keeping build" <<< "$out" | sed -E "s/^(.*)note: keeping build directory '(.*)'(.*)$/\2/")"
 [[ "foo" = $(<"$build_dir"/bar) ]]


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


---

Looks something like this:

```
copying path '/nix/store/cryiszlhhss2h40r3f9m60l92i88m2xd-builder-failing.sh' to 'ssh://localhost'...
note: keeping build directory '/tmp/nix-shell.8G497s/nix-build-failing.drv-16/build'
warning: `--keep-failed` will keep the failed build directory on the remote builder. If the build's architecture matches your host, you can re-run the command with `--builders ''` to disable remote building for this invocation.
error: build of '/nix/store/mqnz9jxm749925bfcgrk0dk5hy5gnz3h-failing.drv' on 'ssh://localhost?remote-store=/tmp/nix-shell.8G497s/nix-test/main/build-remote-input-addressed/machine1?system-features%3Dfoo' failed: Cannot build '/nix/store/mqnz9jxm749925bfcgrk0dk5hy5gnz3h-failing.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/1g84amb7znczw3213msr5k7l1nkbx7i4-failing
```