### PR TITLE
Rename detsys-main to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -47,5 +47,5 @@ assignees: ""
 - [ ] checked [open bug issues and pull requests] for possible duplicates
 
 [latest Determinate Nix manual]: https://manual.determinate.systems/
-[source]: https://github.com/DeterminateSystems/nix-src/tree/detsys-main/doc/manual/source
+[source]: https://github.com/DeterminateSystems/nix-src/tree/main/doc/manual/source
 [open bug issues and pull requests]: https://github.com/DeterminateSystems/nix-src/labels/bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -30,5 +30,5 @@ assignees: ""
 - [ ] checked [open bug issues and pull requests] for possible duplicates
 
 [latest Determinate Nix manual]: https://manual.determinate.systems/
-[source]: https://github.com/DeterminateSystems/nix-src/tree/detsys-main/doc/manual/source
+[source]: https://github.com/DeterminateSystems/nix-src/tree/main/doc/manual/source
 [open bug issues and pull requests]: https://github.com/DeterminateSystems/nix-src/labels/bug

--- a/.github/ISSUE_TEMPLATE/installer.md
+++ b/.github/ISSUE_TEMPLATE/installer.md
@@ -38,5 +38,5 @@ assignees: ""
 - [ ] checked [open bug issues and pull requests] for possible duplicates
 
 [latest Determinate Nix manual]: https://manual.determinate.systems/
-[source]: https://github.com/DeterminateSystems/nix-src/tree/detsys-main/doc/manual/source
+[source]: https://github.com/DeterminateSystems/nix-src/tree/main/doc/manual/source
 [open bug issues and pull requests]: https://github.com/DeterminateSystems/nix-src/labels/bug

--- a/.github/ISSUE_TEMPLATE/missing_documentation.md
+++ b/.github/ISSUE_TEMPLATE/missing_documentation.md
@@ -22,5 +22,5 @@ assignees: ""
 - [ ] checked [open bug issues and pull requests] for possible duplicates
 
 [latest Determinate Nix manual]: https://manual.determinate.systems/
-[source]: https://github.com/DeterminateSystems/nix-src/tree/detsys-main/doc/manual/source
+[source]: https://github.com/DeterminateSystems/nix-src/tree/main/doc/manual/source
 [open bug issues and pull requests]: https://github.com/DeterminateSystems/nix-src/labels/bug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,7 +192,7 @@ jobs:
         if: inputs.publish_manual && inputs.system == 'x86_64-linux'
         with:
           publish-dir: "./result/share/doc/nix/manual"
-          production-branch: detsys-main
+          production-branch: main
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Deploy from GitHub Actions"
           # NOTE(cole-h): We have a perpetual PR displaying our changes against upstream open, but

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     branches:
       # NOTE: make sure any branches here are also valid directory names,
       # otherwise creating the directory and uploading to s3 will fail
-      - detsys-main
       - main
       - master
   merge_group:
@@ -125,7 +124,7 @@ jobs:
           ids_project_name: determinate-nix
           ids_binary_prefix: determinate-nix
           skip_acl: true
-          allowed_branches: '["detsys-main"]'
+          allowed_branches: '["main"]'
 
   publish:
     needs:


### PR DESCRIPTION
## Motivation

This change brings our Determinate Nix source repository in line with our standard branch naming. One reason we used detsys-main was to avoid confusion in case the upstream NixOS/nix repository changed its default branch to main. I don't anticipate that happening any time soon if ever, and so let's make the change.

## Context

Having this repo have a different branch name has a non-zero cost for humans ("oh right, different branch") and code to account for it.

Since we're shifting to internally run from `trunk()` (hi, jj) in more places, it's a "do it or don't" moment. I choose to do it.
