### PR TITLE
More use of boost::concurrent_flat_map and a correctness fix

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2506,8 +2506,7 @@ StorePath EvalState::copyPathToStore(NixStringContext & context, const SourcePat
     if (nix::isDerivation(path.path.abs()))
         error<EvalError>("file names are not allowed to end in '%1%'", drvExtension).debugThrow();
 
-    std::optional<StorePath> dstPathCached;
-    srcToStore->inner.cvisit(path, [&](auto & x) { dstPathCached = x.second; });
+    auto dstPathCached = getConcurrent(srcToStore->inner, path);
 
     auto dstPath = dstPathCached ? *dstPathCached : [&]() {
         auto dstPath = fetchToStore(

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -371,7 +371,8 @@ private:
 
     /* Cache for calls to addToStore(); maps source paths to the store
        paths. */
-    Sync<std::unordered_map<SourcePath, StorePath>> srcToStore;
+    struct SrcToStore;
+    ref<SrcToStore> srcToStore;
 
     /**
      * A cache that maps paths to "resolved" paths for importing Nix

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -384,14 +384,8 @@ private:
     /**
      * A cache from resolved paths to values.
      */
-    typedef std::unordered_map<
-        SourcePath,
-        Value,
-        std::hash<SourcePath>,
-        std::equal_to<SourcePath>,
-        traceable_allocator<std::pair<const SourcePath, Value>>>
-        FileEvalCache;
-    SharedSync<FileEvalCache> fileEvalCache;
+    struct FileEvalCache;
+    ref<FileEvalCache> fileEvalCache;
 
     /**
      * Associate source positions of certain AST nodes with their preceding doc comment, if they have one.

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -378,7 +378,8 @@ private:
      * A cache that maps paths to "resolved" paths for importing Nix
      * expressions, i.e. `/foo` to `/foo/default.nix`.
      */
-    SharedSync<std::unordered_map<SourcePath, SourcePath>> importResolutionCache;
+    struct ImportResolutionCache;
+    ref<ImportResolutionCache> importResolutionCache;
 
     /**
      * A cache from resolved paths to values.

--- a/src/libutil/include/nix/util/source-path.hh
+++ b/src/libutil/include/nix/util/source-path.hh
@@ -119,6 +119,14 @@ struct SourcePath
 
 std::ostream & operator<<(std::ostream & str, const SourcePath & path);
 
+inline std::size_t hash_value(const SourcePath & path)
+{
+    std::size_t hash = 0;
+    boost::hash_combine(hash, path.accessor->number);
+    boost::hash_combine(hash, path.path);
+    return hash;
+}
+
 } // namespace nix
 
 template<>
@@ -126,8 +134,6 @@ struct std::hash<nix::SourcePath>
 {
     std::size_t operator()(const nix::SourcePath & s) const noexcept
     {
-        std::size_t hash = 0;
-        hash_combine(hash, s.accessor->number, s.path);
-        return hash;
+        return nix::hash_value(s);
     }
 };

--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -227,6 +227,14 @@ std::optional<typename T::mapped_type> getOptional(const T & map, const typename
     return {i->second};
 }
 
+template<class T>
+std::optional<typename T::mapped_type> getConcurrent(const T & map, const typename T::key_type & key)
+{
+    std::optional<typename T::mapped_type> res;
+    map.cvisit(key, [&](auto & x) { res = x.second; });
+    return res;
+}
+
 /**
  * Get a value for the specified key from an associate container, or a default value if the key isn't present.
  */

--- a/src/libutil/mounted-source-accessor.cc
+++ b/src/libutil/mounted-source-accessor.cc
@@ -86,9 +86,7 @@ struct MountedSourceAccessorImpl : MountedSourceAccessor
 
     std::shared_ptr<SourceAccessor> getMount(CanonPath mountPoint) override
     {
-        std::optional<ref<SourceAccessor>> res;
-        mounts.cvisit(mountPoint, [&](auto & x) { res = x.second; });
-        if (res)
+        if (auto res = getConcurrent(mounts, mountPoint))
             return *res;
         else
             return nullptr;

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -95,9 +95,7 @@ std::optional<struct stat> PosixSourceAccessor::cachedLstat(const CanonPath & pa
     // former is not hashable on libc++.
     Path absPath = makeAbsPath(path).string();
 
-    std::optional<Cache::mapped_type> res;
-    cache.cvisit(absPath, [&](auto & x) { res.emplace(x.second); });
-    if (res)
+    if (auto res = getConcurrent(cache, absPath))
         return *res;
 
     auto st = nix::maybeLstat(absPath.c_str());


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This converts the file resolution/import caches from `Sync` to `boost::concurrent_flat_map`. It also fixes a bug where a thread might have a pointer to a `Value` in `fileEvalCache` while another thread is resizing it.


<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Replaced lock-based per-object caches with thread-safe concurrent caches to improve multi-threaded file evaluation, import resolution, and path-to-store lookups, reducing contention and improving performance.
  - Streamlined file-evaluation flow so cached results are lazily created and safely reused across threads.

- **Chores**
  - Added helper utilities for concurrent map lookups and centralized hashing to standardize behavior and reduce duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->