### PR TITLE
Fix eval caching for path flakes

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -354,6 +354,8 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
 
     if (!accessor->fingerprint)
         accessor->fingerprint = result.getFingerprint(store);
+    else
+        result.cachedFingerprint = accessor->fingerprint;
 
     return {accessor, std::move(result)};
 }

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -127,8 +127,6 @@ struct PathInputScheme : InputScheme
 
         auto absPath = getAbsPath(input);
 
-        Activity act(*logger, lvlTalkative, actUnknown, fmt("copying %s to the store", absPath));
-
         // FIXME: check whether access to 'path' is allowed.
         auto storePath = store->maybeParseStorePath(absPath.string());
 
@@ -137,6 +135,7 @@ struct PathInputScheme : InputScheme
 
         time_t mtime = 0;
         if (!storePath || storePath->name() != "source" || !store->isValidPath(*storePath)) {
+            Activity act(*logger, lvlTalkative, actUnknown, fmt("copying %s to the store", absPath));
             // FIXME: try to substitute storePath.
             auto src = sinkToSource([&](Sink & sink) {
                 mtime = dumpPathAndGetMtime(absPath.string(), sink, defaultPathFilter);

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -374,6 +374,7 @@ nix build -o $TEST_ROOT/result git+file://$flakeGitBare
 mkdir -p $flake5Dir
 writeDependentFlake $flake5Dir
 nix flake lock path://$flake5Dir
+[[ "$(nix flake metadata path://$flake5Dir --json | jq -r .fingerprint)" != null ]]
 
 # Test tarball flakes.
 tar cfz $TEST_ROOT/flake.tar.gz -C $TEST_ROOT flake5


### PR DESCRIPTION
## Motivation

A user reported that eval caching doesn't work in DetSys Nix for path flakes.

This fix is somewhat hacky since the accessor/input fingerprint situation is a bit of a mess.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
