### PR TITLE
BinaryCacheStore: Allow using NARs from the local NAR cache

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -13,6 +13,7 @@
 #include "nix/util/callback.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/archive.hh"
+#include "nix/store/nar-cache.hh"
 
 #include <chrono>
 #include <future>
@@ -26,6 +27,7 @@ namespace nix {
 
 BinaryCacheStore::BinaryCacheStore(Config & config)
     : config{config}
+    , narCache{config.localNarCache.get() ? std::make_shared<NarCache>(*config.localNarCache.get()) : nullptr}
 {
     if (config.secretKeyFile != "")
         signers.push_back(std::make_unique<LocalSigner>(SecretKey{readFile(config.secretKeyFile)}));
@@ -552,7 +554,7 @@ void BinaryCacheStore::registerDrvOutput(const Realisation & info)
 
 ref<RemoteFSAccessor> BinaryCacheStore::getRemoteFSAccessor(bool requireValidPath)
 {
-    return make_ref<RemoteFSAccessor>(ref<Store>(shared_from_this()), requireValidPath, config.localNarCache);
+    return make_ref<RemoteFSAccessor>(ref<Store>(shared_from_this()), requireValidPath, narCache);
 }
 
 ref<SourceAccessor> BinaryCacheStore::getFSAccessor(bool requireValidPath)

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -12,6 +12,7 @@
 namespace nix {
 
 struct NarInfo;
+class NarCache;
 class RemoteFSAccessor;
 
 struct BinaryCacheStoreConfig : virtual StoreConfig
@@ -88,6 +89,8 @@ protected:
     constexpr const static std::string realisationsPrefix = "realisations";
 
     constexpr const static std::string cacheInfoFile = "nix-cache-info";
+
+    std::shared_ptr<NarCache> narCache;
 
     BinaryCacheStore(Config &);
 

--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -38,9 +38,9 @@ struct BinaryCacheStoreConfig : virtual StoreConfig
     const Setting<std::string> secretKeyFiles{
         this, "", "secret-keys", "List of comma-separated paths to the secret keys used to sign the binary cache."};
 
-    const Setting<Path> localNarCache{
+    const Setting<std::optional<std::filesystem::path>> localNarCache{
         this,
-        "",
+        std::nullopt,
         "local-nar-cache",
         "Path to a local cache of NARs fetched from this binary cache, used by commands such as `nix store cat`."};
 

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -57,6 +57,7 @@ headers = [ config_pub_h ] + files(
   'machines.hh',
   'make-content-addressed.hh',
   'names.hh',
+  'nar-cache.hh',
   'nar-info-disk-cache.hh',
   'nar-info.hh',
   'outputs-spec.hh',

--- a/src/libstore/include/nix/store/nar-cache.hh
+++ b/src/libstore/include/nix/store/nar-cache.hh
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "nix/util/hash.hh"
+#include "nix/util/nar-accessor.hh"
+
+#include <filesystem>
+
+namespace nix {
+
+class NarCache
+{
+
+    const std::filesystem::path cacheDir;
+
+    std::filesystem::path makeCacheFile(const Hash & narHash, const std::string & ext);
+
+public:
+
+    NarCache(std::filesystem::path cacheDir);
+
+    void upsertNar(const Hash & narHash, Source & source);
+
+    void upsertNarListing(const Hash & narHash, std::string_view narListingData);
+
+    // FIXME: use a sink.
+    std::optional<std::string> getNar(const Hash & narHash);
+
+    // FIXME: use a sink.
+    GetNarBytes getNarBytes(const Hash & narHash);
+
+    std::optional<std::string> getNarListing(const Hash & narHash);
+};
+
+} // namespace nix

--- a/src/libstore/include/nix/store/remote-fs-accessor.hh
+++ b/src/libstore/include/nix/store/remote-fs-accessor.hh
@@ -15,13 +15,13 @@ class RemoteFSAccessor : public SourceAccessor
 
     bool requireValidPath;
 
-    Path cacheDir;
+    std::optional<std::filesystem::path> cacheDir;
 
     std::pair<ref<SourceAccessor>, CanonPath> fetch(const CanonPath & path);
 
     friend struct BinaryCacheStore;
 
-    Path makeCacheFile(std::string_view hashPart, const std::string & ext);
+    std::filesystem::path makeCacheFile(std::string_view hashPart, const std::string & ext);
 
     ref<SourceAccessor> addToCache(std::string_view hashPart, std::string && nar);
 
@@ -33,7 +33,7 @@ public:
     std::shared_ptr<SourceAccessor> accessObject(const StorePath & path);
 
     RemoteFSAccessor(
-        ref<Store> store, bool requireValidPath = true, const /* FIXME: use std::optional */ Path & cacheDir = "");
+        ref<Store> store, bool requireValidPath = true, std::optional<std::filesystem::path> cacheDir = {});
 
     std::optional<Stat> maybeLstat(const CanonPath & path) override;
 

--- a/src/libstore/include/nix/store/remote-fs-accessor.hh
+++ b/src/libstore/include/nix/store/remote-fs-accessor.hh
@@ -7,6 +7,8 @@
 
 namespace nix {
 
+struct NarCache;
+
 class RemoteFSAccessor : public SourceAccessor
 {
     ref<Store> store;
@@ -15,19 +17,11 @@ class RemoteFSAccessor : public SourceAccessor
 
     bool requireValidPath;
 
-    std::optional<std::filesystem::path> cacheDir;
+    std::shared_ptr<NarCache> narCache;
 
     std::pair<ref<SourceAccessor>, CanonPath> fetch(const CanonPath & path);
 
     friend struct BinaryCacheStore;
-
-    std::filesystem::path makeCacheFile(const Hash & narHash, const std::string & ext);
-
-    ref<SourceAccessor> addToCache(
-        std::string_view hashPart,
-        const std::filesystem::path & cacheFile,
-        const std::filesystem::path & listingFile,
-        std::string && nar);
 
 public:
 
@@ -36,8 +30,7 @@ public:
      */
     std::shared_ptr<SourceAccessor> accessObject(const StorePath & path);
 
-    RemoteFSAccessor(
-        ref<Store> store, bool requireValidPath = true, std::optional<std::filesystem::path> cacheDir = {});
+    RemoteFSAccessor(ref<Store> store, bool requireValidPath = true, std::shared_ptr<NarCache> narCache = {});
 
     std::optional<Stat> maybeLstat(const CanonPath & path) override;
 

--- a/src/libstore/include/nix/store/remote-fs-accessor.hh
+++ b/src/libstore/include/nix/store/remote-fs-accessor.hh
@@ -21,9 +21,13 @@ class RemoteFSAccessor : public SourceAccessor
 
     friend struct BinaryCacheStore;
 
-    std::filesystem::path makeCacheFile(std::string_view hashPart, const std::string & ext);
+    std::filesystem::path makeCacheFile(const Hash & narHash, const std::string & ext);
 
-    ref<SourceAccessor> addToCache(std::string_view hashPart, std::string && nar);
+    ref<SourceAccessor> addToCache(
+        std::string_view hashPart,
+        const std::filesystem::path & cacheFile,
+        const std::filesystem::path & listingFile,
+        std::string && nar);
 
 public:
 

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -319,6 +319,7 @@ sources = files(
   'make-content-addressed.cc',
   'misc.cc',
   'names.cc',
+  'nar-cache.cc',
   'nar-info-disk-cache.cc',
   'nar-info.cc',
   'optimise-store.cc',

--- a/src/libstore/nar-cache.cc
+++ b/src/libstore/nar-cache.cc
@@ -1,0 +1,64 @@
+#include "nix/store/nar-cache.hh"
+#include "nix/util/file-system.hh"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+namespace nix {
+
+NarCache::NarCache(std::filesystem::path cacheDir_)
+    : cacheDir(std::move(cacheDir_))
+{
+    assert(!cacheDir.empty());
+    createDirs(cacheDir);
+}
+
+std::filesystem::path NarCache::makeCacheFile(const Hash & narHash, const std::string & ext)
+{
+    return (cacheDir / narHash.to_string(HashFormat::Nix32, false)) + "." + ext;
+}
+
+void NarCache::upsertNar(const Hash & narHash, Source & source)
+{
+    try {
+        /* FIXME: do this asynchronously. */
+        writeFile(makeCacheFile(narHash, "nar"), source);
+    } catch (SystemError &) {
+        ignoreExceptionExceptInterrupt();
+    }
+}
+
+void NarCache::upsertNarListing(const Hash & narHash, std::string_view narListingData)
+{
+    try {
+        writeFile(makeCacheFile(narHash, "ls"), narListingData);
+    } catch (SystemError &) {
+        ignoreExceptionExceptInterrupt();
+    }
+}
+
+std::optional<std::string> NarCache::getNar(const Hash & narHash)
+{
+    try {
+        return nix::readFile(makeCacheFile(narHash, "nar"));
+    } catch (SystemError &) {
+        return std::nullopt;
+    }
+}
+
+GetNarBytes NarCache::getNarBytes(const Hash & narHash)
+{
+    return seekableGetNarBytes(makeCacheFile(narHash, "nar"));
+}
+
+std::optional<std::string> NarCache::getNarListing(const Hash & narHash)
+{
+    try {
+        return nix::readFile(makeCacheFile(narHash, "ls"));
+    } catch (SystemError &) {
+        return std::nullopt;
+    }
+}
+
+} // namespace nix

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -233,11 +233,21 @@ mkdir "$narCache"
 
 [[ $(nix store cat --store "file://$cacheDir?local-nar-cache=$narCache" "$outPath/foobar") = FOOBAR ]]
 
-rm -rfv "$cacheDir/nar"
+mv "$cacheDir/nar" "$cacheDir/nar2"
 
 [[ $(nix store cat --store "file://$cacheDir?local-nar-cache=$narCache" "$outPath/foobar") = FOOBAR ]]
 
 (! nix store cat --store "file://$cacheDir" "$outPath/foobar")
+
+
+# Check substitution from the local NAR cache.
+clearStore
+rm -rf "$narCache" "$cacheDir/nar"
+mv "$cacheDir/nar2" "$cacheDir/nar"
+nix-store -r --substituters "file://$cacheDir?local-nar-cache=$narCache" --no-require-sigs "$outPath"
+mv "$cacheDir/nar" "$cacheDir/nar2"
+clearStore
+nix-store -r --substituters "file://$cacheDir?local-nar-cache=$narCache" --no-require-sigs "$outPath"
 
 
 # Test NAR listing generation.


### PR DESCRIPTION
## Motivation

Speed up substitution in CI by having a local NAR cache shared between CI runs.

Note: this changes the local NAR cache to be content-addressed (previously it was addressed by store path).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
