### PR TITLE
Only try to substitute input if fetching from its original location fails

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -90,6 +90,7 @@ static void disableNet()
 {
     // FIXME: should check for command line overrides only.
     if (!settings.useSubstitutes.overridden)
+        // FIXME: should not disable local substituters (like file:///).
         settings.useSubstitutes = false;
     if (!settings.tarballTtl.overridden)
         settings.tarballTtl = std::numeric_limits<unsigned int>::max();

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -35,6 +35,7 @@ suites += {
     'old-lockfiles.sh',
     'trace-ifd.sh',
     'build-time-flake-inputs.sh',
+    'substitution.sh',
   ],
   'workdir' : meson.current_source_dir(),
 }

--- a/tests/functional/flakes/substitution.sh
+++ b/tests/functional/flakes/substitution.sh
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash
+
+# Test that inputs are substituted if they cannot be fetched from their original location.
+
+source ./common.sh
+
+if [[ $(nix config show lazy-trees) = true ]]; then
+    exit 0
+fi
+
+TODO_NixOS
+
+createFlake1
+createFlake2
+
+nix build --no-link "$flake2Dir#bar"
+
+path1="$(nix flake metadata --json "$flake1Dir" | jq -r .path)"
+
+# Building after an input disappeared should succeed, because it's still in the Nix store.
+mv "$flake1Dir" "$flake1Dir-tmp"
+nix build --no-link "$flake2Dir#bar" --no-eval-cache
+
+# Check that Nix will fall back to fetching the input from a substituter.
+cache="file://$TEST_ROOT/binary-cache"
+nix copy --to "$cache" "$path1"
+clearStore
+nix build --no-link "$flake2Dir#bar" --no-eval-cache --substitute --substituters "$cache"
+
+clearStore
+expectStderr 1 nix build --no-link "$flake2Dir#bar" --no-eval-cache | grepQuiet "The path.*does not exist"


### PR DESCRIPTION
## Motivation

Previously we always tried to substitute first (by calling `ensurePath()`). This wasn't a problem before lazy trees, because we always end up copying to the store anyway. But that's not the case with lazy trees. So frequently we ended up substituting an input that we had already fetched.

This showed up as

```
fetching source from https://cache.nixos.org
```

for inputs that you could swear Nix had already fetched just before. This was especially a problem for Nixpkgs inputs, since many Nixpkgs revisions are in cache.nixos.org.

Note that this could also be a problem without lazy trees, e.g. with a local input (like a Nixpkgs clone) that happens to be in the binary cache.

So we now only try substitution as a last resort, if we cannot fetch the input normally.


<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flake input resolution: reuses existing store paths when possible, falls back to substituters on fetch failures, and preserves cached fingerprints to avoid redundant work.
  * Clearer warnings and error messages during substitution and fetch failures.

* **Tests**
  * Added a functional test validating flake input substitution, in-store reuse, and cache-based fallback; included in the flakes test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->