### PR TITLE
Use GHA runners for VMs since they have KVM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
       runner:
         required: true
         type: string
+      runner_for_virt:
+        required: true
+        type: string
       runner_small:
         required: true
         type: string
@@ -61,7 +64,7 @@ jobs:
   vm_tests_smoke:
     if: inputs.run_vm_tests && github.event_name != 'merge_group'
     needs: build
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner_for_virt }}
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/determinate-nix-action@main
@@ -77,7 +80,7 @@ jobs:
   vm_tests_all:
     if: inputs.run_vm_tests && github.event_name == 'merge_group'
     needs: build
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner_for_virt }}
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/determinate-nix-action@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
     with:
       system: x86_64-linux
       runner: namespace-profile-linuxamd32c64g-cache
+      runner_for_virt: UbuntuLatest32Cores128G
       runner_small: ubuntu-latest
       run_tests: true
       run_vm_tests: true
@@ -47,6 +48,7 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       system: aarch64-linux
       runner: UbuntuLatest32Cores128GArm
+      runner_for_virt: UbuntuLatest32Cores128GArm
       runner_small: UbuntuLatest32Cores128GArm
 
   build_x86_64-darwin:
@@ -55,6 +57,7 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       system: x86_64-darwin
       runner: macos-latest-large
+      runner_for_virt: macos-latest-large
       runner_small: macos-latest-large
 
   build_aarch64-darwin:
@@ -62,6 +65,7 @@ jobs:
     with:
       system: aarch64-darwin
       runner: namespace-profile-mac-m2-12c28g
+      runner_for_virt: namespace-profile-mac-m2-12c28g
       runner_small: macos-latest-xlarge
 
   success:


### PR DESCRIPTION
## Motivation

We switched a bunch of CI over to Namespace runners, but the VMs were failing to build in fewer than 10 minutes. That is a significant performance regression, which is because they don't have KVM. This moves those VM builds back to hosts that DO support KVM.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
