### PR TITLE
printValueAsJSON(): Don't wait for futures

### DIFF
--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -12,34 +12,41 @@ namespace nix {
 
 using json = nlohmann::json;
 
+#pragma GCC diagnostic ignored "-Wswitch-enum"
+
+static void parallelForceDeep(EvalState & state, Value & v, PosIdx pos)
+{
+    state.forceValue(v, pos);
+
+    std::vector<std::pair<Executor::work_t, uint8_t>> work;
+
+    switch (v.type()) {
+
+    case nAttrs: {
+        NixStringContext context;
+        if (state.tryAttrsToString(pos, v, context, false, false))
+            return;
+        if (v.attrs()->get(state.sOutPath))
+            return;
+        for (auto & a : *v.attrs())
+            work.emplace_back(
+                [value(allocRootValue(a.value)), pos(a.pos), &state]() { parallelForceDeep(state, **value, pos); }, 0);
+        break;
+    }
+
+    default:
+        break;
+    }
+
+    state.executor->spawn(std::move(work));
+}
+
 // TODO: rename. It doesn't print.
 json printValueAsJSON(
-    EvalState & state, bool strict, Value & v, const PosIdx pos, NixStringContext & context_, bool copyToStore)
+    EvalState & state, bool strict, Value & v, const PosIdx pos, NixStringContext & context, bool copyToStore)
 {
-    FutureVector futures(*state.executor);
-
-    auto doParallel = state.executor->enabled && !Executor::amWorkerThread;
-
-    auto spawn = [&](auto work) {
-        if (doParallel) {
-            futures.spawn(0, [work{std::move(work)}]() { work(); });
-        } else {
-            work();
-        }
-    };
-
-    struct State
-    {
-        NixStringContext & context;
-    };
-
-    Sync<State> state_{State{.context = context_}};
-
-    auto addContext = [&](const NixStringContext & context) {
-        auto state(state_.lock());
-        for (auto & c : context)
-            state->context.insert(c);
-    };
+    if (strict && state.executor->enabled && !Executor::amWorkerThread)
+        parallelForceDeep(state, v, pos);
 
     std::function<void(json & res, Value & v, PosIdx pos)> recurse;
 
@@ -60,19 +67,15 @@ json printValueAsJSON(
             break;
 
         case nString: {
-            NixStringContext context;
             copyContext(v, context);
-            addContext(context);
             res = v.c_str();
             break;
         }
 
         case nPath:
-            if (copyToStore) {
-                NixStringContext context;
+            if (copyToStore)
                 res = state.store->printStorePath(state.copyPathToStore(context, v.path(), v.determinePos(pos)));
-                addContext(context);
-            } else
+            else
                 res = v.path().path.abs();
             break;
 
@@ -81,9 +84,7 @@ json printValueAsJSON(
             break;
 
         case nAttrs: {
-            NixStringContext context;
             auto maybeString = state.tryAttrsToString(pos, v, context, false, false);
-            addContext(context);
             if (maybeString) {
                 res = *maybeString;
                 break;
@@ -94,16 +95,14 @@ json printValueAsJSON(
                 res = json::object();
                 for (auto & a : v.attrs()->lexicographicOrder(state.symbols)) {
                     json & j = res.emplace(state.symbols[a->name], json()).first.value();
-                    spawn([&, a]() {
-                        try {
-                            recurse(j, *a->value, a->pos);
-                        } catch (Error & e) {
-                            e.addTrace(
-                                state.positions[a->pos],
-                                HintFmt("while evaluating attribute '%1%'", state.symbols[a->name]));
-                            throw;
-                        }
-                    });
+                    try {
+                        recurse(j, *a->value, a->pos);
+                    } catch (Error & e) {
+                        e.addTrace(
+                            state.positions[a->pos],
+                            HintFmt("while evaluating attribute '%1%'", state.symbols[a->name]));
+                        throw;
+                    }
                 }
             }
             break;
@@ -124,9 +123,7 @@ json printValueAsJSON(
         }
 
         case nExternal: {
-            NixStringContext context;
             res = v.external()->printValueAsJSON(state, strict, context, copyToStore);
-            addContext(context);
             break;
         }
 
@@ -144,8 +141,6 @@ json printValueAsJSON(
     json res;
 
     recurse(res, v, pos);
-
-    futures.finishAll();
 
     return res;
 }


### PR DESCRIPTION

## Motivation

Just force evaluation in the background, no need to wait for it. If the caller gets to a value before the worker threads do, no problem - the caller will just do the evaluation instead, which is probably faster.

Not waiting removes a deadlock possibility, where the calling thread waits for some work items that are themselves waiting for a thunk that is being evaluated by the calling thread. Fixes #220.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Faster JSON serialization for complex values by leveraging parallel processing when available.
  * Reduced synchronization overhead for smoother evaluations.

* **Reliability**
  * Improved error traces during attribute serialization for clearer diagnostics.
  * More consistent handling of strings, paths, and store-path printing.

* **Refactor**
  * Simplified internal context management and traversal logic to reduce complexity and improve maintainability, without changing output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->