### PR TITLE
ci: don't run the full test suite for x86_64-darwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       runner: macos-latest-large
       runner_for_virt: macos-latest-large
       runner_small: macos-latest-large
+      run_tests: false
 
   build_aarch64-darwin:
     uses: ./.github/workflows/build.yml


### PR DESCRIPTION
Since this platform represents a tiny fraction of our users and causes considerable delays in our release flow, let's disable the more extensive test suite on that platform.

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
