### PR TITLE
libstore/build: fixup JSON logger missing the resBuildResult result event

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -1321,6 +1321,13 @@ Goal::Done DerivationBuildingGoal::doneSuccess(BuildResult::Success::Status stat
         .builtOutputs = std::move(builtOutputs),
     };
 
+    logger->result(
+        act ? act->id : getCurActivity(),
+        resBuildResult,
+        nlohmann::json(KeyedBuildResult(
+            buildResult,
+            DerivedPath::Built{.drvPath = makeConstantStorePathRef(drvPath), .outputs = OutputsSpec::All{}})));
+
     mcRunningBuilds.reset();
 
     if (status == BuildResult::Success::Built)


### PR DESCRIPTION
This was missed in the merge of 2.32.1.

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build result logging to emit structured telemetry data for both successful and failed build outcomes, enabling improved monitoring and diagnostics visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->