### PR TITLE
`nix develop`: Version the JSON + some cleanups

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -300,12 +300,13 @@ static StorePath getDerivationEnvironment(ref<Store> store, ref<Store> evalStore
         bmNormal,
         evalStore);
 
+    // `get-env.sh` will write its JSON output to an arbitrary output
+    // path, so return the first non-empty output path.
     for (auto & [_0, optPath] : evalStore->queryPartialDerivationOutputMap(shellDrvPath)) {
         assert(optPath);
         auto & outPath = *optPath;
-        assert(store->isValidPath(outPath));
-        auto outPathS = store->toRealPath(outPath);
-        if (lstat(outPathS).st_size)
+        auto st = store->getFSAccessor()->lstat(CanonPath(outPath.to_string()));
+        if (st.fileSize.value_or(0))
             return outPath;
     }
 
@@ -495,17 +496,15 @@ struct Common : InstallableCommand, MixProfile
         }
     }
 
-    std::pair<BuildEnvironment, std::string> getBuildEnvironment(ref<Store> store, ref<Installable> installable)
+    std::pair<BuildEnvironment, StorePath> getBuildEnvironment(ref<Store> store, ref<Installable> installable)
     {
         auto shellOutPath = getShellOutPath(store, installable);
 
-        auto strPath = store->printStorePath(shellOutPath);
-
         updateProfile(shellOutPath);
 
-        debug("reading environment file '%s'", strPath);
+        debug("reading environment file '%s'", store->printStorePath(shellOutPath));
 
-        return {BuildEnvironment::parseJSON(readFile(store->toRealPath(shellOutPath))), strPath};
+        return {BuildEnvironment::parseJSON(store->getFSAccessor()->readFile(shellOutPath.to_string())), shellOutPath};
     }
 };
 
@@ -634,7 +633,7 @@ struct CmdDevelop : Common, MixEnvironment
 
         setEnviron();
         // prevent garbage collection until shell exits
-        setEnv("NIX_GCROOT", gcroot.c_str());
+        setEnv("NIX_GCROOT", store->printStorePath(gcroot).c_str());
 
         Path shell = "bash";
 

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -228,11 +228,13 @@ const static std::string getEnvSh =
 #include "get-env.sh.gen.hh"
     ;
 
-/* Given an existing derivation, return the shell environment as
-   initialised by stdenv's setup script. We do this by building a
-   modified derivation with the same dependencies and nearly the same
-   initial environment variables, that just writes the resulting
-   environment to a file and exits. */
+/**
+ * Given an existing derivation, return the shell environment as
+ * initialised by stdenv's setup script. We do this by building a
+ * modified derivation with the same dependencies and nearly the same
+ * initial environment variables, that just writes the resulting
+ * environment to a file and exits.
+ */
 static StorePath getDerivationEnvironment(ref<Store> store, ref<Store> evalStore, const StorePath & drvPath)
 {
     auto drv = evalStore->derivationFromPath(drvPath);

--- a/src/nix/get-env.sh
+++ b/src/nix/get-env.sh
@@ -14,6 +14,7 @@ __functions="$(declare -F)"
 
 __dumpEnv() {
     printf '{\n'
+    printf '  "version": 1,\n'
 
     printf '  "bashFunctions": {\n'
     local __first=1


### PR DESCRIPTION
## Motivation

This adds a `version: 1` field to the JSON environment file created by `nix develop`. This adds some future-proofing if we want to upload environments to binary caches.

Also some miscellaneous cleanups like using `Store::getFSAccessor()`.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The environment JSON now includes a top-level "version": 1 field for forward compatibility.

- Bug Fixes
  - More reliable detection of generated environment output, avoiding empty or unresolved paths.
  - Consistent use of canonical store paths in environment variables (e.g., GC roots), reducing path-related issues.

- Refactor
  - Internal restructuring to integrate the environment script into the build and streamline path handling.

- Documentation
  - Minor formatting improvements to function documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->