### PR TITLE
Disable parallel eval if the debugger is enabled

### DIFF
--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -125,6 +125,13 @@ ref<Store> EvalCommand::getEvalStore()
 ref<EvalState> EvalCommand::getEvalState()
 {
     if (!evalState) {
+        if (startReplOnEvalErrors && evalSettings.evalCores != 1U) {
+            // Disable parallel eval if the debugger is enabled, since
+            // they're incompatible at the moment.
+            warn("using the debugger disables multi-threaded evaluation");
+            evalSettings.evalCores = 1;
+        }
+
         evalState = std::allocate_shared<EvalState>(
             traceable_allocator<EvalState>(), lookupPath, getEvalStore(), fetchSettings, evalSettings, getStore());
 

--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -377,6 +377,8 @@ struct EvalSettings : Config
           * Any evaluation that uses `builtins.parallel`
 
           The value `0` causes Nix to use all available CPU cores in the system.
+
+          Note that enabling the debugger (`--debugger`) disables multi-threaded evaluation.
         )"};
 };
 


### PR DESCRIPTION

## Motivation

They're currently incompatible and it's not obvious how to fix this, so let's just disable parallel eval when the debugger is enabled.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatically falls back to single-threaded evaluation when the debugger is active or when a REPL is started on evaluation errors, improving stability.

- Bug Fixes
  - Prevents crashes and inconsistent behavior by disabling multi-threaded evaluation in those sessions.

- Documentation
  - Clarified that enabling the debugger disables multi-threaded evaluation and noted that REPL-on-error sessions run single-threaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->