### PR TITLE
packaging: fix build with lowdown 2.0.4

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -54,7 +54,7 @@ scope: {
     nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [ pkgs.buildPackages.bmake ];
     postInstall =
       lib.replaceStrings [ "lowdown.so.1" "lowdown.1.dylib" ] [ "lowdown.so.2" "lowdown.2.dylib" ]
-        prevAttrs.postInstall;
+        (prevAttrs.postInstall or "");
   });
 
   # TODO: Remove this when https://github.com/NixOS/nixpkgs/pull/442682 is included in a stable release


### PR DESCRIPTION
After update to lowdown `2.0.4` in https://github.com/NixOS/nixpkgs/pull/462187 it no longer has any `postInstall` defined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system stability with enhanced handling of package installation configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->