### PR TITLE
Fix queryPathInfo() negative caching

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1991,14 +1991,17 @@ static void prim_readFile(EvalState & state, const PosIdx pos, Value ** args, Va
             .debugThrow();
     StorePathSet refs;
     if (state.store->isInStore(path.path.abs())) {
-        try {
-            refs = state.store->queryPathInfo(state.store->toStorePath(path.path.abs()).first)->references;
-        } catch (Error &) { // FIXME: should be InvalidPathError
+        auto storePath = state.store->toStorePath(path.path.abs()).first;
+        // Skip virtual paths since they don't have references and
+        // don't exist anyway.
+        if (!state.storeFS->getMount(CanonPath(state.store->printStorePath(storePath)))) {
+            if (auto info = state.store->maybeQueryPathInfo(state.store->toStorePath(path.path.abs()).first)) {
+                // Re-scan references to filter down to just the ones that actually occur in the file.
+                auto refsSink = PathRefScanSink::fromPaths(info->references);
+                refsSink << s;
+                refs = refsSink.getResultPaths();
+            }
         }
-        // Re-scan references to filter down to just the ones that actually occur in the file.
-        auto refsSink = PathRefScanSink::fromPaths(refs);
-        refsSink << s;
-        refs = refsSink.getResultPaths();
     }
     NixStringContext context;
     for (auto && p : std::move(refs)) {

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -249,6 +249,8 @@ protected:
         LRUCache<std::string, PathInfoCacheValue> pathInfoCache;
     };
 
+    void invalidatePathInfoCacheFor(const StorePath & path);
+
     SharedSync<State> state;
 
     std::shared_ptr<NarInfoDiskCache> diskCache;

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -457,7 +457,9 @@ StorePath RemoteStore::addToStoreFromDump(
     }
     if (fsm != dumpMethod)
         unsupported("RemoteStore::addToStoreFromDump doesn't support this `dumpMethod` `hashMethod` combination");
-    return addCAToStore(dump, name, hashMethod, hashAlgo, references, repair)->path;
+    auto storePath = addCAToStore(dump, name, hashMethod, hashAlgo, references, repair)->path;
+    invalidatePathInfoCacheFor(storePath);
+    return storePath;
 }
 
 void RemoteStore::addToStore(const ValidPathInfo & info, Source & source, RepairFlag repair, CheckSigsFlag checkSigs)

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -264,8 +264,9 @@ void RemoteStore::queryPathInfoUncached(
             conn->queryPathInfo(*this, &conn.daemonException, path);
         });
         if (!info)
-            throw InvalidPath("path '%s' is not valid", printStorePath(path));
-        callback(std::make_shared<ValidPathInfo>(StorePath{path}, *info));
+            callback(nullptr);
+        else
+            callback(std::make_shared<ValidPathInfo>(StorePath{path}, *info));
     } catch (...) {
         callback.rethrow();
     }

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -429,6 +429,11 @@ bool Store::PathInfoCacheValue::isKnownNow()
     return std::chrono::steady_clock::now() < time_point + ttl;
 }
 
+void Store::invalidatePathInfoCacheFor(const StorePath & path)
+{
+    state.lock()->pathInfoCache.erase(path.to_string());
+}
+
 std::map<std::string, std::optional<StorePath>> Store::queryStaticPartialDerivationOutputMap(const StorePath & path)
 {
     std::map<std::string, std::optional<StorePath>> outputs;


### PR DESCRIPTION
## Motivation

`builtins.readFile` was (unnecessarily) calling `queryPathInfo()` on virtual paths. Since these don't exist, we got a negative response which turns out not be cached properly. This PR also stops `builtins.readFile` from calling `queryPathInfo()` on virtual paths in the first place.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
