### PR TITLE
Print the Nix version when using `-vv` (or more) verbosity

### DIFF
--- a/src/libmain/include/nix/main/shared.hh
+++ b/src/libmain/include/nix/main/shared.hh
@@ -29,6 +29,8 @@ void parseCmdLine(
     const Strings & args,
     std::function<bool(Strings::iterator & arg, const Strings::iterator & end)> parseArg);
 
+std::string version();
+
 void printVersion(const std::string & programName);
 
 /**

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -290,9 +290,14 @@ void parseCmdLine(
     LegacyArgs(programName, parseArg).parseCmdline(args);
 }
 
+std::string version()
+{
+    return fmt("(Determinate Nix %s) %s", determinateNixVersion, nixVersion);
+}
+
 void printVersion(const std::string & programName)
 {
-    std::cout << fmt("%s (Determinate Nix %s) %s", programName, determinateNixVersion, nixVersion) << std::endl;
+    std::cout << fmt("%s %s", programName, version()) << std::endl;
     if (verbosity > lvlInfo) {
         Strings cfg;
 #if NIX_USE_BOEHMGC

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -509,6 +509,8 @@ void mainWrapped(int argc, char ** argv)
 
     applyJSONLogger();
 
+    printTalkative("Nix %s", version());
+
     if (args.helpRequested) {
         std::vector<std::string> subcommand;
         MultiCommand * command = &args;


### PR DESCRIPTION
Knowing the Nix version a user is running on is useful when attempting to debug, and if the user is giving you the output of e.g. `nix build ... --debug`, you won't have to ask for the version separately since it'll be in the log.

Requiring 2 `v`s was a conscious decision: `-v` doesn't really print anything that would be useful for debugging anyways, but `-vv` might. Rather than printing more likely-unnecessary information, just sequester it away to Talkative or higher verbosities.

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application now logs the Nix version at startup.
  * Exposed a public method to obtain the application version as a formatted string for display or logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->