### PR TITLE
Fix: register extra builtins just once

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -5028,12 +5028,6 @@ void EvalState::createBaseEnv(const EvalSettings & evalSettings)
         addPrimOp(std::move(primOpAdjusted));
     }
 
-    for (auto & primOp : evalSettings.extraPrimOps) {
-        auto primOpAdjusted = primOp;
-        primOpAdjusted.arity = std::max(primOp.args.size(), primOp.arity);
-        addPrimOp(std::move(primOpAdjusted));
-    }
-
     /* Add a wrapper around the derivation primop that computes the
        `drvPath' and `outPath' attributes lazily.
 


### PR DESCRIPTION

## Motivation

This avoids builtins like `parseFlakeRef` from showing up twice in `builtins`.

This was the result of a bad merge.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
