### PR TITLE
Fixup the complainy docs line

### DIFF
--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -130,7 +130,6 @@
 - [Determinate Nix Release Notes](release-notes-determinate/index.md)
   - [Changes between Nix and Determinate Nix](release-notes-determinate/changes.md)<!-- next -->
   - [Release 3.6.4 (2025-06-12)](release-notes-determinate/rl-3.6.4.md)
-  - ~~Release 3.6.3 (2025-06-12) (revoked)~~
   - [Release 3.6.2 (2025-06-02)](release-notes-determinate/rl-3.6.2.md)
   - [Release 3.6.1 (2025-05-24)](release-notes-determinate/rl-3.6.1.md)
   - [Release 3.6.0 (2025-05-22)](release-notes-determinate/rl-3.6.0.md)


### PR DESCRIPTION
## Motivation

In #109 it merged after all the builds failed. This is because the `test` jobs were skipped, because their dependent `build` job failed. The `test` job being skipped was considered a pass, so it failed and merged right away.

I made the `build` checks mandatory as well in the settings.