### PR TITLE
incident-20251118-nix-flake-registry-is-down use our mirrored registry

### DIFF
--- a/src/libfetchers/include/nix/fetchers/fetch-settings.hh
+++ b/src/libfetchers/include/nix/fetchers/fetch-settings.hh
@@ -115,7 +115,7 @@ struct Settings : public Config
 
     Setting<std::string> flakeRegistry{
         this,
-        "https://install.determinate.systems/flake-registry/stable/registry.json",
+        "https://install.determinate.systems/flake-registry/stable/flake-registry.json",
         "flake-registry",
         R"(
           Path or URI of the global flake registry.

--- a/tests/nixos/github-flakes.nix
+++ b/tests/nixos/github-flakes.nix
@@ -17,7 +17,7 @@ let
 
     openssl req -newkey rsa:2048 -nodes -keyout $out/server.key \
       -subj "/C=CN/ST=Denial/L=Springfield/O=Dis/CN=github.com" -out server.csr
-    openssl x509 -req -extfile <(printf "subjectAltName=DNS:api.github.com,DNS:github.com,DNS:channels.nixos.org") \
+    openssl x509 -req -extfile <(printf "subjectAltName=DNS:api.github.com,DNS:github.com,DNS:channels.nixos.org,DNS:install.determinate.systems") \
       -days 36500 -in server.csr -CA $out/ca.crt -CAkey ca.key -CAcreateserial -out $out/server.crt
   '';
 
@@ -107,13 +107,13 @@ in
         services.httpd.extraConfig = ''
           ErrorLog syslog:local6
         '';
-        services.httpd.virtualHosts."channels.nixos.org" = {
+        services.httpd.virtualHosts."install.determinate.systems" = {
           forceSSL = true;
           sslServerKey = "${cert}/server.key";
           sslServerCert = "${cert}/server.crt";
           servedDirs = [
             {
-              urlPath = "/";
+              urlPath = "/flake-registry/stable/";
               dir = registry;
             }
           ];
@@ -165,6 +165,7 @@ in
         nix.settings.substituters = lib.mkForce [ ];
         networking.hosts.${(builtins.head nodes.github.networking.interfaces.eth1.ipv4.addresses).address} =
           [
+            "install.determinate.systems"
             "channels.nixos.org"
             "api.github.com"
             "github.com"


### PR DESCRIPTION
## Motivation

ref: https://status.determinate.systems/incidents/9d0f78af-1550-49cf-8a2e-c4d2b37b1eb0

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default flake registry URL to a new install.determinate.systems endpoint.
* **Tests**
  * Test environment updated to recognize the new host: certificate SAN, virtual host and served registry path (/flake-registry/stable/), and networking host entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->