### PR TITLE
don't include derivation name in temporary build directories

### DIFF
--- a/doc/manual/rl-next/shorter-build-dir-names.md
+++ b/doc/manual/rl-next/shorter-build-dir-names.md
@@ -1,0 +1,6 @@
+---
+synopsis: "Temporary build directories no longer include derivation names"
+prs: [13839]
+---
+
+Temporary build directories created during derivation builds no longer include the derivation name in their path to avoid build failures when the derivation name is too long. This change ensures predictable prefix lengths for build directories under `/nix/var/nix/builds`.

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -717,7 +717,7 @@ void DerivationBuilderImpl::startBuilder()
 
     /* Create a temporary directory where the build will take
        place. */
-    topTmpDir = createTempDir(buildDir, "nix-build-" + std::string(drvPath.name()), 0700);
+    topTmpDir = createTempDir(buildDir, "nix", 0700);
     setBuildTmpDir();
     assert(!tmpDir.empty());
 

--- a/tests/functional/check.sh
+++ b/tests/functional/check.sh
@@ -52,10 +52,10 @@ test_custom_build_dir() {
   nix-build check.nix -A failed --argstr checkBuildId "$checkBuildId" \
       --no-out-link --keep-failed --option build-dir "$TEST_ROOT/custom-build-dir" 2> "$TEST_ROOT/log" || status=$?
   [ "$status" = "100" ]
-  [[ 1 == "$(count "$customBuildDir/nix-build-"*)" ]]
-  local buildDir=("$customBuildDir/nix-build-"*)
+  [[ 1 == "$(count "$customBuildDir/nix-"*)" ]]
+  local buildDir=("$customBuildDir/nix-"*)
   if [[ "${#buildDir[@]}" -ne 1 ]]; then
-    echo "expected one nix-build-* directory, got: ${buildDir[*]}" >&2
+    echo "expected one nix-* directory, got: ${buildDir[*]}" >&2
     exit 1
   fi
   if [[ -e ${buildDir[*]}/build ]]; then

--- a/tests/nixos/user-sandboxing/default.nix
+++ b/tests/nixos/user-sandboxing/default.nix
@@ -104,8 +104,8 @@ in
 
           # Wait for the build to be ready
           # This is OK because it runs as root, so we can access everything
-          machine.wait_until_succeeds("stat /nix/var/nix/builds/nix-build-open-build-dir.drv-*/build/syncPoint")
-          dir = machine.succeed("ls -d /nix/var/nix/builds/nix-build-open-build-dir.drv-*").strip()
+          machine.wait_until_succeeds("stat /nix/var/nix/builds/nix-*/build/syncPoint")
+          dir = machine.succeed("ls -d /nix/var/nix/builds/nix-*").strip()
 
           # But Alice shouldn't be able to access the build directory
           machine.fail(f"su alice -c 'ls {dir}/build'")
@@ -125,8 +125,8 @@ in
                 args = [ (builtins.storePath "${create-hello-world}") ];
             }' >&2 &
           """.strip())
-          machine.wait_until_succeeds("stat /nix/var/nix/builds/nix-build-innocent.drv-*/build/syncPoint")
-          dir = machine.succeed("ls -d /nix/var/nix/builds/nix-build-innocent.drv-*").strip()
+          machine.wait_until_succeeds("stat /nix/var/nix/builds/nix-*/build/syncPoint")
+          dir = machine.succeed("ls -d /nix/var/nix/builds/nix-*").strip()
 
           # The build ran as `nixbld1` (which is the only build user on the
           # machine), but a process running as `nixbld1` outside the sandbox


### PR DESCRIPTION

## Motivation

With the migration to /nix/var/nix/builds we now have failing builds when the derivation name is too long.
This change removes the derivation name from the temporary build to have a predictable prefix length:

Also see: https://github.com/NixOS/infra/pull/764
for context.

(cherry picked from commit 725a2f379fcd76ff1137132fee48dffba9c0c396) (cherry picked from commit 7c3fd50617c2de632bccb7b6f59945357766af76)

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary build directories no longer include derivation names, reducing path-length-related build failures and providing predictable nix-* prefixes under /nix/var/nix/builds.

* **Documentation**
  * Added a page explaining the new temporary build directory naming and its implications, with references for further details.

* **Tests**
  * Updated functional and NixOS tests to reflect the new nix-* build directory patterns for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->