### PR TITLE
Imply --offline during tab completion

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -86,6 +86,19 @@ static bool haveInternet()
 #endif
 }
 
+static void disableNet()
+{
+    // FIXME: should check for command line overrides only.
+    if (!settings.useSubstitutes.overridden)
+        settings.useSubstitutes = false;
+    if (!settings.tarballTtl.overridden)
+        settings.tarballTtl = std::numeric_limits<unsigned int>::max();
+    if (!fileTransferSettings.tries.overridden)
+        fileTransferSettings.tries = 0;
+    if (!fileTransferSettings.connectTimeout.overridden)
+        fileTransferSettings.connectTimeout = 1;
+}
+
 std::string programPath;
 
 struct NixArgs : virtual MultiCommand, virtual MixCommonArgs, virtual RootArgs
@@ -470,6 +483,12 @@ void mainWrapped(int argc, char ** argv)
         }
     });
 
+    if (getEnv("NIX_GET_COMPLETIONS"))
+        /* Avoid fetching stuff during tab completion. We have to this
+           early because we haven't checked `haveInternet()` yet
+           (below). */
+        disableNet();
+
     try {
         auto isNixCommand = std::regex_search(programName, std::regex("nix$"));
         auto allowShebang = isNixCommand && argc > 1;
@@ -513,17 +532,8 @@ void mainWrapped(int argc, char ** argv)
         args.useNet = false;
     }
 
-    if (!args.useNet) {
-        // FIXME: should check for command line overrides only.
-        if (!settings.useSubstitutes.overridden)
-            settings.useSubstitutes = false;
-        if (!settings.tarballTtl.overridden)
-            settings.tarballTtl = std::numeric_limits<unsigned int>::max();
-        if (!fileTransferSettings.tries.overridden)
-            fileTransferSettings.tries = 0;
-        if (!fileTransferSettings.connectTimeout.overridden)
-            fileTransferSettings.connectTimeout = 1;
-    }
+    if (!args.useNet)
+        disableNet();
 
     if (args.refresh) {
         settings.tarballTtl = 0;


### PR DESCRIPTION
## Motivation

A small QoL improvement (cherry-picked from upstream https://github.com/NixOS/nix/pull/12595). 

Previously, if you don't have Internet connectivity, tab completion might try to fetch the flake registry, e.g.

```
$ NIX_GET_COMPLETIONS=4 nix build -vvvvv --offline /home/eelco/De
evaluating file '<nix/derivation-internal.nix>'
downloading 'https://channels.nixos.org/flake-registry.json'...
warning: error: unable to download 'https://channels.nixos.org/flake-registry.json': Could not resolve hostname (6) Could not resolve host: channels.nixos.org; retrying in 294 ms
warning: error: unable to download 'https://channels.nixos.org/flake-registry.json': Could not resolve hostname (6) Could not resolve host: channels.nixos.org; retrying in 541 ms
warning: error: unable to download 'https://channels.nixos.org/flake-registry.json': Could not resolve hostname (6) Could not resolve host: channels.nixos.org; retrying in 1230 ms
warning: error: unable to download 'https://channels.nixos.org/flake-registry.json': Could not resolve hostname (6) Could not resolve host: channels.nixos.org; retrying in 2285 ms
warning: error: unable to download 'https://channels.nixos.org/flake-registry.json': Could not resolve hostname (6) Could not resolve host: channels.nixos.org; using cached version
```
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
