### PR TITLE
fetchToStore(): Improve caching in dry-run mode

### DIFF
--- a/src/libfetchers/cache.cc
+++ b/src/libfetchers/cache.cc
@@ -122,7 +122,8 @@ struct CacheImpl : Cache
 
     std::optional<ResultWithStorePath> lookupStorePath(
         Key key,
-        Store & store) override
+        Store & store,
+        bool allowInvalid) override
     {
         key.second.insert_or_assign("store", store.storeDir);
 
@@ -135,7 +136,7 @@ struct CacheImpl : Cache
         ResultWithStorePath res2(*res, StorePath(storePathS));
 
         store.addTempRoot(res2.storePath);
-        if (!store.isValidPath(res2.storePath)) {
+        if (!allowInvalid && !store.isValidPath(res2.storePath)) {
             // FIXME: we could try to substitute 'storePath'.
             debug("ignoring disappeared cache entry '%s:%s' -> '%s'",
                 key.first,
@@ -157,7 +158,7 @@ struct CacheImpl : Cache
         Key key,
         Store & store) override
     {
-        auto res = lookupStorePath(std::move(key), store);
+        auto res = lookupStorePath(std::move(key), store, false);
         return res && !res->expired ? res : std::nullopt;
     }
 };

--- a/src/libfetchers/fetch-to-store.cc
+++ b/src/libfetchers/fetch-to-store.cc
@@ -35,7 +35,7 @@ StorePath fetchToStore(
 
     if (!filter && (fingerprint = path.accessor->getFingerprint(path.path))) {
         cacheKey = makeFetchToStoreCacheKey(std::string{name}, *fingerprint, method, path.path.abs());
-        if (auto res = fetchers::getCache()->lookupStorePath(*cacheKey, store)) {
+        if (auto res = fetchers::getCache()->lookupStorePath(*cacheKey, store, mode == FetchMode::DryRun)) {
             debug("store path cache hit for '%s'", path);
             return res->storePath;
         }

--- a/src/libfetchers/include/nix/fetchers/cache.hh
+++ b/src/libfetchers/include/nix/fetchers/cache.hh
@@ -76,11 +76,12 @@ struct Cache
 
     /**
      * Look up a store path in the cache. The returned store path will
-     * be valid, but it may be expired.
+     * be valid (unless `allowInvalid` is true), but it may be expired.
      */
     virtual std::optional<ResultWithStorePath> lookupStorePath(
         Key key,
-        Store & store) = 0;
+        Store & store,
+        bool allowInvalid = false) = 0;
 
     /**
      * Look up a store path in the cache. Return nothing if its TTL


### PR DESCRIPTION

## Motivation

In dry-run mode, we don't need to require a valid path (and it won't exist if the cache entry was added by `fetchToStore()` in dry-run mode).

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
