### PR TITLE
C API: add nix_locked_flake_read_path for flake file reading

### DIFF
--- a/src/libflake-c/nix_api_flake.cc
+++ b/src/libflake-c/nix_api_flake.cc
@@ -206,4 +206,20 @@ nix_value * nix_locked_flake_get_output_attrs(
     NIXC_CATCH_ERRS_NULL
 }
 
+nix_err nix_locked_flake_read_path(
+    nix_c_context * context,
+    nix_locked_flake * lockedFlake,
+    const char * path,
+    nix_get_string_callback callback,
+    void * user_data)
+{
+    nix_clear_err(context);
+    try {
+        auto source_path = lockedFlake->lockedFlake->flake.path.parent() / nix::CanonPath(path);
+        auto v = source_path.readFile();
+        return call_nix_get_string_callback(v, callback, user_data);
+    }
+    NIXC_CATCH_ERRS
+}
+
 } // extern "C"

--- a/src/libflake-c/nix_api_flake.h
+++ b/src/libflake-c/nix_api_flake.h
@@ -238,6 +238,23 @@ void nix_flake_reference_free(nix_flake_reference * store);
 nix_value * nix_locked_flake_get_output_attrs(
     nix_c_context * context, nix_flake_settings * settings, EvalState * evalState, nix_locked_flake * lockedFlake);
 
+/**
+ * @brief Reads a file within the flake.
+ * @note The callback borrows the string only for the duration of the call.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] locked_flake the flake to get the path for
+ * @param[in] path The path within the flake.
+ * @param[in] callback The callback to call with the string
+ * @param[in] user_data Additional data to pass for the callback
+ */
+nix_err nix_locked_flake_read_path(
+    nix_c_context * context,
+    nix_locked_flake * lockedFlake,
+    const char * path,
+    nix_get_string_callback callback,
+    void * user_data);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Need a way to get the path of a Flake when it is not local.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a C API capability to read a file located relative to a locked flake and return its contents via a caller-supplied callback.
  * The returned string is borrowed only for the duration of the callback invocation.
  * This extends flake file-reading support without changing existing API behavior or error-reporting contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->