### PR TITLE
importPaths(): Seek over paths that are already in the store

### DIFF
--- a/src/libstore/export-import.cc
+++ b/src/libstore/export-import.cc
@@ -138,10 +138,13 @@ StorePaths importPaths(Store & store, Source & source, CheckSigsFlag checkSigs)
             auto info = WorkerProto::Serialise<ValidPathInfo>::read(
                 store, WorkerProto::ReadConn{.from = source, .version = 16, .shortStorePaths = true});
 
-            Activity act(
-                *logger, lvlTalkative, actUnknown, fmt("importing path '%s'", store.printStorePath(info.path)));
+            if (!store.isValidPath(info.path)) {
+                Activity act(
+                    *logger, lvlTalkative, actUnknown, fmt("importing path '%s'", store.printStorePath(info.path)));
 
-            store.addToStore(info, source, NoRepair, checkSigs);
+                store.addToStore(info, source, NoRepair, checkSigs);
+            } else
+                source.skip(info.narSize);
 
             res.push_back(info.path);
         }


### PR DESCRIPTION
## Motivation

This speeds up re-importing a 15 GiB closure from 5.2s to 0.05s.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized import-export operations to skip unnecessary re-imports of already-valid paths in the store, improving performance for repeated import operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->