### PR TITLE
Fix broken fetchToStore() caching

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -338,8 +338,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
 
             auto accessor = make_ref<SubstitutedSourceAccessor>(makeStorePathAccessor(store, storePath));
 
-            if (auto fingerprint = getFingerprint(store))
-                accessor->setFingerprint(*fingerprint);
+            accessor->fingerprint = getFingerprint(store);
 
             // FIXME: ideally we would use the `showPath()` of the
             // "real" accessor for this fetcher type.
@@ -353,10 +352,8 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
 
     auto [accessor, result] = scheme->getAccessor(store, *this);
 
-    assert(!accessor->getFingerprint(CanonPath::root));
-
-    if (auto fingerprint = result.getFingerprint(store))
-        accessor->setFingerprint(*fingerprint);
+    assert(!accessor->fingerprint);
+    accessor->fingerprint = result.getFingerprint(store);
 
     return {accessor, std::move(result)};
 }

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -355,7 +355,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
 
     assert(!accessor->getFingerprint(CanonPath::root));
 
-    if (auto fingerprint = getFingerprint(store))
+    if (auto fingerprint = result.getFingerprint(store))
         accessor->setFingerprint(*fingerprint);
 
     return {accessor, std::move(result)};

--- a/src/libfetchers/filtering-source-accessor.cc
+++ b/src/libfetchers/filtering-source-accessor.cc
@@ -58,14 +58,11 @@ std::string FilteringSourceAccessor::showPath(const CanonPath & path)
     return displayPrefix + next->showPath(prefix / path) + displaySuffix;
 }
 
-std::optional<std::string> FilteringSourceAccessor::getFingerprint(const CanonPath & path)
+std::pair<CanonPath, std::optional<std::string>> FilteringSourceAccessor::getFingerprint(const CanonPath & path)
 {
+    if (fingerprint)
+        return {path, fingerprint};
     return next->getFingerprint(prefix / path);
-}
-
-void FilteringSourceAccessor::setFingerprint(std::string fingerprint)
-{
-    next->setFingerprint(std::move(fingerprint));
 }
 
 void FilteringSourceAccessor::checkAccess(const CanonPath & path)

--- a/src/libfetchers/include/nix/fetchers/filtering-source-accessor.hh
+++ b/src/libfetchers/include/nix/fetchers/filtering-source-accessor.hh
@@ -50,9 +50,7 @@ struct FilteringSourceAccessor : SourceAccessor
 
     std::string showPath(const CanonPath & path) override;
 
-    std::optional<std::string> getFingerprint(const CanonPath & path) override;
-
-    void setFingerprint(std::string fingerprint) override;
+    std::pair<CanonPath, std::optional<std::string>> getFingerprint(const CanonPath & path) override;
 
     /**
      * Call `makeNotAllowedError` to throw a `RestrictedPathError`

--- a/src/libutil/include/nix/util/forwarding-source-accessor.hh
+++ b/src/libutil/include/nix/util/forwarding-source-accessor.hh
@@ -52,16 +52,6 @@ struct ForwardingSourceAccessor : SourceAccessor
     {
         return next->getPhysicalPath(path);
     }
-
-    std::optional<std::string> getFingerprint(const CanonPath & path) override
-    {
-        return next->getFingerprint(path);
-    }
-
-    void setFingerprint(std::string fingerprint) override
-    {
-        next->setFingerprint(std::move(fingerprint));
-    }
 };
 
 }

--- a/src/libutil/mounted-source-accessor.cc
+++ b/src/libutil/mounted-source-accessor.cc
@@ -91,12 +91,11 @@ struct MountedSourceAccessorImpl : MountedSourceAccessor
             return nullptr;
     }
 
-    std::optional<std::string> getFingerprint(const CanonPath & path) override
+    std::pair<CanonPath, std::optional<std::string>> getFingerprint(const CanonPath & path) override
     {
+        if (fingerprint)
+            return {path, fingerprint};
         auto [accessor, subpath] = resolve(path);
-        // FIXME: check that there are no mounts underneath the mount
-        // point of `accessor`, since that would invalidate the
-        // fingerprint. (However we don't have such at the moment.)
         return accessor->getFingerprint(subpath);
     }
 };

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -112,6 +112,12 @@ nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir#default"
 nix build -o "$TEST_ROOT/result" "$flake1Dir?ref=HEAD#default"
 nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir?ref=HEAD#default"
 
+# Check that the fetcher cache works.
+if [[ $(nix config show lazy-trees) = false ]]; then
+    nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir?ref=HEAD#default" -vvvvv 2>&1 | grepQuietInverse "source path.*is uncacheable"
+    nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir?ref=HEAD#default" -vvvvv 2>&1 | grepQuiet "store path cache hit"
+fi
+
 # Check that relative paths are allowed for git flakes.
 # This may change in the future once git submodule support is refined.
 # See: https://discourse.nixos.org/t/57783 and #9708.


### PR DESCRIPTION
## Motivation

Fixes 
```
source path '«github:NixOS/nixpkgs/022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf»/' is uncacheable (0, 0)
copying '«github:NixOS/nixpkgs/022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf»/' to the store...
```

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
