### PR TITLE
CI: Fail if store paths are in the source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,18 @@ jobs:
       - uses: DeterminateSystems/determinate-nix-action@main
       - run: nix flake show --all-systems --json
 
+  no-store-paths-in-source:
+    runs-on: UbuntuLatest32Cores128G
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          grep  -r '/nix/store/[0123456789abcdfghijklmnpqrsvwxyz]\{32\}-' . || exit 0
+          echo "Please do not put valid store paths in the documentation or source code."
+          echo "This can cause fetching the artifact as a fixed-output derivation to fail if the store path is present in the fetching closure"
+          exit 1
+
   build_x86_64-linux:
     uses: ./.github/workflows/build.yml
     with:
@@ -78,6 +90,7 @@ jobs:
       - build_x86_64-linux
       - build_aarch64-linux
       - build_aarch64-darwin
+      - no-store-paths-in-source
     if: ${{ always() }}
     steps:
       - run: "true"


### PR DESCRIPTION
## Motivation

A customer noted that the tarball for Determinate Nix 3.15 cannot be fetched because the documentation contains "live" store path references in the documentation:

```
src/nix/ps.md
11:  nixbld11  3534394    0.8s  └───bash -e /nix/store/vj1c3wf9c11a0qs6p3ymfvrnsdgsdcbq-source-stdenv.sh /nix/store/shkw4qm9qcw5sc5n1k5jznc83ny02

doc/manual/source/release-notes-determinate/v3.14.0.md
13:_nixbld1  30167  0.2s  └───bash -e /nix/store/vj1c3wf9c11a0qs6p3ymfvrnsdgsdcbq-source-stdenv.sh /nix/store/shkw4qm9qcw5sc5n1k5jznc83ny02r39-default-builder.s
```

which causes fixed output fetchers to fail.

I propose we remediate this by replacing one character in these examples with an impossible character, like "o".

---

Ideally, this PR fails CI immediately.