### PR TITLE
Use WAL mode for SQLite cache databases (2nd attempt)

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -69,7 +69,7 @@ struct AttrDb
     {
         auto state(_state->lock());
 
-        auto cacheDir = std::filesystem::path(getCacheDir()) / "eval-cache-v5";
+        auto cacheDir = std::filesystem::path(getCacheDir()) / "eval-cache-v6";
         createDirs(cacheDir);
 
         auto dbPath = cacheDir / (fingerprint.to_string(HashFormat::Base16, false) + ".sqlite");

--- a/src/libfetchers/cache.cc
+++ b/src/libfetchers/cache.cc
@@ -37,7 +37,7 @@ struct CacheImpl : Cache
     {
         auto state(_state.lock());
 
-        auto dbPath = getCacheDir() + "/fetcher-cache-v3.sqlite";
+        auto dbPath = getCacheDir() + "/fetcher-cache-v4.sqlite";
         createDirs(dirOf(dbPath));
 
         state->db = SQLite(dbPath);

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -86,7 +86,7 @@ public:
 
     Sync<State> _state;
 
-    NarInfoDiskCacheImpl(Path dbPath = getCacheDir() + "/binary-cache-v6.sqlite")
+    NarInfoDiskCacheImpl(Path dbPath = getCacheDir() + "/binary-cache-v7.sqlite")
     {
         auto state(_state.lock());
 

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -123,7 +123,7 @@ SQLite::~SQLite()
 void SQLite::isCache()
 {
     exec("pragma synchronous = off");
-    exec("pragma main.journal_mode = truncate");
+    exec("pragma main.journal_mode = wal");
 }
 
 void SQLite::exec(const std::string & stmt)
@@ -279,7 +279,7 @@ void handleSQLiteBusy(const SQLiteBusy & e, time_t & nextWarning)
     time_t now = time(0);
     if (now > nextWarning) {
         nextWarning = now + 10;
-        logWarning({.msg = HintFmt(e.what())});
+        logWarning({.msg = e.info().msg});
     }
 
     /* Sleep for a while since retrying the transaction right away

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -182,8 +182,10 @@ void ignoreExceptionInDestructor(Verbosity lvl)
     try {
         try {
             throw;
+        } catch (Error & e) {
+            printMsg(lvl, ANSI_RED "error (ignored):" ANSI_NORMAL " %s", e.info().msg);
         } catch (std::exception & e) {
-            printMsg(lvl, "error (ignored): %1%", e.what());
+            printMsg(lvl, ANSI_RED "error (ignored):" ANSI_NORMAL " %s", e.what());
         }
     } catch (...) {
     }
@@ -195,8 +197,10 @@ void ignoreExceptionExceptInterrupt(Verbosity lvl)
         throw;
     } catch (const Interrupted & e) {
         throw;
+    } catch (Error & e) {
+        printMsg(lvl, ANSI_RED "error (ignored):" ANSI_NORMAL " %s", e.info().msg);
     } catch (std::exception & e) {
-        printMsg(lvl, "error (ignored): %1%", e.what());
+        printMsg(lvl, ANSI_RED "error (ignored):" ANSI_NORMAL " %s", e.what());
     }
 }
 


### PR DESCRIPTION
## Motivation

See https://github.com/DeterminateSystems/nix-src/pull/150, which was reverted in https://github.com/DeterminateSystems/nix-src/pull/155.

This time, we update the versions of the SQLite caches. This avoids problems with older versions of Nix that don't put the caches in WAL mode. That's generally not a problem, until you do something like
    
```
nix build --print-out-paths ... | cachix
```
    
which deadlocks because cachix tries to switch the caches to truncate mode, which requires exclusive access. But the first process cannot make progress because the cachix process isn't reading from the pipe.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
