### PR TITLE
feat: support user-provided paths to land in $PATH

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -27,6 +27,8 @@
     "org.opencontainers.image.description" = "Nix container image";
   },
   Cmd ? [ (lib.getExe bashInteractive) ],
+  extraPrePaths ? [ ],
+  extraPostPaths ? [ ],
   # Default Packages
   nix ? pkgs.nix,
   bashInteractive ? pkgs.bashInteractive,
@@ -373,11 +375,15 @@ dockerTools.buildLayeredImageWithNixDb {
     Env = [
       "USER=${uname}"
       "PATH=${
-        lib.concatStringsSep ":" [
-          "${userHome}/.nix-profile/bin"
-          "/nix/var/nix/profiles/default/bin"
-          "/nix/var/nix/profiles/default/sbin"
-        ]
+        lib.concatStringsSep ":" (
+          extraPrePaths
+          ++ [
+            "${userHome}/.nix-profile/bin"
+            "/nix/var/nix/profiles/default/bin"
+            "/nix/var/nix/profiles/default/sbin"
+          ]
+          ++ extraPostPaths
+        )
       }"
       "MANPATH=${
         lib.concatStringsSep ":" [


### PR DESCRIPTION
## Motivation

We ran into an issue in production where `/bin` needed to be added to `$PATH`. We're hacking around this, now, with a setup step which modifies `$PATH` but ideally we could cook this into our container image. We don't care if it's before/after since there are no collisions between things in our `/bin` and things in the other paths in `$PATH`. But, this PR introduces the ability to add paths with higher/lower priority than what would be the default if there's a collision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizable PATH environment variable configuration. Users can now prepend and append custom paths to the default PATH setup in their Docker environment through new optional configuration parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->