### PR TITLE
Fix flake registry ignoring `dir` parameter

### DIFF
--- a/src/libfetchers/include/nix/fetchers/input-cache.hh
+++ b/src/libfetchers/include/nix/fetchers/input-cache.hh
@@ -11,6 +11,7 @@ struct InputCache
         ref<SourceAccessor> accessor;
         Input resolvedInput;
         Input lockedInput;
+        Attrs extraAttrs;
     };
 
     CachedResult getAccessor(ref<Store> store, const Input & originalInput, UseRegistries useRegistries);

--- a/src/libfetchers/include/nix/fetchers/input-cache.hh
+++ b/src/libfetchers/include/nix/fetchers/input-cache.hh
@@ -20,6 +20,7 @@ struct InputCache
     {
         Input lockedInput;
         ref<SourceAccessor> accessor;
+        Attrs extraAttrs;
     };
 
     virtual std::optional<CachedInput> lookup(const Input & originalInput) const = 0;

--- a/src/libfetchers/input-cache.cc
+++ b/src/libfetchers/input-cache.cc
@@ -8,6 +8,7 @@ namespace nix::fetchers {
 InputCache::CachedResult
 InputCache::getAccessor(ref<Store> store, const Input & originalInput, UseRegistries useRegistries)
 {
+    Attrs extraAttrs;
     auto fetched = lookup(originalInput);
     Input resolvedInput = originalInput;
 
@@ -17,7 +18,8 @@ InputCache::getAccessor(ref<Store> store, const Input & originalInput, UseRegist
             fetched.emplace(CachedInput{.lockedInput = lockedInput, .accessor = accessor});
         } else {
             if (useRegistries != UseRegistries::No) {
-                auto [res, extraAttrs] = lookupInRegistries(store, originalInput, useRegistries);
+                auto [res, extraAttrs_] = lookupInRegistries(store, originalInput, useRegistries);
+                extraAttrs = extraAttrs_;
                 resolvedInput = std::move(res);
                 fetched = lookup(resolvedInput);
                 if (!fetched) {
@@ -36,7 +38,7 @@ InputCache::getAccessor(ref<Store> store, const Input & originalInput, UseRegist
 
     debug("got tree '%s' from '%s'", fetched->accessor, fetched->lockedInput.to_string());
 
-    return {fetched->accessor, resolvedInput, fetched->lockedInput};
+    return {fetched->accessor, resolvedInput, fetched->lockedInput, extraAttrs};
 }
 
 struct InputCacheImpl : InputCache

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -335,8 +335,9 @@ static Flake getFlake(
     // Fetch a lazy tree first.
     auto cachedInput = state.inputCache->getAccessor(state.store, originalRef.input, useRegistries);
 
-    auto resolvedRef = FlakeRef(std::move(cachedInput.resolvedInput), originalRef.subdir);
-    auto lockedRef = FlakeRef(std::move(cachedInput.lockedInput), originalRef.subdir);
+    auto subdir = fetchers::maybeGetStrAttr(cachedInput.extraAttrs, "dir").value_or(originalRef.subdir);
+    auto resolvedRef = FlakeRef(std::move(cachedInput.resolvedInput), subdir);
+    auto lockedRef = FlakeRef(std::move(cachedInput.lockedInput), subdir);
 
     // Parse/eval flake.nix to get at the input.self attributes.
     auto flake = readFlake(state, originalRef, resolvedRef, lockedRef, {cachedInput.accessor}, lockRootAttrPath);

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -484,3 +484,20 @@ cat > "$flake3Dir/flake.nix" <<EOF
 EOF
 
 [[ "$(nix flake metadata --json "$flake3Dir" | jq -r .locks.nodes.flake1.locked.rev)" = $prevFlake1Rev ]]
+
+baseDir=$TEST_ROOT/$RANDOM
+subdirFlakeDir=$baseDir/foo
+mkdir -p "$subdirFlakeDir"
+
+writeSimpleFlake "$baseDir"
+
+cat > "$subdirFlakeDir"/flake.nix <<EOF
+{
+  outputs = inputs: {
+    shouldBeOne = 1;
+  };
+}
+EOF
+
+nix registry add --registry "$registry" flake2 "path:$baseDir?dir=foo"
+[[ "$(nix eval --flake-registry "$registry" flake2#shouldBeOne)" = 1 ]]


### PR DESCRIPTION
This broke in e3042f10afb5f4e64ef9a5e08bef52b168cb4bf1.

Fixes upstream issue 13269.

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flake registry entries can now specify a subdirectory via the dir attribute (e.g., path:/some/dir?dir=foo). When present, this subdirectory is used to resolve and lock inputs for registry-based path flakes.

* **Tests**
  * Added functional tests verifying registry-based path flakes with a dir attribute resolve and evaluate correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->