### PR TITLE
lockFlake(): When updating a lock, respect the input's lock file

### DIFF
--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -723,16 +723,12 @@ LockedFlake lockFlake(
                             Finally cleanup([&]() { parents.pop_back(); });
 
                             /* Recursively process the inputs of this
-                               flake. Also, unless we already have this flake
-                               in the top-level lock file, use this flake's
-                               own lock file. */
+                               flake, using its own lock file. */
                             nodePaths.emplace(childNode, inputFlake.path.parent());
                             computeLocks(
                                 inputFlake.inputs, childNode, inputAttrPath,
-                                oldLock
-                                ? std::dynamic_pointer_cast<const Node>(oldLock)
-                                : readLockFile(state.fetchSettings, inputFlake.lockFilePath()).root.get_ptr(),
-                                oldLock ? followsPrefix : inputAttrPath,
+                                readLockFile(state.fetchSettings, inputFlake.lockFilePath()).root.get_ptr(),
+                                inputAttrPath,
                                 inputFlake.path,
                                 false);
 

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -446,3 +446,41 @@ nix flake metadata "$flake2Dir" --reference-lock-file $TEST_ROOT/flake2-overridd
 
 # reference-lock-file can only be used if allow-dirty is set.
 expectStderr 1 nix flake metadata "$flake2Dir" --no-allow-dirty --reference-lock-file $TEST_ROOT/flake2-overridden.lock
+
+# After changing an input (flake2 from newFlake2Rev to prevFlake2Rev), we should have the transitive inputs locked by revision $prevFlake2Rev of flake2.
+prevFlake1Rev=$(nix flake metadata --json "$flake1Dir" | jq -r .revision)
+prevFlake2Rev=$(nix flake metadata --json "$flake2Dir" | jq -r .revision)
+
+echo "# bla" >> "$flake1Dir/flake.nix"
+git -C "$flake1Dir" commit flake.nix -m 'bla'
+
+nix flake update --flake "$flake2Dir"
+git -C "$flake2Dir" commit flake.lock -m 'bla'
+
+newFlake1Rev=$(nix flake metadata --json "$flake1Dir" | jq -r .revision)
+newFlake2Rev=$(nix flake metadata --json "$flake2Dir" | jq -r .revision)
+
+cat > "$flake3Dir/flake.nix" <<EOF
+{
+  inputs.flake2.url = "flake:flake2/master/$newFlake2Rev";
+
+  outputs = { self, flake2 }: {
+  };
+}
+EOF
+git -C "$flake3Dir" commit flake.nix -m 'bla'
+
+rm "$flake3Dir/flake.lock"
+nix flake lock "$flake3Dir"
+[[ "$(nix flake metadata --json "$flake3Dir" | jq -r .locks.nodes.flake1.locked.rev)" = $newFlake1Rev ]]
+
+cat > "$flake3Dir/flake.nix" <<EOF
+{
+  inputs.flake2.url = "flake:flake2/master/$prevFlake2Rev";
+
+  outputs = { self, flake2 }: {
+  };
+}
+EOF
+
+[[ "$(nix flake metadata --json "$flake3Dir" | jq -r .locks.nodes.flake1.locked.rev)" = $prevFlake1Rev ]]


### PR DESCRIPTION
## Motivation

For example, if a flake has a lock for `a` and `a/b`, and we change the flakeref for `a`, previously Nix would fetch the latest version of `b` rather than using the lock for `b` from `a`.

Fixes https://github.com/NixOS/nix/issues/8976. Updated version of https://github.com/NixOS/nix/pull/8977.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
