### PR TITLE
Fix startup race in S3 VM test

### DIFF
--- a/tests/nixos/s3-binary-cache-store.nix
+++ b/tests/nixos/s3-binary-cache-store.nix
@@ -67,6 +67,9 @@ in
       server.wait_for_unit("minio")
       server.wait_for_unit("network-addresses-eth1.service")
 
+      # Explicitly wait on minio (actual startup lags behind the systemd unit)
+      server.succeed("while ! mc ping local -x; do sleep 1; done", timeout=30)
+
       server.succeed("mc config host add minio http://localhost:9000 ${accessKey} ${secretKey} --api s3v4")
       server.succeed("mc mb minio/my-cache")
 


### PR DESCRIPTION
The s3-binary-cache store test is kind of flaky due to a race with Minio startup. This PR addresses that by explicitly waiting until the minio address can be pinged.