### PR TITLE
Use 'published' release type to avoid double uploads

### DIFF
--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -18,7 +18,7 @@ on:
       - labeled
   release:
     types:
-      - released
+      - published
 
 permissions:
   id-token: "write"


### PR DESCRIPTION
## Motivation

The `released` event type can sometimes fire twice, which we don't want.