### PR TITLE
Fix race condition in Value::isTrivial()

### DIFF
--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -774,6 +774,16 @@ protected:
 
 public:
 
+    /**
+     * Check whether forcing this value requires a trivial amount of
+     * computation. A value is trivial if it's finished or if it's a
+     * thunk whose expression is an attrset with no dynamic
+     * attributes, a lambda or a list. Note that it's up to the caller
+     * to check whether the members of those attrsets or lists must be
+     * trivial.
+     */
+    bool isTrivial() const;
+
     inline void reset()
     {
         p1 = 0;
@@ -808,6 +818,9 @@ void ValueStorage<sizeof(void *)>::notifyWaiters();
 
 template<>
 ValueStorage<sizeof(void *)>::PackedPointer ValueStorage<sizeof(void *)>::waitOnThunk(EvalState & state, bool awaited);
+
+template<>
+bool ValueStorage<sizeof(void *)>::isTrivial() const;
 
 /**
  * View into a list of Value * that is itself immutable.
@@ -1235,16 +1248,6 @@ public:
     }
 
     PosIdx determinePos(const PosIdx pos) const;
-
-    /**
-     * Check whether forcing this value requires a trivial amount of
-     * computation. A value is trivial if it's finished or if it's a
-     * thunk whose expression is an attrset with no dynamic
-     * attributes, a lambda or a list. Note that it's up to the caller
-     * to check whether the members of those attrsets or lists must be
-     * trivial.
-     */
-    bool isTrivial() const;
 
     SourcePath path() const
     {

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -28,15 +28,16 @@ namespace flake {
 
 static void forceTrivialValue(EvalState & state, Value & value, const PosIdx pos)
 {
-    if (!value.isFinished() && value.isTrivial())
+    if (value.isTrivial())
         state.forceValue(value, pos);
 }
 
 static void expectType(EvalState & state, ValueType type, Value & value, const PosIdx pos)
 {
     forceTrivialValue(state, value, pos);
-    if (value.type() != type)
-        throw Error("expected %s but got %s at %s", showType(type), showType(value.type()), state.positions[pos]);
+    auto t = value.type();
+    if (t != type)
+        throw Error("expected %s but got %s at %s", showType(type), showType(t), state.positions[pos]);
 }
 
 static std::pair<std::map<FlakeId, FlakeInput>, fetchers::Attrs> parseFlakeInputs(


### PR DESCRIPTION
## Motivation

The use of `thunk()` is racy since the value might stop being a thunk while we're accessing it.

This is unlikely to happen in practice, but can occur with test cases like
```nix
with builtins;
let
  range = first: last: if first > last then [ ] else genList (n: first + n) (last - first + 1);
in
builtins.listToAttrs
  (map
    (n: {
      name = "n${toString n}";
      value = (builtins.getFlake "github:NixOS/hydra/8481acda2fa07b353ef716e4933c5f213cdd6f45").nixosConfigurations.container.config.system.build.toplevel.drvPath;
    })
    (range 0 7))
```
where we're evaluating the same flake multiple times in parallel, leading to segfaults or errors like
```
error: expected a set but got a set at /nix/store/aj913djlr9z5f6kkzawl8q4cnblm0wma-source/flake.nix:6:3
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Improvements
  - Broader detection of "trivial" values and more aggressive auto-forcing, improving evaluation responsiveness.
  - More consistent behavior under concurrency to reduce stalls.
  - Slightly clearer and more accurate type error messages.

- Refactor
  - Trivial-value detection reworked to be more precise and thread-aware.

- Chores
  - Public API adjusted to expose triviality checks at storage level while preserving user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->