### PR TITLE
Fix infinite recursion detection

### DIFF
--- a/src/libexpr/include/nix/expr/eval-inline.hh
+++ b/src/libexpr/include/nix/expr/eval-inline.hh
@@ -88,6 +88,13 @@ Env & EvalState::allocEnv(size_t size)
     return *env;
 }
 
+/**
+ * An identifier of the current thread for deadlock detection, stored
+ * in p0 of pending/awaited thunks. We're not using std::thread::id
+ * because it's not guaranteed to fit.
+ */
+extern thread_local uint32_t myEvalThreadId;
+
 template<std::size_t ptrSize>
 void ValueStorage<ptrSize, std::enable_if_t<detail::useBitPackedValueStorage<ptrSize>>>::force(
     EvalState & state, PosIdx pos)
@@ -103,12 +110,16 @@ void ValueStorage<ptrSize, std::enable_if_t<detail::useBitPackedValueStorage<ptr
             auto p1_ = p1;
 
             // Atomically set the thunk to "pending".
-            if (!p0.compare_exchange_strong(p0_, pdPending, std::memory_order_acquire, std::memory_order_acquire)) {
+            if (!p0.compare_exchange_strong(
+                    p0_,
+                    pdPending | (myEvalThreadId << discriminatorBits),
+                    std::memory_order_acquire,
+                    std::memory_order_acquire)) {
                 pd = static_cast<PrimaryDiscriminator>(p0_ & discriminatorMask);
                 if (pd == pdPending || pd == pdAwaited) {
                     // The thunk is already "pending" or "awaited", so
                     // we need to wait for it.
-                    p0_ = waitOnThunk(state, pd == pdAwaited);
+                    p0_ = waitOnThunk(state, p0_);
                     goto done;
                 }
                 assert(pd != pdThunk);
@@ -134,7 +145,7 @@ void ValueStorage<ptrSize, std::enable_if_t<detail::useBitPackedValueStorage<ptr
     }
 
     else if (pd == pdPending || pd == pdAwaited)
-        p0_ = waitOnThunk(state, pd == pdAwaited);
+        p0_ = waitOnThunk(state, p0_);
 
 done:
     if (InternalType(p0_ & 0xff) == tFailed)

--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -805,7 +805,7 @@ private:
      * state, wait for it to finish. Returns the first word of the
      * value.
      */
-    PackedPointer waitOnThunk(EvalState & state, bool awaited);
+    PackedPointer waitOnThunk(EvalState & state, PackedPointer p0);
 
     /**
      * Wake up any threads that are waiting on this value.
@@ -817,7 +817,8 @@ template<>
 void ValueStorage<sizeof(void *)>::notifyWaiters();
 
 template<>
-ValueStorage<sizeof(void *)>::PackedPointer ValueStorage<sizeof(void *)>::waitOnThunk(EvalState & state, bool awaited);
+ValueStorage<sizeof(void *)>::PackedPointer
+ValueStorage<sizeof(void *)>::waitOnThunk(EvalState & state, PackedPointer p0);
 
 template<>
 bool ValueStorage<sizeof(void *)>::isTrivial() const;


### PR DESCRIPTION

## Motivation

This detects infinite recursion within the same thread (i.e. when a thread waits on a thunk that it's already evaluating). This is done by storing a thread ID in pending/awaited values.

It does not detect cycles between threads, e.g. in `rec { x = y; y = x; }` if `x` and `y` are marked as pending by different threads. But those are much less likely in practice.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved multi-threaded evaluation with per-thread tracking to prevent self-deadlocks.
- Performance
  - More efficient synchronization when multiple threads evaluate the same expression, improving parallel performance.
- Bug Fixes
  - Fixed rare deadlocks and infinite recursion during evaluation under heavy concurrency.
  - Corrected handling of pending/awaited states to avoid stalls and spurious waits.
- Reliability
  - Enhanced stability in parallel builds by tightening state transitions and early-exit conditions during waits.
  - Reduced race conditions when finalizing values under contention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->