### PR TITLE
Make threads waiting on thunks interruptible

### DIFF
--- a/src/libexpr/include/nix/expr/counter.hh
+++ b/src/libexpr/include/nix/expr/counter.hh
@@ -5,7 +5,8 @@
 
 namespace nix {
 
-struct Counter
+// Counters are aligned on cache lines to prevent false sharing.
+struct alignas(64) Counter
 {
     using value_type = uint64_t;
 
@@ -59,6 +60,6 @@ struct Counter
     {
         return enabled ? inner -= n : 0;
     }
-} __attribute__((aligned(64))); // cache line alignment to prevent false sharing
+};
 
 } // namespace nix

--- a/src/libexpr/include/nix/expr/parallel-eval.hh
+++ b/src/libexpr/include/nix/expr/parallel-eval.hh
@@ -41,6 +41,8 @@ struct Executor
 
     const bool enabled;
 
+    const std::unique_ptr<InterruptCallback> interruptCallback;
+
     Sync<State> state_;
 
     std::condition_variable wakeup;

--- a/src/libexpr/include/nix/expr/symbol-table.hh
+++ b/src/libexpr/include/nix/expr/symbol-table.hh
@@ -32,7 +32,7 @@ struct ContiguousArena
     // Put this in a separate cache line to ensure that a thread
     // adding a symbol doesn't slow down threads dereferencing symbols
     // by invalidating the read-only `data` field.
-    std::atomic<size_t> size __attribute__((aligned(64))){0};
+    alignas(64) std::atomic<size_t> size{0};
 
     ContiguousArena(size_t maxSize);
 

--- a/src/libexpr/parallel-eval.cc
+++ b/src/libexpr/parallel-eval.cc
@@ -5,6 +5,13 @@
 
 namespace nix {
 
+struct WaiterDomain
+{
+    std::condition_variable cv;
+} __attribute__((aligned(64))); // cache line alignment to prevent false sharing
+
+static std::array<Sync<WaiterDomain>, 128> waiterDomains;
+
 thread_local bool Executor::amWorkerThread{false};
 
 unsigned int Executor::getEvalCores(const EvalSettings & evalSettings)
@@ -15,6 +22,10 @@ unsigned int Executor::getEvalCores(const EvalSettings & evalSettings)
 Executor::Executor(const EvalSettings & evalSettings)
     : evalCores(getEvalCores(evalSettings))
     , enabled(evalCores > 1)
+    , interruptCallback(createInterruptCallback([&]() {
+        for (auto & domain : waiterDomains)
+            domain.lock()->cv.notify_all();
+    }))
 {
     debug("executor using %d threads", evalCores);
     auto state(state_.lock());
@@ -169,13 +180,6 @@ void FutureVector::finishAll()
         std::rethrow_exception(ex);
 }
 
-struct WaiterDomain
-{
-    std::condition_variable cv;
-} __attribute__((aligned(64))); // cache line alignment to prevent false sharing
-
-static std::array<Sync<WaiterDomain>, 128> waiterDomains;
-
 static Sync<WaiterDomain> & getWaiterDomain(detail::ValueBase & v)
 {
     auto domain = (((size_t) &v) >> 5) % waiterDomains.size();
@@ -241,6 +245,7 @@ ValueStorage<sizeof(void *)>::PackedPointer ValueStorage<sizeof(void *)>::waitOn
             return p0_;
         }
         state.nrSpuriousWakeups++;
+        checkInterrupt();
     }
 }
 

--- a/src/libexpr/parallel-eval.cc
+++ b/src/libexpr/parallel-eval.cc
@@ -5,10 +5,11 @@
 
 namespace nix {
 
-struct WaiterDomain
+// cache line alignment to prevent false sharing
+struct alignas(64) WaiterDomain
 {
     std::condition_variable cv;
-} __attribute__((aligned(64))); // cache line alignment to prevent false sharing
+};
 
 static std::array<Sync<WaiterDomain>, 128> waiterDomains;
 


### PR DESCRIPTION

## Motivation

In particular, this makes Ctrl-C work in case of infinite recursion.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of cancellation/interrupts during evaluation so waiting tasks are reliably and promptly awakened, reducing hangs and delayed responses.
  * Better handling of spurious wakeups to ensure interrupts are processed consistently.

* **New Features**
  * Interrupt-driven wakeups now operate across all evaluation domains, improving responsiveness when stopping or cancelling operations.

* **Notes**
  * No user-facing API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->