### PR TITLE
Make the S3 test more robust

### DIFF
--- a/tests/nixos/s3-binary-cache-store.nix
+++ b/tests/nixos/s3-binary-cache-store.nix
@@ -66,6 +66,7 @@ in
       # Create a binary cache.
       server.wait_for_unit("minio")
       server.wait_for_unit("network-addresses-eth1.service")
+      server.wait_for_open_port(9000)
 
       server.succeed("mc config host add minio http://localhost:9000 ${accessKey} ${secretKey} --api s3v4")
       server.succeed("mc mb minio/my-cache")


### PR DESCRIPTION
This replaces #99 with a backport of ca9696748a0ec17341dfa98c5ae5f823032c595b.