### PR TITLE
nix flake check: Skip substitutable derivations

### DIFF
--- a/src/libmain/include/nix/main/shared.hh
+++ b/src/libmain/include/nix/main/shared.hh
@@ -35,15 +35,17 @@ void printVersion(const std::string & programName);
 void printGCWarning();
 
 class Store;
+struct MissingPaths;
 
 void printMissing(
     ref<Store> store,
     const std::vector<DerivedPath> & paths,
     Verbosity lvl = lvlInfo);
 
-void printMissing(ref<Store> store, const StorePathSet & willBuild,
-    const StorePathSet & willSubstitute, const StorePathSet & unknown,
-    uint64_t downloadSize, uint64_t narSize, Verbosity lvl = lvlInfo);
+void printMissing(
+    ref<Store> store,
+    const MissingPaths & missing,
+    Verbosity lvl = lvlInfo);
 
 std::string getArg(const std::string & opt,
     Strings::iterator & i, const Strings::iterator & end);

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -46,10 +46,8 @@ void printGCWarning()
 
 void printMissing(ref<Store> store, const std::vector<DerivedPath> & paths, Verbosity lvl)
 {
-    uint64_t downloadSize, narSize;
-    StorePathSet willBuild, willSubstitute, unknown;
-    store->queryMissing(paths, willBuild, willSubstitute, unknown, downloadSize, narSize);
-    printMissing(store, willBuild, willSubstitute, unknown, downloadSize, narSize, lvl);
+    auto missing = store->queryMissing(paths);
+    printMissing(store, missing.willBuild, missing.willSubstitute, missing.unknown, missing.downloadSize, missing.narSize, lvl);
 }
 
 

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -46,41 +46,41 @@ void printGCWarning()
 
 void printMissing(ref<Store> store, const std::vector<DerivedPath> & paths, Verbosity lvl)
 {
-    auto missing = store->queryMissing(paths);
-    printMissing(store, missing.willBuild, missing.willSubstitute, missing.unknown, missing.downloadSize, missing.narSize, lvl);
+    printMissing(store, store->queryMissing(paths), lvl);
 }
 
 
-void printMissing(ref<Store> store, const StorePathSet & willBuild,
-    const StorePathSet & willSubstitute, const StorePathSet & unknown,
-    uint64_t downloadSize, uint64_t narSize, Verbosity lvl)
+void printMissing(
+    ref<Store> store,
+    const MissingPaths & missing,
+    Verbosity lvl)
 {
-    if (!willBuild.empty()) {
-        if (willBuild.size() == 1)
+    if (!missing.willBuild.empty()) {
+        if (missing.willBuild.size() == 1)
             printMsg(lvl, "this derivation will be built:");
         else
-            printMsg(lvl, "these %d derivations will be built:", willBuild.size());
-        auto sorted = store->topoSortPaths(willBuild);
+            printMsg(lvl, "these %d derivations will be built:", missing.willBuild.size());
+        auto sorted = store->topoSortPaths(missing.willBuild);
         reverse(sorted.begin(), sorted.end());
         for (auto & i : sorted)
             printMsg(lvl, "  %s", store->printStorePath(i));
     }
 
-    if (!willSubstitute.empty()) {
-        const float downloadSizeMiB = downloadSize / (1024.f * 1024.f);
-        const float narSizeMiB = narSize / (1024.f * 1024.f);
-        if (willSubstitute.size() == 1) {
+    if (!missing.willSubstitute.empty()) {
+        const float downloadSizeMiB = missing.downloadSize / (1024.f * 1024.f);
+        const float narSizeMiB = missing.narSize / (1024.f * 1024.f);
+        if (missing.willSubstitute.size() == 1) {
             printMsg(lvl, "this path will be fetched (%.2f MiB download, %.2f MiB unpacked):",
                 downloadSizeMiB,
                 narSizeMiB);
         } else {
             printMsg(lvl, "these %d paths will be fetched (%.2f MiB download, %.2f MiB unpacked):",
-                willSubstitute.size(),
+                missing.willSubstitute.size(),
                 downloadSizeMiB,
                 narSizeMiB);
         }
         std::vector<const StorePath *> willSubstituteSorted = {};
-        std::for_each(willSubstitute.begin(), willSubstitute.end(),
+        std::for_each(missing.willSubstitute.begin(), missing.willSubstitute.end(),
                    [&](const StorePath &p) { willSubstituteSorted.push_back(&p); });
         std::sort(willSubstituteSorted.begin(), willSubstituteSorted.end(),
                   [](const StorePath *lhs, const StorePath *rhs) {
@@ -93,10 +93,10 @@ void printMissing(ref<Store> store, const StorePathSet & willBuild,
             printMsg(lvl, "  %s", store->printStorePath(*p));
     }
 
-    if (!unknown.empty()) {
+    if (!missing.unknown.empty()) {
         printMsg(lvl, "don't know how to build these paths%s:",
                 (settings.readOnlyMode ? " (may be caused by read-only store access)" : ""));
-        for (auto & i : unknown)
+        for (auto & i : missing.unknown)
             printMsg(lvl, "  %s", store->printStorePath(i));
     }
 }

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -289,9 +289,7 @@ void Worker::run(const Goals & _topGoals)
     }
 
     /* Call queryMissing() to efficiently query substitutes. */
-    StorePathSet willBuild, willSubstitute, unknown;
-    uint64_t downloadSize, narSize;
-    store.queryMissing(topPaths, willBuild, willSubstitute, unknown, downloadSize, narSize);
+    store.queryMissing(topPaths);
 
     debug("entered goal loop");
 

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -949,14 +949,12 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
     case WorkerProto::Op::QueryMissing: {
         auto targets = WorkerProto::Serialise<DerivedPaths>::read(*store, rconn);
         logger->startWork();
-        StorePathSet willBuild, willSubstitute, unknown;
-        uint64_t downloadSize, narSize;
-        store->queryMissing(targets, willBuild, willSubstitute, unknown, downloadSize, narSize);
+        auto missing = store->queryMissing(targets);
         logger->stopWork();
-        WorkerProto::write(*store, wconn, willBuild);
-        WorkerProto::write(*store, wconn, willSubstitute);
-        WorkerProto::write(*store, wconn, unknown);
-        conn.to << downloadSize << narSize;
+        WorkerProto::write(*store, wconn, missing.willBuild);
+        WorkerProto::write(*store, wconn, missing.willSubstitute);
+        WorkerProto::write(*store, wconn, missing.unknown);
+        conn.to << missing.downloadSize << missing.narSize;
         break;
     }
 

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -149,9 +149,7 @@ struct RemoteStore :
 
     void addSignatures(const StorePath & storePath, const StringSet & sigs) override;
 
-    void queryMissing(const std::vector<DerivedPath> & targets,
-        StorePathSet & willBuild, StorePathSet & willSubstitute, StorePathSet & unknown,
-        uint64_t & downloadSize, uint64_t & narSize) override;
+    MissingPaths queryMissing(const std::vector<DerivedPath> & targets) override;
 
     void addBuildLog(const StorePath & drvPath, std::string_view log) override;
 

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -71,6 +71,18 @@ struct KeyedBuildResult;
 
 typedef std::map<StorePath, std::optional<ContentAddress>> StorePathCAMap;
 
+/**
+ * Information about what paths will be built or substituted, returned
+ * by Store::queryMissing().
+ */
+struct MissingPaths
+{
+    StorePathSet willBuild;
+    StorePathSet willSubstitute;
+    StorePathSet unknown;
+    uint64_t downloadSize{0};
+    uint64_t narSize{0};
+};
 
 /**
  * About the class hierarchy of the store types:
@@ -694,9 +706,7 @@ public:
      * derivations that will be built, and the set of output paths that
      * will be substituted.
      */
-    virtual void queryMissing(const std::vector<DerivedPath> & targets,
-        StorePathSet & willBuild, StorePathSet & willSubstitute, StorePathSet & unknown,
-        uint64_t & downloadSize, uint64_t & narSize);
+    virtual MissingPaths queryMissing(const std::vector<DerivedPath> & targets);
 
     /**
      * Sort a set of paths topologically under the references

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -794,15 +794,12 @@ void Store::substitutePaths(const StorePathSet & paths)
     for (auto & path : paths)
         if (!path.isDerivation())
             paths2.emplace_back(DerivedPath::Opaque{path});
-    uint64_t downloadSize, narSize;
-    StorePathSet willBuild, willSubstitute, unknown;
-    queryMissing(paths2,
-        willBuild, willSubstitute, unknown, downloadSize, narSize);
+    auto missing = queryMissing(paths2);
 
-    if (!willSubstitute.empty())
+    if (!missing.willSubstitute.empty())
         try {
             std::vector<DerivedPath> subs;
-            for (auto & p : willSubstitute) subs.emplace_back(DerivedPath::Opaque{p});
+            for (auto & p : missing.willSubstitute) subs.emplace_back(DerivedPath::Opaque{p});
             buildPaths(subs);
         } catch (Error & e) {
             logWarning(e.info());

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -425,7 +425,7 @@ static void main_nix_build(int argc, char * * argv)
         auto missing = store->queryMissing(paths);
 
         if (settings.printMissing)
-            printMissing(ref<Store>(store), missing.willBuild, missing.willSubstitute, missing.unknown, missing.downloadSize, missing.narSize);
+            printMissing(ref<Store>(store), missing);
 
         if (!dryRun)
             store->buildPaths(paths, buildMode, evalStore);

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -422,13 +422,10 @@ static void main_nix_build(int argc, char * * argv)
     auto buildPaths = [&](const std::vector<DerivedPath> & paths) {
         /* Note: we do this even when !printMissing to efficiently
            fetch binary cache data. */
-        uint64_t downloadSize, narSize;
-        StorePathSet willBuild, willSubstitute, unknown;
-        store->queryMissing(paths,
-            willBuild, willSubstitute, unknown, downloadSize, narSize);
+        auto missing = store->queryMissing(paths);
 
         if (settings.printMissing)
-            printMissing(ref<Store>(store), willBuild, willSubstitute, unknown, downloadSize, narSize);
+            printMissing(ref<Store>(store), missing.willBuild, missing.willSubstitute, missing.unknown, missing.downloadSize, missing.narSize);
 
         if (!dryRun)
             store->buildPaths(paths, buildMode, evalStore);

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -420,12 +420,8 @@ static void main_nix_build(int argc, char * * argv)
     state->maybePrintStats();
 
     auto buildPaths = [&](const std::vector<DerivedPath> & paths) {
-        /* Note: we do this even when !printMissing to efficiently
-           fetch binary cache data. */
-        auto missing = store->queryMissing(paths);
-
         if (settings.printMissing)
-            printMissing(ref<Store>(store), missing);
+            printMissing(ref<Store>(store), paths);
 
         if (!dryRun)
             store->buildPaths(paths, buildMode, evalStore);

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -158,7 +158,7 @@ static void opRealise(Strings opFlags, Strings opArgs)
     }
 
     if (settings.printMissing)
-        printMissing(ref<Store>(store), missing.willBuild, missing.willSubstitute, missing.unknown, missing.downloadSize, missing.narSize);
+        printMissing(ref<Store>(store), missing);
 
     if (dryRun) return;
 

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -146,23 +146,19 @@ static void opRealise(Strings opFlags, Strings opArgs)
     for (auto & i : opArgs)
         paths.push_back(followLinksToStorePathWithOutputs(*store, i));
 
-    uint64_t downloadSize, narSize;
-    StorePathSet willBuild, willSubstitute, unknown;
-    store->queryMissing(
-        toDerivedPaths(paths),
-        willBuild, willSubstitute, unknown, downloadSize, narSize);
+    auto missing = store->queryMissing(toDerivedPaths(paths));
 
     /* Filter out unknown paths from `paths`. */
     if (ignoreUnknown) {
         std::vector<StorePathWithOutputs> paths2;
         for (auto & i : paths)
-            if (!unknown.count(i.path)) paths2.push_back(i);
+            if (!missing.unknown.count(i.path)) paths2.push_back(i);
         paths = std::move(paths2);
-        unknown = StorePathSet();
+        missing.unknown = StorePathSet();
     }
 
     if (settings.printMissing)
-        printMissing(ref<Store>(store), willBuild, willSubstitute, unknown, downloadSize, narSize);
+        printMissing(ref<Store>(store), missing.willBuild, missing.willSubstitute, missing.unknown, missing.downloadSize, missing.narSize);
 
     if (dryRun) return;
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Since `nix flake check` doesn't produce a `result` symlink, it doesn't actually need to build/substitute derivations that are already known to have succeeded, i.e. that are substitutable.
    
This can speed up CI jobs in cases where the derivations have already been built by other jobs. For instance, a command like

```    
nix flake check github:NixOS/hydra/aa62c7f7db31753f0cde690f8654dd1907fc0ce2
```
    
should no longer build anything because the outputs are already in cache.nixos.org.

Includes https://github.com/NixOS/nix/pull/13420.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
