### PR TITLE
libstore-c: add nix_store_get_fs_closure

### DIFF
--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -180,3 +180,31 @@ nix_err nix_store_copy_closure(nix_c_context * context, Store * srcStore, Store 
     }
     NIXC_CATCH_ERRS
 }
+
+nix_err nix_store_get_fs_closure(
+    nix_c_context * context,
+    Store * store,
+    const StorePath * store_path,
+    bool flip_direction,
+    bool include_outputs,
+    bool include_derivers,
+    void * userdata,
+    void (*callback)(void * userdata, const StorePath * store_path))
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        const auto nixStore = store->ptr;
+
+        nix::StorePathSet set;
+        nixStore->computeFSClosure(store_path->path, set, flip_direction, include_outputs, include_derivers);
+
+        if (callback) {
+            for (const auto & path : set) {
+                const StorePath tmp{path};
+                callback(userdata, &tmp);
+            }
+        }
+    }
+    NIXC_CATCH_ERRS
+}

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -217,6 +217,30 @@ nix_store_get_version(nix_c_context * context, Store * store, nix_get_string_cal
  */
 nix_err nix_store_copy_closure(nix_c_context * context, Store * srcStore, Store * dstStore, StorePath * path);
 
+/**
+ * @brief Gets the closure of a specific store path
+ *
+ * @note The callback borrows each StorePath only for the duration of the call.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] store nix store reference
+ * @param[in] store_path The path to compute from
+ * @param[in] flip_direction
+ * @param[in] include_outputs
+ * @param[in] include_derivers
+ * @param[in] callback The function to call for every store path
+ * @param[in] userdata The userdata to pass to the callback
+ */
+nix_err nix_store_get_fs_closure(
+    nix_c_context * context,
+    Store * store,
+    const StorePath * store_path,
+    bool flip_direction,
+    bool include_outputs,
+    bool include_derivers,
+    void * userdata,
+    void (*callback)(void * userdata, const StorePath * store_path));
+
 // cffi end
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Exposes the nix store API's `computeFSClosure` function inside the C API as `nix_store_compute_fs_closure`.

## Context

This is useful for expanding the nixops4 Rust bindings so we're able to look into a store path's closure.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API to compute the filesystem closure for a store path.
  * Supports options for traversal direction, including outputs, and including derivers.
  * Adds a callback mechanism to receive each path in the computed closure.
  * Uses the existing error-reporting context for consistent error handling and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->