### PR TITLE
Fix fetchToStore() caching

### DIFF
--- a/src/libexpr/paths.cc
+++ b/src/libexpr/paths.cc
@@ -80,6 +80,7 @@ StorePath EvalState::mountInput(
     storeFS->mount(CanonPath(store->printStorePath(storePath)), accessor);
 
     if (requireLockable && (!settings.lazyTrees || !input.isLocked()) && !input.getNarHash()) {
+        // FIXME: use fetchToStore to make it cache this
         auto narHash = accessor->hashPath(CanonPath::root);
         input.attrs.insert_or_assign("narHash", narHash.to_string(HashFormat::SRI, true));
     }

--- a/src/libfetchers/fetch-to-store.cc
+++ b/src/libfetchers/fetch-to-store.cc
@@ -31,15 +31,16 @@ StorePath fetchToStore(
     // a `PosixSourceAccessor` pointing to a store path.
 
     std::optional<fetchers::Cache::Key> cacheKey;
+    std::optional<std::string> fingerprint;
 
-    if (!filter && path.accessor->fingerprint) {
-        cacheKey = makeFetchToStoreCacheKey(std::string{name}, *path.accessor->fingerprint, method, path.path.abs());
+    if (!filter && (fingerprint = path.accessor->getFingerprint(path.path))) {
+        cacheKey = makeFetchToStoreCacheKey(std::string{name}, *fingerprint, method, path.path.abs());
         if (auto res = fetchers::getCache()->lookupStorePath(*cacheKey, store)) {
             debug("store path cache hit for '%s'", path);
             return res->storePath;
         }
     } else
-        debug("source path '%s' is uncacheable", path);
+        debug("source path '%s' is uncacheable (%d, %d)", path, filter, (bool) fingerprint);
 
     Activity act(*logger, lvlChatty, actUnknown,
         fmt(mode == FetchMode::DryRun ? "hashing '%s'" : "copying '%s' to the store", path));

--- a/src/libfetchers/fetch-to-store.cc
+++ b/src/libfetchers/fetch-to-store.cc
@@ -55,7 +55,7 @@ StorePath fetchToStore(
 
     debug(mode == FetchMode::DryRun ? "hashed '%s'" : "copied '%s' to '%s'", path, store.printStorePath(storePath));
 
-    if (cacheKey && mode == FetchMode::Copy)
+    if (cacheKey)
         fetchers::getCache()->upsert(*cacheKey, store, {}, storePath);
 
     return storePath;

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -338,7 +338,8 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
 
             auto accessor = make_ref<SubstitutedSourceAccessor>(makeStorePathAccessor(store, storePath));
 
-            accessor->fingerprint = getFingerprint(store);
+            if (auto fingerprint = getFingerprint(store))
+                accessor->setFingerprint(*fingerprint);
 
             // FIXME: ideally we would use the `showPath()` of the
             // "real" accessor for this fetcher type.
@@ -352,8 +353,10 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
 
     auto [accessor, result] = scheme->getAccessor(store, *this);
 
-    assert(!accessor->fingerprint);
-    accessor->fingerprint = result.getFingerprint(store);
+    assert(!accessor->getFingerprint(CanonPath::root));
+
+    if (auto fingerprint = getFingerprint(store))
+        accessor->setFingerprint(*fingerprint);
 
     return {accessor, std::move(result)};
 }

--- a/src/libfetchers/filtering-source-accessor.cc
+++ b/src/libfetchers/filtering-source-accessor.cc
@@ -14,6 +14,12 @@ std::string FilteringSourceAccessor::readFile(const CanonPath & path)
     return next->readFile(prefix / path);
 }
 
+void FilteringSourceAccessor::readFile(const CanonPath & path, Sink & sink, std::function<void(uint64_t)> sizeCallback)
+{
+    checkAccess(path);
+    return next->readFile(prefix / path, sink, sizeCallback);
+}
+
 bool FilteringSourceAccessor::pathExists(const CanonPath & path)
 {
     return isAllowed(path) && next->pathExists(prefix / path);
@@ -50,6 +56,16 @@ std::string FilteringSourceAccessor::readLink(const CanonPath & path)
 std::string FilteringSourceAccessor::showPath(const CanonPath & path)
 {
     return displayPrefix + next->showPath(prefix / path) + displaySuffix;
+}
+
+std::optional<std::string> FilteringSourceAccessor::getFingerprint(const CanonPath & path)
+{
+    return next->getFingerprint(prefix / path);
+}
+
+void FilteringSourceAccessor::setFingerprint(std::string fingerprint)
+{
+    next->setFingerprint(std::move(fingerprint));
 }
 
 void FilteringSourceAccessor::checkAccess(const CanonPath & path)

--- a/src/libfetchers/include/nix/fetchers/filtering-source-accessor.hh
+++ b/src/libfetchers/include/nix/fetchers/filtering-source-accessor.hh
@@ -36,6 +36,8 @@ struct FilteringSourceAccessor : SourceAccessor
 
     std::string readFile(const CanonPath & path) override;
 
+    void readFile(const CanonPath & path, Sink & sink, std::function<void(uint64_t)> sizeCallback) override;
+
     bool pathExists(const CanonPath & path) override;
 
     Stat lstat(const CanonPath & path) override;
@@ -47,6 +49,10 @@ struct FilteringSourceAccessor : SourceAccessor
     std::string readLink(const CanonPath & path) override;
 
     std::string showPath(const CanonPath & path) override;
+
+    std::optional<std::string> getFingerprint(const CanonPath & path) override;
+
+    void setFingerprint(std::string fingerprint) override;
 
     /**
      * Call `makeNotAllowedError` to throw a `RestrictedPathError`

--- a/src/libutil/include/nix/util/forwarding-source-accessor.hh
+++ b/src/libutil/include/nix/util/forwarding-source-accessor.hh
@@ -52,6 +52,16 @@ struct ForwardingSourceAccessor : SourceAccessor
     {
         return next->getPhysicalPath(path);
     }
+
+    std::optional<std::string> getFingerprint(const CanonPath & path) override
+    {
+        return next->getFingerprint(path);
+    }
+
+    void setFingerprint(std::string fingerprint) override
+    {
+        next->setFingerprint(std::move(fingerprint));
+    }
 };
 
 }

--- a/src/libutil/include/nix/util/source-accessor.hh
+++ b/src/libutil/include/nix/util/source-accessor.hh
@@ -177,10 +177,27 @@ struct SourceAccessor : std::enable_shared_from_this<SourceAccessor>
         SymlinkResolution mode = SymlinkResolution::Full);
 
     /**
-     * A string that uniquely represents the contents of this
-     * accessor. This is used for caching lookups (see `fetchToStore()`).
+     * Return a string that uniquely represents the contents of this
+     * accessor. This is used for caching lookups (see
+     * `fetchToStore()`).
+     *
+     * Fingerprints are generally for the entire accessor, but this
+     * method takes a `path` argument to support accessors like
+     * `MountedSourceAccessor` that combine multiple underlying
+     * accessors. A fingerprint should only be returned if it uniquely
+     * represents everything under `path`.
      */
-    std::optional<std::string> fingerprint;
+    virtual std::optional<std::string> getFingerprint(const CanonPath & path)
+    {
+        return _fingerprint;
+    }
+
+    virtual void setFingerprint(std::string fingerprint)
+    {
+        _fingerprint = std::move(fingerprint);
+    }
+
+    std::optional<std::string> _fingerprint;
 
     /**
      * Return the maximum last-modified time of the files in this

--- a/src/libutil/mounted-source-accessor.cc
+++ b/src/libutil/mounted-source-accessor.cc
@@ -90,6 +90,15 @@ struct MountedSourceAccessorImpl : MountedSourceAccessor
         else
             return nullptr;
     }
+
+    std::optional<std::string> getFingerprint(const CanonPath & path) override
+    {
+        auto [accessor, subpath] = resolve(path);
+        // FIXME: check that there are no mounts underneath the mount
+        // point of `accessor`, since that would invalidate the
+        // fingerprint. (However we don't have such at the moment.)
+        return accessor->getFingerprint(subpath);
+    }
 };
 
 ref<MountedSourceAccessor> makeMountedSourceAccessor(std::map<CanonPath, ref<SourceAccessor>> mounts)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This was broken because `MountedSourceAccessor` did not return a fingerprint. Previously fingerprints were global to an accessor, but with a `MountedSourceAccessor` the fingerprint can be different for each mount point.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
