### PR TITLE
Test that `builtOutputs` is present in the JSON log

### DIFF
--- a/tests/functional/logging.sh
+++ b/tests/functional/logging.sh
@@ -40,5 +40,6 @@ if [[ "$NIX_REMOTE" != "daemon" ]]; then
     nix build -vv --file dependencies.nix --no-link --json-log-path "$TEST_ROOT/log.json" 2>&1 | grepQuiet 'building.*dependencies-top.drv'
     jq < "$TEST_ROOT/log.json"
     grep '{"action":"start","fields":\[".*-dependencies-top.drv","",1,1\],"id":.*,"level":3,"parent":0' "$TEST_ROOT/log.json" >&2
+    grep -E '{"action":"result","id":[^,]+,"payload":{"builtOutputs":{"out":{"path":"[^-]+-dependencies-top"' "$TEST_ROOT/log.json" >&2
     (( $(grep -c '{"action":"msg","level":5,"msg":"executing builder .*"}' "$TEST_ROOT/log.json" ) == 5 ))
 fi


### PR DESCRIPTION
## Motivation

ref: https://github.com/DeterminateSystems/nix-src/pull/246

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced log validation to ensure output consistency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->