### PR TITLE
exportReferencesGraph: Handle heterogeneous arrays

### DIFF
--- a/src/libstore/derivation-options.cc
+++ b/src/libstore/derivation-options.cc
@@ -99,6 +99,17 @@ DerivationOptions DerivationOptions::fromStructuredAttrs(
     return fromStructuredAttrs(env, parsed ? &*parsed : nullptr);
 }
 
+static void flatten(const nlohmann::json & value, StringSet & res)
+{
+    if (value.is_array())
+        for (auto & v : value)
+            flatten(v, res);
+    else if (value.is_string())
+        res.insert(value);
+    else
+        throw Error("'exportReferencesGraph' value is not an array or a string");
+}
+
 DerivationOptions
 DerivationOptions::fromStructuredAttrs(const StringMap & env, const StructuredAttrs * parsed, bool shouldWarn)
 {
@@ -219,12 +230,9 @@ DerivationOptions::fromStructuredAttrs(const StringMap & env, const StructuredAt
                     if (!e || !e->is_object())
                         return ret;
                     for (auto & [key, value] : getObject(*e)) {
-                        if (value.is_array())
-                            ret.insert_or_assign(key, value);
-                        else if (value.is_string())
-                            ret.insert_or_assign(key, StringSet{value});
-                        else
-                            throw Error("'exportReferencesGraph' value is not an array or a string");
+                        StringSet ss;
+                        flatten(value, ss);
+                        ret.insert_or_assign(key, ss);
                     }
                 } else {
                     auto s = getOr(env, "exportReferencesGraph", "");

--- a/tests/functional/structured-attrs.nix
+++ b/tests/functional/structured-attrs.nix
@@ -82,4 +82,8 @@ mkDerivation {
   "foo$" = "BAD";
 
   exportReferencesGraph.refs = [ dep ];
+  exportReferencesGraph.refs2 = [
+    dep
+    [ dep ]
+  ]; # regression test for heterogeneous arrays
 }


### PR DESCRIPTION
## Motivation

This barfed with

```
error: [json.exception.type_error.302] type must be string, but is array
```
on `nix build github:malt3/bazel-env#bazel-env` because it has a `exportReferencesGraph` with a value like `["string",...["string"]]`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of exportReferencesGraph to correctly handle nested and heterogeneous arrays of references, with clearer errors for invalid types.

* **Refactor**
  * Internal parsing logic streamlined for consistent handling of structured and environment-based attributes without changing public APIs or behavior.

* **Tests**
  * Added a regression test covering nested/heterogeneous reference arrays in structured derivations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->