### PR TITLE
Auto update release notes

### DIFF
--- a/.github/release-notes.sh
+++ b/.github/release-notes.sh
@@ -61,9 +61,9 @@ linkify_gh() {
 
 (
     cat doc/manual/source/SUMMARY.md.in \
-        | sed 's/\(<!-- next -->\)$/\1\n  - [Release '"$DETERMINATE_NIX_VERSION"' ('"$DATE"')](release-notes-determinate\/rl-'"$DETERMINATE_NIX_VERSION"'.md)/'
+        | sed 's/\(<!-- next -->\)$/\1\n  - [Release '"$DETERMINATE_NIX_VERSION"' ('"$DATE"')](release-notes-determinate\/'"$TAG_NAME"'.md)/'
 ) > "$scratch/summary.md"
 
 mv "$scratch/changes.md" doc/manual/source/release-notes-determinate/changes.md
-mv "$scratch/rl.md" "doc/manual/source/release-notes-determinate/rl-${DETERMINATE_NIX_VERSION}.md"
+mv "$scratch/rl.md" "doc/manual/source/release-notes-determinate/v${DETERMINATE_NIX_VERSION}.md"
 mv "$scratch/summary.md" doc/manual/source/SUMMARY.md.in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,3 +143,10 @@ jobs:
           rolling: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
           visibility: "public"
           tag: "${{ github.ref_name }}"
+      - name: Update the release notes
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release edit "$TAG_NAME" --notes-file doc/manual/source/release-notes-determinate/v"$TAG_NAME".md || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
     environment: ${{ github.event_name == 'release' && 'production' || '' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

In our release automation we collect all the tag changelogs to publish our blog posts. In most cases the'yre just generated from GitHub PRs automatically.

For Determinate Nix, though, we work harder to make the release notes good. That means we have to do extra copying and work to make the updates nice.

This automatically gets the release .md file and adds it to github as the changelog.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
