### PR TITLE
libstore: use new apple-sdk pattern

### DIFF
--- a/src/libstore/package.nix
+++ b/src/libstore/package.nix
@@ -4,7 +4,7 @@
   mkMesonLibrary,
 
   unixtools,
-  darwin,
+  apple-sdk,
 
   nix-util,
   boost,
@@ -68,7 +68,7 @@ mkMesonLibrary (finalAttrs: {
     ]
     ++ lib.optional stdenv.hostPlatform.isLinux libseccomp
     # There have been issues building these dependencies
-    ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.libs.sandbox
+    ++ lib.optional stdenv.hostPlatform.isDarwin apple-sdk
     ++ lib.optional withAWS aws-sdk-cpp;
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Newer Nixpkgs have removed the `darwin.apple_sdk` construct.

## Motivation

Fixes https://github.com/DeterminateSystems/nix-src/issues/178.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
