### PR TITLE
builtins.parallel: Register values as GC roots

### DIFF
--- a/src/libexpr/parallel-eval.cc
+++ b/src/libexpr/parallel-eval.cc
@@ -274,9 +274,9 @@ static void prim_parallel(EvalState & state, const PosIdx pos, Value ** args, Va
 
     if (state.executor->evalCores > 1) {
         std::vector<std::pair<Executor::work_t, uint8_t>> work;
-        for (auto v : args[0]->listView())
-            if (!v->isFinished())
-                work.emplace_back([v, &state, pos]() { state.forceValue(*v, pos); }, 0);
+        for (auto value : args[0]->listView())
+            if (!value->isFinished())
+                work.emplace_back([value(allocRootValue(value)), &state, pos]() { state.forceValue(**value, pos); }, 0);
         state.executor->spawn(std::move(work));
     }
 


### PR DESCRIPTION
## Motivation

Otherwise Nix can crash if a GC happens while a work item from `builtins.parallel` is in the queue.

Seen in issue #220.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined how items are prepared and handled during parallel evaluation to improve robustness when using multiple cores.

* **Performance**
  * Minor efficiency improvements in multi-core evaluation scenarios, potentially reducing overhead per task.

* **Stability**
  * Improved consistency of value handling during parallel execution, reducing the likelihood of edge-case evaluation issues under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->