### PR TITLE
determinePos(): Don't read from app values

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -173,8 +173,11 @@ PosIdx Value::determinePos(const PosIdx pos) const
         return attrs()->pos;
     case tLambda:
         return lambda().fun->pos;
+#if 0
+    // FIXME: disabled because reading from an app is racy.
     case tApp:
         return app().left->determinePos(pos);
+#endif
     default:
         return pos;
     }


### PR DESCRIPTION
## Motivation

App values can be overwritten by another thread while we're reading them, so this is unsafe.

Fixes https://github.com/DeterminateSystems/nix-src/issues/256.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified internal position handling for function applications to address potential race conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->