### PR TITLE
C API: make nix_store_get_fs_closure compatible with upstream

### DIFF
--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -256,7 +256,7 @@ nix_err nix_store_get_fs_closure(
     bool include_outputs,
     bool include_derivers,
     void * userdata,
-    void (*callback)(void * userdata, const StorePath * store_path))
+    void (*callback)(nix_c_context * context, void * userdata, const StorePath * store_path))
 {
     if (context)
         context->last_err_code = NIX_OK;
@@ -269,7 +269,9 @@ nix_err nix_store_get_fs_closure(
         if (callback) {
             for (const auto & path : set) {
                 const StorePath tmp{path};
-                callback(userdata, &tmp);
+                callback(context, userdata, &tmp);
+                if (context && context->last_err_code != NIX_OK)
+                    return context->last_err_code;
             }
         }
     }

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -291,7 +291,7 @@ nix_err nix_store_get_fs_closure(
     bool include_outputs,
     bool include_derivers,
     void * userdata,
-    void (*callback)(void * userdata, const StorePath * store_path));
+    void (*callback)(nix_c_context * context, void * userdata, const StorePath * store_path));
 
 /**
  * @brief Returns the derivation associated with the store path


### PR DESCRIPTION
## Motivation

Makes `nix_store_get_fs_closure` compatible with upstream

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Needed for the nixops4 -> nix-bindings-rust migration

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated the callback interface for file system closure operations to include context information, enabling improved error handling and propagation during path iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->