### PR TITLE
nix flake clone: Support all input types

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -6,6 +6,7 @@
 #include "nix/fetchers/store-path-accessor.hh"
 #include "nix/fetchers/fetch-settings.hh"
 #include "nix/util/forwarding-source-accessor.hh"
+#include "nix/util/archive.hh"
 
 #include <nlohmann/json.hpp>
 
@@ -389,10 +390,10 @@ Input Input::applyOverrides(std::optional<std::string> ref, std::optional<Hash> 
     return scheme->applyOverrides(*this, ref, rev);
 }
 
-void Input::clone(const std::filesystem::path & destDir) const
+void Input::clone(ref<Store> store, const std::filesystem::path & destDir) const
 {
     assert(scheme);
-    scheme->clone(*this, destDir);
+    scheme->clone(store, *this, destDir);
 }
 
 std::optional<std::filesystem::path> Input::getSourcePath() const
@@ -505,9 +506,18 @@ void InputScheme::putFile(
     throw Error("input '%s' does not support modifying file '%s'", input.to_string(), path);
 }
 
-void InputScheme::clone(const Input & input, const std::filesystem::path & destDir) const
+void InputScheme::clone(ref<Store> store, const Input & input, const std::filesystem::path & destDir) const
 {
-    throw Error("do not know how to clone input '%s'", input.to_string());
+    if (std::filesystem::exists(destDir))
+        throw Error("cannot clone into existing path %s", destDir);
+
+    auto [accessor, input2] = getAccessor(store, input);
+
+    Activity act(*logger, lvlTalkative, actUnknown, fmt("copying '%s' to %s...", input2.to_string(), destDir));
+
+    auto source = sinkToSource([&](Sink & sink) { accessor->dumpPath(CanonPath::root, sink); });
+
+    restorePath(destDir, *source);
 }
 
 std::optional<ExperimentalFeature> InputScheme::experimentalFeature() const

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -283,7 +283,7 @@ struct GitInputScheme : InputScheme
         return res;
     }
 
-    void clone(const Input & input, const std::filesystem::path & destDir) const override
+    void clone(ref<Store> store, const Input & input, const std::filesystem::path & destDir) const override
     {
         auto repoInfo = getRepoInfo(input);
 

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -426,12 +426,12 @@ struct GitHubInputScheme : GitArchiveInputScheme
         return DownloadUrl{url, headers};
     }
 
-    void clone(const Input & input, const std::filesystem::path & destDir) const override
+    void clone(ref<Store> store, const Input & input, const std::filesystem::path & destDir) const override
     {
         auto host = getHost(input);
         Input::fromURL(*input.settings, fmt("git+https://%s/%s/%s.git", host, getOwner(input), getRepo(input)))
             .applyOverrides(input.getRef(), input.getRev())
-            .clone(destDir);
+            .clone(store, destDir);
     }
 };
 
@@ -506,7 +506,7 @@ struct GitLabInputScheme : GitArchiveInputScheme
         return DownloadUrl{url, headers};
     }
 
-    void clone(const Input & input, const std::filesystem::path & destDir) const override
+    void clone(ref<Store> store, const Input & input, const std::filesystem::path & destDir) const override
     {
         auto host = maybeGetStrAttr(input.attrs, "host").value_or("gitlab.com");
         // FIXME: get username somewhere
@@ -514,7 +514,7 @@ struct GitLabInputScheme : GitArchiveInputScheme
             *input.settings,
             fmt("git+https://%s/%s/%s.git", host, getStrAttr(input.attrs, "owner"), getStrAttr(input.attrs, "repo")))
             .applyOverrides(input.getRef(), input.getRev())
-            .clone(destDir);
+            .clone(store, destDir);
     }
 };
 
@@ -598,14 +598,14 @@ struct SourceHutInputScheme : GitArchiveInputScheme
         return DownloadUrl{url, headers};
     }
 
-    void clone(const Input & input, const std::filesystem::path & destDir) const override
+    void clone(ref<Store> store, const Input & input, const std::filesystem::path & destDir) const override
     {
         auto host = maybeGetStrAttr(input.attrs, "host").value_or("git.sr.ht");
         Input::fromURL(
             *input.settings,
             fmt("git+https://%s/%s/%s", host, getStrAttr(input.attrs, "owner"), getStrAttr(input.attrs, "repo")))
             .applyOverrides(input.getRef(), input.getRev())
-            .clone(destDir);
+            .clone(store, destDir);
     }
 };
 

--- a/src/libfetchers/include/nix/fetchers/fetchers.hh
+++ b/src/libfetchers/include/nix/fetchers/fetchers.hh
@@ -150,7 +150,7 @@ public:
 
     Input applyOverrides(std::optional<std::string> ref, std::optional<Hash> rev) const;
 
-    void clone(const std::filesystem::path & destDir) const;
+    void clone(ref<Store> store, const std::filesystem::path & destDir) const;
 
     std::optional<std::filesystem::path> getSourcePath() const;
 
@@ -223,7 +223,7 @@ struct InputScheme
 
     virtual Input applyOverrides(const Input & input, std::optional<std::string> ref, std::optional<Hash> rev) const;
 
-    virtual void clone(const Input & input, const std::filesystem::path & destDir) const;
+    virtual void clone(ref<Store> store, const Input & input, const std::filesystem::path & destDir) const;
 
     virtual std::optional<std::filesystem::path> getSourcePath(const Input & input) const;
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1054,7 +1054,7 @@ struct CmdFlakeClone : FlakeCommand
         if (destDir.empty())
             throw Error("missing flag '--dest'");
 
-        getFlakeRef().resolve(store).input.clone(destDir);
+        getFlakeRef().resolve(store).input.clone(store, destDir);
     }
 };
 

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -381,6 +381,10 @@ tar cfz $TEST_ROOT/flake.tar.gz -C $TEST_ROOT flake5
 
 nix build -o $TEST_ROOT/result file://$TEST_ROOT/flake.tar.gz
 
+nix flake clone file://$TEST_ROOT/flake.tar.gz --dest $TEST_ROOT/unpacked
+[[ -e $TEST_ROOT/unpacked/flake.nix ]]
+expectStderr 1 nix flake clone file://$TEST_ROOT/flake.tar.gz --dest $TEST_ROOT/unpacked | grep 'existing path'
+
 # Building with a tarball URL containing a SRI hash should also work.
 url=$(nix flake metadata --json file://$TEST_ROOT/flake.tar.gz | jq -r .url)
 [[ $url =~ sha256- ]]


### PR DESCRIPTION
## Motivation

This makes `nix flake clone` work on all input types, including tarballs, e.g.
```
# nix flake clone "https://flakehub.com/f/NixOS/nixpkgs/*" --dest nixpkgs
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support cloning tarball-based flakes into a directory via flake clone.
- Bug Fixes
  - More robust path handling and clearer errors when the destination already exists during flake cloning.
- Refactor
  - Standardized destination path handling and propagated store context for cloning operations to improve reliability.
- Tests
  - Added functional tests covering cloning of tarball flakes, presence of flake.nix in the unpacked directory, and error behavior on re-clone into an existing path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->