### PR TITLE
feat: support consumers of docker.nix supplying their own base image

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -8,6 +8,7 @@
   # Image configuration
   name ? "nix",
   tag ? "latest",
+  fromImage ? null,
   bundleNixpkgs ? true,
   channelName ? "nixpkgs",
   channelURL ? "https://nixos.org/channels/nixpkgs-unstable",
@@ -352,6 +353,7 @@ dockerTools.buildLayeredImageWithNixDb {
     gid
     uname
     gname
+    fromImage
     ;
 
   contents = [ baseSystem ];


### PR DESCRIPTION
This PR allows for consumers to specify their base image to use with `docker.nix`. We're currently relying on
```nix
  detSysNixBaseImage.override (_: {
    fromImage = builtins.elemAt ourLayers ((builtins.length ourLayers) - 1);
  })
```
which is fine. But, internally at our organization, we've used this PR's change set to (apparently) preclude the need for such an `override`. And, I guess our current `.override` approach may not be future-proof considering how `fromImage` may be used by `buildLayeredImageWithNixDb` or by `streamLayeredImage` or whatever in the future (I'm thinking about cases like that common problems where overriding `version` doesn't propagate to a `src` which relies on `version`).

There may be reasons that that concern is irrelevant/pathological, though, so I'm not strongly opinionated that this PR be merged. I'm just submitting this diff so that Determinate Systems might consider it and hopefully at least provide some feedback on its value.

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to specify a custom base image for Docker image builds. The option is optional with a default value.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->