### PR TITLE
Make the `nix repl` test more stable

### DIFF
--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -163,7 +163,8 @@ foo + baz
 # - Re-eval it
 # - Check that the result has changed
 mkfifo repl_fifo
-nix repl ./flake < repl_fifo > repl_output 2>&1 &
+touch repl_output
+nix repl ./flake < repl_fifo >> repl_output 2>&1 &
 repl_pid=$!
 exec 3>repl_fifo # Open fifo for writing
 echo "changingThing" >&3


### PR DESCRIPTION


## Motivation

Seen in https://github.com/DeterminateSystems/nix-src/actions/runs/15590867877/job/43909540271:

```
nix-functional-tests> grep: repl_output: No such file or directory
nix-functional-tests> +(repl.sh:174) cat repl_output
```

This is because there is a small possibility that the `nix repl` child process hasn't created `repl_output` yet. So make sure it exists.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
