### PR TITLE
nix flake check: Remove incorrect assertion

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -820,8 +820,6 @@ struct CmdFlakeCheck : FlakeCommand
             // not actually produce the outputs.
             state->waitForAllPaths();
             auto missing = store->queryMissing(drvPaths);
-            // Only occurs if `drvPaths` contains a `DerivedPath::Opaque`, which should never happen
-            assert(missing.unknown.empty());
 
             std::vector<DerivedPath> toBuild;
             for (auto & path : missing.willBuild) {


### PR DESCRIPTION
## Motivation

The assumption that no unknown paths can be returned is incorrect. It can happen if a derivation has outputs that are substitutable, but that have references that cannot be substituted (i.e. an incomplete closure in the binary cache). This can easily happen with magic-nix-cache.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed a runtime validation check to streamline the check process, allowing the application to proceed without this strict enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->