### PR TITLE
Abbreviate flakerefs in error messages

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -129,11 +129,17 @@ std::optional<std::string> Input::getFingerprint(ref<Store> store) const
     return fingerprint;
 }
 
-ParsedURL Input::toURL() const
+ParsedURL Input::toURL(bool abbreviate) const
 {
     if (!scheme)
         throw Error("cannot show unsupported input '%s'", attrsToJSON(attrs));
-    return scheme->toURL(*this);
+
+    auto url = scheme->toURL(*this, abbreviate);
+
+    if (abbreviate)
+        url.query.erase("narHash");
+
+    return url;
 }
 
 std::string Input::toURLString(const StringMap & extraQuery) const
@@ -144,9 +150,9 @@ std::string Input::toURLString(const StringMap & extraQuery) const
     return url.to_string();
 }
 
-std::string Input::to_string() const
+std::string Input::to_string(bool abbreviate) const
 {
-    return toURL().to_string();
+    return toURL(abbreviate).to_string();
 }
 
 bool Input::isDirect() const
@@ -348,7 +354,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
 
         // FIXME: ideally we would use the `showPath()` of the
         // "real" accessor for this fetcher type.
-        accessor->setPathDisplay("«" + to_string() + "»");
+        accessor->setPathDisplay("«" + to_string(true) + "»");
 
         return {accessor, *this};
     };
@@ -490,7 +496,7 @@ std::optional<time_t> Input::getLastModified() const
     return {};
 }
 
-ParsedURL InputScheme::toURL(const Input & input) const
+ParsedURL InputScheme::toURL(const Input & input, bool abbreviate) const
 {
     throw Error("don't know how to convert input '%s' to a URL", attrsToJSON(input.attrs));
 }

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -241,15 +241,17 @@ struct GitInputScheme : InputScheme
         return input;
     }
 
-    ParsedURL toURL(const Input & input) const override
+    ParsedURL toURL(const Input & input, bool abbreviate) const override
     {
         auto url = parseURL(getStrAttr(input.attrs, "url"));
         if (url.scheme != "git")
             url.scheme = "git+" + url.scheme;
         if (auto rev = input.getRev())
             url.query.insert_or_assign("rev", rev->gitRev());
-        if (auto ref = input.getRef())
-            url.query.insert_or_assign("ref", *ref);
+        if (auto ref = input.getRef()) {
+            if (!abbreviate || (*ref != "master" && *ref != "main"))
+                url.query.insert_or_assign("ref", *ref);
+        }
         if (getShallowAttr(input))
             url.query.insert_or_assign("shallow", "1");
         if (getLfsAttr(input))
@@ -720,7 +722,7 @@ struct GitInputScheme : InputScheme
 
         bool exportIgnore = getExportIgnoreAttr(input);
         bool smudgeLfs = getLfsAttr(input);
-        auto accessor = repo->getAccessor(rev, exportIgnore, "«" + input.to_string() + "»", smudgeLfs);
+        auto accessor = repo->getAccessor(rev, exportIgnore, "«" + input.to_string(true) + "»", smudgeLfs);
 
         /* If the repo has submodules, fetch them and return a mounted
            input accessor consisting of the accessor for the top-level
@@ -757,7 +759,7 @@ struct GitInputScheme : InputScheme
                 attrs.insert_or_assign("allRefs", Explicit<bool>{true});
                 auto submoduleInput = fetchers::Input::fromAttrs(*input.settings, std::move(attrs));
                 auto [submoduleAccessor, submoduleInput2] = submoduleInput.getAccessor(store);
-                submoduleAccessor->setPathDisplay("«" + submoduleInput.to_string() + "»");
+                submoduleAccessor->setPathDisplay("«" + submoduleInput.to_string(true) + "»");
                 mounts.insert_or_assign(submodule.path, submoduleAccessor);
             }
 
@@ -810,7 +812,7 @@ struct GitInputScheme : InputScheme
 
                 auto submoduleInput = fetchers::Input::fromAttrs(*input.settings, std::move(attrs));
                 auto [submoduleAccessor, submoduleInput2] = submoduleInput.getAccessor(store);
-                submoduleAccessor->setPathDisplay("«" + submoduleInput.to_string() + "»");
+                submoduleAccessor->setPathDisplay("«" + submoduleInput.to_string(true) + "»");
 
                 /* If the submodule is dirty, mark this repo dirty as
                    well. */

--- a/src/libfetchers/include/nix/fetchers/fetchers.hh
+++ b/src/libfetchers/include/nix/fetchers/fetchers.hh
@@ -68,11 +68,11 @@ public:
      */
     static Input fromAttrs(const Settings & settings, Attrs && attrs);
 
-    ParsedURL toURL() const;
+    ParsedURL toURL(bool abbreviate = false) const;
 
     std::string toURLString(const StringMap & extraQuery = {}) const;
 
-    std::string to_string() const;
+    std::string to_string(bool abbreviate = false) const;
 
     Attrs toAttrs() const;
 
@@ -219,7 +219,7 @@ struct InputScheme
      */
     virtual StringSet allowedAttrs() const = 0;
 
-    virtual ParsedURL toURL(const Input & input) const;
+    virtual ParsedURL toURL(const Input & input, bool abbreviate = false) const;
 
     virtual Input applyOverrides(const Input & input, std::optional<std::string> ref, std::optional<Hash> rev) const;
 

--- a/src/libfetchers/indirect.cc
+++ b/src/libfetchers/indirect.cc
@@ -81,7 +81,7 @@ struct IndirectInputScheme : InputScheme
         return input;
     }
 
-    ParsedURL toURL(const Input & input) const override
+    ParsedURL toURL(const Input & input, bool abbreviate) const override
     {
         ParsedURL url{
             .scheme = "flake",

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -94,7 +94,7 @@ struct MercurialInputScheme : InputScheme
         return input;
     }
 
-    ParsedURL toURL(const Input & input) const override
+    ParsedURL toURL(const Input & input, bool abbreviate) const override
     {
         auto url = parseURL(getStrAttr(input.attrs, "url"));
         url.scheme = "hg+" + url.scheme;
@@ -222,9 +222,7 @@ struct MercurialInputScheme : InputScheme
 
         auto revInfoKey = [&](const Hash & rev) {
             if (rev.algo != HashAlgorithm::SHA1)
-                throw Error(
-                    "Hash '%s' is not supported by Mercurial. Only sha1 is supported.",
-                    rev.to_string(HashFormat::Base16, true));
+                throw Error("Hash '%s' is not supported by Mercurial. Only sha1 is supported.", rev.gitRev());
 
             return Cache::Key{"hgRev", {{"store", store->storeDir}, {"name", name}, {"rev", input.getRev()->gitRev()}}};
         };
@@ -333,7 +331,7 @@ struct MercurialInputScheme : InputScheme
         // We just added it, it should be there.
         auto accessor = ref{store->getFSAccessor(storePath)};
 
-        accessor->setPathDisplay("«" + input.to_string() + "»");
+        accessor->setPathDisplay("«" + input.to_string(true) + "»");
 
         return {accessor, input};
     }

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -65,7 +65,7 @@ struct PathInputScheme : InputScheme
         return input;
     }
 
-    ParsedURL toURL(const Input & input) const override
+    ParsedURL toURL(const Input & input, bool abbreviate) const override
     {
         auto query = attrsToQuery(input.attrs);
         query.erase("path");

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -309,7 +309,7 @@ struct CurlInputScheme : InputScheme
         return input;
     }
 
-    ParsedURL toURL(const Input & input) const override
+    ParsedURL toURL(const Input & input, bool abbreviate) const override
     {
         auto url = parseURL(getStrAttr(input.attrs, "url"));
         // NAR hashes are preferred over file hashes since tar/zip
@@ -355,7 +355,7 @@ struct FileInputScheme : CurlInputScheme
 
         auto accessor = ref{store->getFSAccessor(file.storePath)};
 
-        accessor->setPathDisplay("«" + input.to_string() + "»");
+        accessor->setPathDisplay("«" + input.to_string(true) + "»");
 
         return {accessor, input};
     }
@@ -382,7 +382,7 @@ struct TarballInputScheme : CurlInputScheme
         auto input(_input);
 
         auto result =
-            downloadTarball_(*input.settings, getStrAttr(input.attrs, "url"), {}, "«" + input.to_string() + "»");
+            downloadTarball_(*input.settings, getStrAttr(input.attrs, "url"), {}, "«" + input.to_string(true) + "»");
 
         if (result.immutableUrl) {
             auto immutableInput = Input::fromURL(*input.settings, *result.immutableUrl);

--- a/tests/functional/flakes/source-paths.sh
+++ b/tests/functional/flakes/source-paths.sh
@@ -30,10 +30,10 @@ expectStderr 1 nix eval "$repo#y" | grepQuiet "at $repo/flake.nix:"
 
 git -C "$repo" commit -a -m foo
 
-expectStderr 1 nix eval "git+file://$repo?ref=master#y" | grepQuiet "at «git+file://$repo?ref=master&rev=.*»/flake.nix:"
+expectStderr 1 nix eval "git+file://$repo?ref=master#y" | grepQuiet "at «git+file://$repo?rev=.*»/flake.nix:"
 
 expectStderr 1 nix eval "$repo#z" | grepQuiet "error: Path 'foo' does not exist in Git repository \"$repo\"."
-expectStderr 1 nix eval "git+file://$repo?ref=master#z" | grepQuiet "error: '«git+file://$repo?ref=master&rev=.*»/foo' does not exist"
+expectStderr 1 nix eval "git+file://$repo?ref=master#z" | grepQuiet "error: '«git+file://$repo?rev=.*»/foo' does not exist"
 expectStderr 1 nix eval "$repo#a" | grepQuiet "error: Path 'foo' does not exist in Git repository \"$repo\"."
 
 echo 123 > "$repo/foo"


### PR DESCRIPTION


## Motivation

In particular, this gets rid of the `narHash` query parameter and shortens the Git revision in GitHub flakerefs. So instead of

```
   … from call site
     at «github:NixOS/nixpkgs/3bea86e918d8b54aa49780505d2d4cd9261413be?narHash=sha256-Ica%2B%2BSXFuLyxX9Q7YxhfZulUif6/gwM8AEQYlUxqSgE%3D»/lib/customisation.nix:69:16:
       68|     let
       69|       result = f origArgs;
         |                ^
       70|
```

we get

```
   … from call site
     at «github:NixOS/nixpkgs/3bea86e»/lib/customisation.nix:69:16:
       68|     let
       69|       result = f origArgs;
         |                ^
       70|
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inputs now support abbreviated representations in diagnostics and error messages, displaying shortened revision hashes and omitting unnecessary parameters for cleaner, more concise output.

* **Tests**
  * Updated test expectations to reflect the new abbreviated URL display format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->