### PR TITLE
BasicClientConnection::queryPathInfo(): Don't throw exception for invalid paths

### DIFF
--- a/src/libstore/include/nix/store/worker-protocol-connection.hh
+++ b/src/libstore/include/nix/store/worker-protocol-connection.hh
@@ -109,7 +109,8 @@ struct WorkerProto::BasicClientConnection : WorkerProto::BasicConnection
         const StorePathSet & paths,
         SubstituteFlag maybeSubstitute);
 
-    UnkeyedValidPathInfo queryPathInfo(const StoreDirConfig & store, bool * daemonException, const StorePath & path);
+    std::optional<UnkeyedValidPathInfo>
+    queryPathInfo(const StoreDirConfig & store, bool * daemonException, const StorePath & path);
 
     void putBuildDerivationRequest(
         const StoreDirConfig & store,

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -259,13 +259,13 @@ void RemoteStore::queryPathInfoUncached(
     const StorePath & path, Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept
 {
     try {
-        std::shared_ptr<const ValidPathInfo> info;
-        {
+        auto info = ({
             auto conn(getConnection());
-            info = std::make_shared<ValidPathInfo>(
-                StorePath{path}, conn->queryPathInfo(*this, &conn.daemonException, path));
-        }
-        callback(std::move(info));
+            conn->queryPathInfo(*this, &conn.daemonException, path);
+        });
+        if (!info)
+            throw InvalidPath("path '%s' is not valid", printStorePath(path));
+        callback(std::make_shared<ValidPathInfo>(StorePath{path}, *info));
     } catch (...) {
         callback.rethrow();
     }

--- a/src/libstore/worker-protocol-connection.cc
+++ b/src/libstore/worker-protocol-connection.cc
@@ -244,7 +244,7 @@ void WorkerProto::BasicServerConnection::postHandshake(const StoreDirConfig & st
     WorkerProto::write(store, *this, info);
 }
 
-UnkeyedValidPathInfo WorkerProto::BasicClientConnection::queryPathInfo(
+std::optional<UnkeyedValidPathInfo> WorkerProto::BasicClientConnection::queryPathInfo(
     const StoreDirConfig & store, bool * daemonException, const StorePath & path)
 {
     to << WorkerProto::Op::QueryPathInfo << store.printStorePath(path);
@@ -253,14 +253,14 @@ UnkeyedValidPathInfo WorkerProto::BasicClientConnection::queryPathInfo(
     } catch (Error & e) {
         // Ugly backwards compatibility hack.
         if (e.msg().find("is not valid") != std::string::npos)
-            throw InvalidPath(std::move(e.info()));
+            return std::nullopt;
         throw;
     }
     if (GET_PROTOCOL_MINOR(protoVersion) >= 17) {
         bool valid;
         from >> valid;
         if (!valid)
-            throw InvalidPath("path '%s' is not valid", store.printStorePath(path));
+            return std::nullopt;
     }
     return WorkerProto::Serialise<UnkeyedValidPathInfo>::read(store, *this);
 }


### PR DESCRIPTION

## Motivation

This caused `RemoteStore::queryPathInfoUncached()` to mark the connection as invalid (see
`RemoteStore::ConnectionHandle::~ConnectionHandle()`), causing it to disconnect and reconnect after every lookup of an invalid path. This caused huge slowdowns in conjunction with 19f89eb6842747570f262c003d977f02cb155968` and lazy-trees.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
