### PR TITLE
Change reference for default template flake

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -839,7 +839,7 @@ static Strings defaultTemplateAttrPaths = {"templates.default", "defaultTemplate
 
 struct CmdFlakeInitCommon : virtual Args, EvalCommand
 {
-    std::string templateUrl = "templates";
+    std::string templateUrl = "https://flakehub.com/f/DeterminateSystems/flake-templates/0.1";
     Path destDir;
 
     const LockFlags lockFlags{.writeLockFile = false};

--- a/tests/functional/flakes/init.sh
+++ b/tests/functional/flakes/init.sh
@@ -63,8 +63,8 @@ nix flake show templates
 nix flake show templates --json | jq
 
 createGitRepo "$flakeDir"
-(cd "$flakeDir" && nix flake init)
-(cd "$flakeDir" && nix flake init) # check idempotence
+(cd "$flakeDir" && nix flake init --option flake-registry "$registry")
+(cd "$flakeDir" && nix flake init --option flake-registry "$registry") # check idempotence
 git -C "$flakeDir" add flake.nix
 nix flake check "$flakeDir"
 nix flake show "$flakeDir"
@@ -74,13 +74,13 @@ git -C "$flakeDir" commit -a -m 'Initial'
 # Test 'nix flake init' with benign conflicts
 createGitRepo "$flakeDir"
 echo a > "$flakeDir/a"
-(cd "$flakeDir" && nix flake init) # check idempotence
+(cd "$flakeDir" && nix flake init --option flake-registry "$registry") # check idempotence
 
 # Test 'nix flake init' with conflicts
 createGitRepo "$flakeDir"
 echo b > "$flakeDir/a"
 pushd "$flakeDir"
-(! nix flake init) |& grep "refusing to overwrite existing file '$flakeDir/a'"
+(! nix flake init --option flake-registry "$registry") |& grep "refusing to overwrite existing file '$flakeDir/a'"
 popd
 git -C "$flakeDir" commit -a -m 'Changed'
 

--- a/tests/functional/flakes/init.sh
+++ b/tests/functional/flakes/init.sh
@@ -8,7 +8,8 @@ templatesDir=$TEST_ROOT/templates
 flakeDir=$TEST_ROOT/flake
 nixpkgsDir=$TEST_ROOT/nixpkgs
 
-nix registry add --registry "$registry" templates "git+file://$templatesDir"
+# remap the flake reference in the registry to $tempalatesDir to obey the sandbox
+nix registry add --registry "$registry" https://flakehub.com/f/DeterminateSystems/flake-templates/0.1 "git+file://$templatesDir"
 nix registry add --registry "$registry" nixpkgs "git+file://$nixpkgsDir"
 
 nix registry list

--- a/tests/functional/flakes/init.sh
+++ b/tests/functional/flakes/init.sh
@@ -8,11 +8,9 @@ templatesDir=$TEST_ROOT/templates
 flakeDir=$TEST_ROOT/flake
 nixpkgsDir=$TEST_ROOT/nixpkgs
 
-# remap the flake reference in the registry to $tempalatesDir to obey the sandbox
+# remap the flake reference in the registry to obey the sandbox
 nix registry add --registry "$registry" https://flakehub.com/f/DeterminateSystems/flake-templates/0.1 "git+file://$templatesDir"
 nix registry add --registry "$registry" nixpkgs "git+file://$nixpkgsDir"
-
-nix registry list
 
 createGitRepo "$nixpkgsDir"
 createSimpleGitFlake "$nixpkgsDir"

--- a/tests/functional/flakes/init.sh
+++ b/tests/functional/flakes/init.sh
@@ -8,8 +8,8 @@ templatesDir=$TEST_ROOT/templates
 flakeDir=$TEST_ROOT/flake
 nixpkgsDir=$TEST_ROOT/nixpkgs
 
-nix registry add --registry "$registry" nixpkgs "git+file://$nixpkgsDir"
 nix registry add --registry "$registry" templates "git+file://$templatesDir"
+nix registry add --registry "$registry" nixpkgs "git+file://$nixpkgsDir"
 
 createGitRepo "$nixpkgsDir"
 createSimpleGitFlake "$nixpkgsDir"

--- a/tests/functional/flakes/init.sh
+++ b/tests/functional/flakes/init.sh
@@ -11,6 +11,8 @@ nixpkgsDir=$TEST_ROOT/nixpkgs
 nix registry add --registry "$registry" templates "git+file://$templatesDir"
 nix registry add --registry "$registry" nixpkgs "git+file://$nixpkgsDir"
 
+nix registry list
+
 createGitRepo "$nixpkgsDir"
 createSimpleGitFlake "$nixpkgsDir"
 

--- a/tests/functional/flakes/init.sh
+++ b/tests/functional/flakes/init.sh
@@ -63,8 +63,8 @@ nix flake show templates
 nix flake show templates --json | jq
 
 createGitRepo "$flakeDir"
-(cd "$flakeDir" && nix flake init --option flake-registry "$registry")
-(cd "$flakeDir" && nix flake init --option flake-registry "$registry") # check idempotence
+(cd "$flakeDir" && nix flake init)
+(cd "$flakeDir" && nix flake init) # check idempotence
 git -C "$flakeDir" add flake.nix
 nix flake check "$flakeDir"
 nix flake show "$flakeDir"
@@ -74,13 +74,13 @@ git -C "$flakeDir" commit -a -m 'Initial'
 # Test 'nix flake init' with benign conflicts
 createGitRepo "$flakeDir"
 echo a > "$flakeDir/a"
-(cd "$flakeDir" && nix flake init --option flake-registry "$registry") # check idempotence
+(cd "$flakeDir" && nix flake init) # check idempotence
 
 # Test 'nix flake init' with conflicts
 createGitRepo "$flakeDir"
 echo b > "$flakeDir/a"
 pushd "$flakeDir"
-(! nix flake init --option flake-registry "$registry") |& grep "refusing to overwrite existing file '$flakeDir/a'"
+(! nix flake init) |& grep "refusing to overwrite existing file '$flakeDir/a'"
 popd
 git -C "$flakeDir" commit -a -m 'Changed'
 


### PR DESCRIPTION
This PR makes [this](https://github.com/DeterminateSystems/flake-templates) the default flake used when running `nix flake init`.