### PR TITLE
nix flake prefetch-inputs: Skip build-time inputs

### DIFF
--- a/src/nix/flake-prefetch-inputs.cc
+++ b/src/nix/flake-prefetch-inputs.cc
@@ -44,6 +44,8 @@ struct CmdFlakePrefetchInputs : FlakeCommand
                 return;
 
             if (auto lockedNode = dynamic_cast<const LockedNode *>(&node)) {
+                if (lockedNode->buildTime)
+                    return;
                 try {
                     Activity act(*logger, lvlInfo, actUnknown, fmt("fetching '%s'", lockedNode->lockedRef));
                     auto accessor = lockedNode->lockedRef.input.getAccessor(store).first;

--- a/src/nix/flake-prefetch-inputs.md
+++ b/src/nix/flake-prefetch-inputs.md
@@ -12,6 +12,6 @@ R""(
 
 Fetch the inputs of a flake. This ensures that they are already available for any subsequent evaluation of the flake.
 
-This operation is recursive: it will fetch not just the direct inputs of the top-level flake, but also transitive inputs.
+This operation is recursive: it fetches not just the direct inputs of the top-level flake, but also transitive inputs. It skips build-time inputs, i.e. inputs that have the attribute `buildTime = true`.
 
 )""


### PR DESCRIPTION
## Motivation

Build-time inputs can already be fetched in parallel, so prefetching them is usually not what you want.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `flake prefetch-inputs` command now skips inputs marked with `buildTime = true`.

* **Documentation**
  * Updated documentation to clarify that `flake prefetch-inputs` recursively fetches transitive inputs and explicitly skips build-time inputs.

* **Tests**
  * Added test coverage to verify build-time inputs are properly skipped during prefetch operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->