### PR TITLE
Fix segfault in ~EvalState when using builtins.parallel

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -243,7 +243,6 @@ EvalState::EvalState(
     std::shared_ptr<Store> buildStore)
     : fetchSettings{fetchSettings}
     , settings{settings}
-    , executor{make_ref<Executor>(settings)}
     , sWith(symbols.create("<with>"))
     , sOutPath(symbols.create("outPath"))
     , sDrvPath(symbols.create("drvPath"))
@@ -377,6 +376,7 @@ EvalState::EvalState(
     , baseEnv(allocEnv(BASE_ENV_SIZE))
 #endif
     , staticBaseEnv{std::make_shared<StaticEnv>(nullptr, nullptr)}
+    , executor{make_ref<Executor>(settings)}
 {
     corepkgsFS->setPathDisplay("<nix", ">");
     internalFS->setPathDisplay("«nix-internal»", "");

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -224,8 +224,6 @@ public:
     const fetchers::Settings & fetchSettings;
     const EvalSettings & settings;
 
-    ref<Executor> executor;
-
     SymbolTable symbols;
     PosTable positions;
 
@@ -1004,6 +1002,17 @@ private:
 
     friend struct Value;
     friend class ListBuilder;
+
+public:
+    /**
+     * Worker threads manager.
+     *
+     * Note: keep this last to ensure that it's destroyed first, so we
+     * don't have any background work items (e.g. from
+     * `builtins.parallel`) referring to a partially destroyed
+     * `EvalState`.
+     */
+    ref<Executor> executor;
 };
 
 struct DebugTraceStacker


### PR DESCRIPTION

## Motivation

We have to make sure that any backgrounded work items are destroyed before we destroy the rest of EvalState, since those work items can call EvalState.

Fixes https://github.com/DeterminateSystems/nix-src/issues/216.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted initialization and teardown sequencing for the evaluation engine’s worker manager, improving construction order and lifecycle clarity.
* **Bug Fixes**
  * Improved stability during shutdown when background tasks are active, reducing potential race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->