### PR TITLE
Only build the manual on x86_64-linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,9 +186,10 @@ jobs:
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Build manual
+        if: inputs.system == 'x86_64-linux'
         run: nix build .#hydraJobs.manual
       - uses: nwtgck/actions-netlify@v3.0
-        if: inputs.publish_manual
+        if: inputs.publish_manual && inputs.system == 'x86_64-linux'
         with:
           publish-dir: "./result/share/doc/nix/manual"
           production-branch: detsys-main


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Otherwise the build will randomly fail on other platforms depending on whether the result is already in the binary cache.

Fixes this random CI failure: https://github.com/DeterminateSystems/nix-src/actions/runs/16273635793/job/45947468468?pr=125

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
