### PR TITLE
Build against Determinate Secure Packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
-      - run: nix flake check ${{ inputs.flake }} -L --system ${{ inputs.system }}
+      - run: nix flake check --keep-going ${{ inputs.flake }} -L --system ${{ inputs.system }}
 
   vm_tests_smoke:
     if: inputs.run_vm_tests && github.event_name != 'merge_group'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      flake:
+        required: false
+        default: "./packaging/secure-packages"
+        type: string
       system:
         required: true
         type: string
@@ -33,6 +37,10 @@ on:
         required: false
         default: false
         type: boolean
+      upload_artifacts:
+        required: false
+        default: true
+        type: boolean
     secrets:
       manual_netlify_auth_token:
         required: false
@@ -56,9 +64,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
-      - run: nix build .#packages.${{ inputs.system }}.default .#packages.${{ inputs.system }}.binaryTarball --no-link -L
-      - run: nix build .#packages.${{ inputs.system }}.binaryTarball --out-link tarball
-      - run: nix build .#^debug,out
+      - run: nix build ${{ inputs.flake }}#packages.${{ inputs.system }}.default .#packages.${{ inputs.system }}.binaryTarball --no-link -L
+      - run: nix build ${{ inputs.flake }}#packages.${{ inputs.system }}.binaryTarball --out-link tarball
+      - run: nix build ${{ inputs.flake }}#^debug,out
       - name: Upload debug info to Sentry
         run: ./maintainers/upload-debug-info-to-sentry.py --debug-dir ./result-debug ./result/bin/nix
         if: env.SENTRY_AUTH_TOKEN != ''
@@ -67,6 +75,7 @@ jobs:
           SENTRY_ORG: ${{ secrets.sentry_org }}
           SENTRY_PROJECT: ${{ secrets.sentry_project }}
       - uses: actions/upload-artifact@v6
+        if: inputs.upload_artifacts
         with:
           name: ${{ inputs.system }}
           path: ./tarball/*.xz
@@ -81,7 +90,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
-      - run: nix build .#packages.${{ inputs.system }}.nix-cli-static --no-link -L
+      - run: nix build ${{ inputs.flake }}#packages.${{ inputs.system }}.nix-cli-static --no-link -L
 
   test:
     if: ${{ inputs.if && inputs.run_tests}}
@@ -94,7 +103,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
-      - run: nix flake check -L --system ${{ inputs.system }}
+      - run: nix flake check ${{ inputs.flake }} -L --system ${{ inputs.system }}
 
   vm_tests_smoke:
     if: inputs.run_vm_tests && github.event_name != 'merge_group'
@@ -106,10 +115,10 @@ jobs:
       - uses: DeterminateSystems/flakehub-cache-action@main
       - run: |
           nix build -L \
-            .#hydraJobs.tests.functional_user \
-            .#hydraJobs.tests.githubFlakes \
-            .#hydraJobs.tests.nix-docker \
-            .#hydraJobs.tests.tarballFlakes \
+            ${{ inputs.flake }}#hydraJobs.tests.functional_user \
+            ${{ inputs.flake }}#hydraJobs.tests.githubFlakes \
+            ${{ inputs.flake }}#hydraJobs.tests.nix-docker \
+            ${{ inputs.flake }}#hydraJobs.tests.tarballFlakes \
             ;
 
   vm_tests_all:
@@ -128,7 +137,7 @@ jobs:
                   .hydraJobs.tests
                   | with_entries(select(.value.type == "derivation"))
                   | keys[]
-                  | ".#hydraJobs.tests." + .')
+                  | "${{ inputs.flake }}#hydraJobs.tests." + .')
           }
 
           if ! cmd; then
@@ -203,7 +212,7 @@ jobs:
             mkdir -p "${NSC_CACHE_PATH}/nix/xdg-cache"
             export XDG_CACHE_HOME="${NSC_CACHE_PATH}/nix/xdg-cache"
           fi
-          nix build -L --out-link ./new-nix
+          nix build ${{ inputs.flake }} -L --out-link ./new-nix
           export PATH=$(pwd)/new-nix/bin:$PATH
           [[ $(type -p nix) = $(pwd)/new-nix/bin/nix ]]
 
@@ -235,7 +244,7 @@ jobs:
       - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Build manual
         if: inputs.system == 'x86_64-linux'
-        run: nix build .#hydraJobs.manual
+        run: nix build ${{ inputs.flake }}#hydraJobs.manual
       - uses: nwtgck/actions-netlify@v3.0
         if: inputs.publish_manual && inputs.system == 'x86_64-linux'
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/determinate-nix-action@main
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/determinate-nix-action@main
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/determinate-nix-action@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,20 @@ jobs:
       sentry_org: ${{ secrets.SENTRY_ORG }}
       sentry_project: ${{ secrets.SENTRY_PROJECT }}
 
+  build_x86_64-linux_no_dsp:
+    uses: ./.github/workflows/build.yml
+    if: github.event_name == 'merge_group'
+    with:
+      flake: .
+      system: x86_64-linux
+      runner: namespace-profile-linuxamd32c64g-cache
+      runner_for_virt: UbuntuLatest32Cores128G
+      runner_small: ubuntu-latest
+      run_tests: true
+      run_vm_tests: true
+      run_regression_tests: true
+      upload_artifacts: false
+
   build_aarch64-linux:
     uses: ./.github/workflows/build.yml
     with:
@@ -131,7 +145,7 @@ jobs:
               )
             }}
         run: |
-          nix build .#fallbackPathsNix --out-link fallback
+          nix build ./packaging/secure-packages#fallbackPathsNix --out-link fallback
           cat fallback > ./artifacts/fallback-paths.nix
 
       - uses: DeterminateSystems/push-artifact-ids@main

--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -16,6 +16,16 @@
 
       # https://flake.parts/options/git-hooks-nix#options
       pre-commit.settings = {
+        # `self.outPath` from git-hooks-nix's flake-module is not path-normalized,
+        # so when this flake is evaluated via `packaging/secure-packages` (whose
+        # `inputs.nix.url = "../.."`), it expands to `.../source/packaging/secure-packages/../..`,
+        # which breaks the stdenv unpackPhase. Use a clean relative path instead.
+        rootSrc = lib.mkForce (
+          builtins.path {
+            name = "source";
+            path = ../.;
+          }
+        );
         hooks = {
           # Conflicts are usually found by other checks, but not those in docs,
           # and potentially other places.

--- a/packaging/secure-packages/flake.lock
+++ b/packaging/secure-packages/flake.lock
@@ -80,16 +80,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779115762,
-        "narHash": "sha256-Hp/+fmW3u/uG9PeJLuAur8TheOyGTVPLY2q2AkcDTH8=",
-        "rev": "47836af8a912ea891bd3d9ec378ff0e1375fb145",
-        "revCount": 990585,
+        "lastModified": 1779826571,
+        "narHash": "sha256-TdGToOjjyE4OU6J1L7PvNJnBfGZmmyzxXrhrkV1wg9o=",
+        "rev": "6ed3313ea30b8946fba1a378b59d3d5361b90e51",
+        "revCount": 912491,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/secure-packages-rolling/0.1.990585%2Brev-47836af8a912ea891bd3d9ec378ff0e1375fb145/019e3b9c-d32f-74f2-8f0a-18950b3c25cc/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/secure-packages-25.11/0.1.912491%2Brev-6ed3313ea30b8946fba1a378b59d3d5361b90e51/019e6658-99c1-7e32-9759-0f024f615a2c/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/secure-packages-rolling/0"
+        "url": "https://flakehub.com/f/DeterminateSystems/secure-packages-25.11/0"
       }
     },
     "nixpkgs-23-11": {

--- a/packaging/secure-packages/flake.lock
+++ b/packaging/secure-packages/flake.lock
@@ -1,0 +1,135 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1748821116,
+        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
+        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
+        "revCount": 377,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/hercules-ci/flake-parts/0.1.377%2Brev-49f0870db23e8c1ca0b5259734a02cd9e1e371a1/01972f28-554a-73f8-91f4-d488cc502f08/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/hercules-ci/flake-parts/0.1"
+      }
+    },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": [
+          "nix"
+        ],
+        "nixpkgs": [
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1747372754,
+        "narHash": "sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo+bnXU9D9k=",
+        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
+        "revCount": 1026,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/cachix/git-hooks.nix/0.1.1026%2Brev-80479b6ec16fefd9c1db3ea13aeb038c60530f46/0196d79a-1b35-7b8e-a021-c894fb62163d/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/cachix/git-hooks.nix/0.1.941"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-23-11": "nixpkgs-23-11",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "path": "../..",
+        "type": "path"
+      },
+      "original": {
+        "path": "../..",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779115762,
+        "narHash": "sha256-Hp/+fmW3u/uG9PeJLuAur8TheOyGTVPLY2q2AkcDTH8=",
+        "rev": "47836af8a912ea891bd3d9ec378ff0e1375fb145",
+        "revCount": 990585,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/secure-packages-rolling/0.1.990585%2Brev-47836af8a912ea891bd3d9ec378ff0e1375fb145/019e3b9c-d32f-74f2-8f0a-18950b3c25cc/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/DeterminateSystems/secure-packages-rolling/0"
+      }
+    },
+    "nixpkgs-23-11": {
+      "locked": {
+        "lastModified": 1717159533,
+        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix": "nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/packaging/secure-packages/flake.nix
+++ b/packaging/secure-packages/flake.nix
@@ -2,5 +2,5 @@
   inputs.nix.url = "../..";
   inputs.nix.inputs.nixpkgs.url = "https://flakehub.com/f/DeterminateSystems/secure-packages-25.11/0";
 
-  outputs = { self, nix }: nix;
+  outputs = { self, nix }: nix.outputs;
 }

--- a/packaging/secure-packages/flake.nix
+++ b/packaging/secure-packages/flake.nix
@@ -1,7 +1,6 @@
 {
   inputs.nix.url = "../..";
-  inputs.nix.inputs.nixpkgs.url =
-    "https://flakehub.com/f/DeterminateSystems/secure-packages-rolling/0";
+  inputs.nix.inputs.nixpkgs.url = "https://flakehub.com/f/DeterminateSystems/secure-packages-25.11/0";
 
   outputs = { self, nix }: nix;
 }

--- a/packaging/secure-packages/flake.nix
+++ b/packaging/secure-packages/flake.nix
@@ -1,0 +1,7 @@
+{
+  inputs.nix.url = "../..";
+  inputs.nix.inputs.nixpkgs.url =
+    "https://flakehub.com/f/DeterminateSystems/secure-packages-rolling/0";
+
+  outputs = { self, nix }: nix;
+}

--- a/tests/functional/json.sh
+++ b/tests/functional/json.sh
@@ -51,7 +51,7 @@ if type script &>/dev/null; then
     if [[ $acceptsCommandFlag -eq 0 ]]; then
       script -e -q /dev/null "$@"
     else
-      script -e -q /dev/null -c "$(shellEscapeArray "$@")"
+      script -e -q -c "$(shellEscapeArray "$@")" /dev/null
     fi
   }
   runScript nix eval --json --expr "{ a.b.c = true; }" > "$TEST_HOME/actual.json"


### PR DESCRIPTION
## Motivation

The top-level flake still builds against upstream Nixpkgs. But `packaging/secure-packages/flake.nix` overrides that to use DSP.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Flexible build workflow: configurable flake target and optional artifact upload gating
  * New conditional build job for extra x86_64 verification that reuses the build workflow and skips publishing artifacts
  * Added packaging flake to support the configurable flake target

* **Tests**
  * Adjusted test helper invocation for broader compatibility across environments

* **Documentation**
  * Corrected anchors, excluded additional broken fragments, and updated daemon reference links

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->