### PR TITLE
Pass `dir` in extraAttrs when overriding the registry

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -178,10 +178,16 @@ MixFlakeOptions::MixFlakeOptions()
             for (auto & [inputName, input] : flake.lockFile.root->inputs) {
                 auto input2 = flake.lockFile.findInput({inputName}); // resolve 'follows' nodes
                 if (auto input3 = std::dynamic_pointer_cast<const flake::LockedNode>(input2)) {
+                    fetchers::Attrs extraAttrs;
+
+                    if (!input3->lockedRef.subdir.empty()) {
+                        extraAttrs["dir"] = input3->lockedRef.subdir;
+                    }
+
                     overrideRegistry(
                         fetchers::Input::fromAttrs(fetchSettings, {{"type", "indirect"}, {"id", inputName}}),
                         input3->lockedRef.input,
-                        {});
+                        extraAttrs);
                 }
             }
         }},

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -486,12 +486,12 @@ EOF
 [[ "$(nix flake metadata --json "$flake3Dir" | jq -r .locks.nodes.flake1.locked.rev)" = $prevFlake1Rev ]]
 
 baseDir=$TEST_ROOT/$RANDOM
-subdirFlakeDir=$baseDir/foo
-mkdir -p "$subdirFlakeDir"
+subdirFlakeDir1=$baseDir/foo1
+mkdir -p "$subdirFlakeDir1"
 
 writeSimpleFlake "$baseDir"
 
-cat > "$subdirFlakeDir"/flake.nix <<EOF
+cat > "$subdirFlakeDir1"/flake.nix <<EOF
 {
   outputs = inputs: {
     shouldBeOne = 1;
@@ -499,5 +499,18 @@ cat > "$subdirFlakeDir"/flake.nix <<EOF
 }
 EOF
 
-nix registry add --registry "$registry" flake2 "path:$baseDir?dir=foo"
+nix registry add --registry "$registry" flake2 "path:$baseDir?dir=foo1"
 [[ "$(nix eval --flake-registry "$registry" flake2#shouldBeOne)" = 1 ]]
+
+subdirFlakeDir2=$baseDir/foo2
+mkdir -p "$subdirFlakeDir2"
+cat > "$subdirFlakeDir2"/flake.nix <<EOF
+{
+  inputs.foo1.url = "path:$baseDir?dir=foo1";
+
+  outputs = inputs: { };
+}
+EOF
+
+# Regression test for https://github.com/NixOS/nix/issues/13918
+[[ "$(nix eval --inputs-from "$subdirFlakeDir2" foo1#shouldBeOne)" = 1 ]]


### PR DESCRIPTION
## Motivation

Fixes upstream issue 13918.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Indirect flake inputs now correctly inherit subdirectory context from registry entries, ensuring nested inputs resolve as expected.
  * Fixes issues when evaluating via --inputs-from with path registries pointing to subdirectories.

* **Tests**
  * Expanded functional tests to cover multi-level flake inputs across separate subdirectories.
  * Added a regression check to verify correct resolution of indirect inputs referenced by another flake.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->