### PR TITLE
Avoid isValidPath(), use queryPathInfo() instead

### DIFF
--- a/src/libfetchers/fetch-to-store.cc
+++ b/src/libfetchers/fetch-to-store.cc
@@ -52,7 +52,7 @@ std::pair<StorePath, Hash> fetchToStore2(
             auto hash = Hash::parseSRI(fetchers::getStrAttr(*res, "hash"));
             auto storePath = store.makeFixedOutputPathFromCA(name,
                 ContentAddressWithReferences::fromParts(method, hash, {}));
-            if (mode == FetchMode::DryRun || store.isValidPath(storePath)) {
+            if (mode == FetchMode::DryRun || store.maybeQueryPathInfo(storePath)) {
                 debug("source path '%s' cache hit in '%s' (hash '%s')", path, store.printStorePath(storePath), hash.to_string(HashFormat::SRI, true));
                 return {storePath, hash};
             }

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -269,7 +269,9 @@ public:
     StorePath followLinksToStorePath(std::string_view path) const;
 
     /**
-     * Check whether a path is valid.
+     * Check whether a path is valid. NOTE: this function does not
+     * generally cache whether a path is valid. You may want to use
+     * `maybeQueryPathInfo()`, which does cache.
      */
     bool isValidPath(const StorePath & path);
 
@@ -308,9 +310,16 @@ public:
 
     /**
      * Query information about a valid path. It is permitted to omit
-     * the name part of the store path.
+     * the name part of the store path. Throws an exception if the
+     * path is not valid.
      */
     ref<const ValidPathInfo> queryPathInfo(const StorePath & path);
+
+    /**
+     * Like `queryPathInfo()`, but returns `nullptr` if the path is
+     * not valid.
+     */
+    std::shared_ptr<const ValidPathInfo> maybeQueryPathInfo(const StorePath & path);
 
     /**
      * Asynchronous version of queryPathInfo().

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -44,7 +44,7 @@ struct LocalStoreAccessor : PosixSourceAccessor
     void requireStoreObject(const CanonPath & path)
     {
         auto [storePath, rest] = store->toStorePath(store->storeDir + path.abs());
-        if (requireValidPath && !store->isValidPath(storePath))
+        if (requireValidPath && !store->maybeQueryPathInfo(storePath))
             throw InvalidPath("path '%1%' is not a valid store path", store->printStorePath(storePath));
     }
 


### PR DESCRIPTION
## Motivation

Since recently we call `isValidPath()` a lot from the evaluator, specifically from `LocalStoreAccessor::requireStoreObject()`. Unfortunately, `isValidPath()` uses but does not populate the in-memory path info cache; only `queryPathInfo()` does that. So `isValidPath()` is fast *if* we happened to call `queryPathInfo()` on the same path previously. This is not the case when lazy-trees is enabled, so we got a lot of superfluous, high-latency calls to the daemon (which show up in verbose output as `performing daemon worker op: 1`).

Similarly, `fetchToStore()` called `isValidPath()` as well.

The fix is to use `queryPathInfo()`, which for one particular eval reduced the number of daemon calls from 15246 to 2324. This may cause Nix to fetch some unnecessary information from the daemon, but that probably doesn't matter much given the high latency.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
