### PR TITLE
Allow access to the result of fetchClosure

### DIFF
--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -64,6 +64,8 @@ static void runFetchClosureWithRewrite(
              .pos = state.positions[pos]});
     }
 
+    state.allowClosure(toPath);
+
     state.mkStorePathString(toPath, v);
 }
 
@@ -91,6 +93,8 @@ static void runFetchClosureWithContentAddressedPath(
              .pos = state.positions[pos]});
     }
 
+    state.allowClosure(fromPath);
+
     state.mkStorePathString(fromPath, v);
 }
 
@@ -114,6 +118,8 @@ static void runFetchClosureWithInputAddressedPath(
                  state.store->printStorePath(fromPath)),
              .pos = state.positions[pos]});
     }
+
+    state.allowClosure(fromPath);
 
     state.mkStorePathString(fromPath, v);
 }

--- a/tests/functional/dependencies.builder0.sh
+++ b/tests/functional/dependencies.builder0.sh
@@ -17,4 +17,6 @@ ln -s "$out" "$out"/self
 echo program > "$out"/program
 chmod +x "$out"/program
 
+echo '1 + 2' > "$out"/foo.nix
+
 echo FOO

--- a/tests/functional/fetchClosure.sh
+++ b/tests/functional/fetchClosure.sh
@@ -99,6 +99,14 @@ clearStore
 
 [ -e "$caPath" ]
 
+# Test import-from-derivation on the result of fetchClosure.
+[[ $(nix eval -v --expr "
+  import \"\${builtins.fetchClosure {
+    fromStore = \"file://$cacheDir\";
+    fromPath = $caPath;
+  }}/foo.nix\"
+") = 3 ]]
+
 # Check that URL query parameters aren't allowed.
 clearStore
 narCache=$TEST_ROOT/nar-cache


### PR DESCRIPTION
## Motivation

There is no reason not to allow importing from a `fetchClosure` call.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured path allowance is applied before writing store paths in closure fetching, correcting path validation across multiple fetch scenarios.

* **Tests**
  * Added functional tests that create a simple derivation and verify importing the fetched closure yields the expected result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->