### PR TITLE
libexpr-c: fix changing eval settings having no effect

### DIFF
--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -19,9 +19,8 @@
 
 namespace nix {
 
-EvalSettings evalSettings{
-    settings.readOnlyMode,
-    {
+static GlobalConfig::Register rEvalSettings(&evalSettings, [] {
+    evalSettings.lookupPathHooks = {
         {
             "flake",
             [](EvalState & state, std::string_view rest) {
@@ -40,10 +39,8 @@ EvalSettings evalSettings{
                 return state.storePath(storePath);
             },
         },
-    },
-};
-
-static GlobalConfig::Register rEvalSettings(&evalSettings);
+    };
+});
 
 flake::Settings flakeSettings;
 

--- a/src/libexpr-c/nix_api_expr.cc
+++ b/src/libexpr-c/nix_api_expr.cc
@@ -6,6 +6,7 @@
 #include "nix/expr/eval-gc.hh"
 #include "nix/store/globals.hh"
 #include "nix/expr/eval-settings.hh"
+#include "nix/fetchers/fetch-settings.hh"
 #include "nix/util/ref.hh"
 
 #include "nix_api_expr.h"
@@ -137,8 +138,8 @@ nix_eval_state_builder * nix_eval_state_builder_new(nix_c_context * context, Sto
         return unsafe_new_with_self<nix_eval_state_builder>([&](auto * self) {
             return nix_eval_state_builder{
                 .store = nix::ref<nix::Store>(store->ptr),
-                .settings = nix::EvalSettings{/* &bool */ self->readOnlyMode},
-                .fetchSettings = nix::fetchers::Settings{},
+                .settings = &nix::evalSettings,
+                .fetchSettings = &nix::fetchSettings,
                 .readOnlyMode = true,
             };
         });
@@ -159,9 +160,9 @@ nix_err nix_eval_state_builder_load(nix_c_context * context, nix_eval_state_buil
         context->last_err_code = NIX_OK;
     try {
         // TODO: load in one go?
-        builder->settings.readOnlyMode = nix::settings.readOnlyMode;
-        loadConfFile(builder->settings);
-        loadConfFile(builder->fetchSettings);
+        builder->settings->readOnlyMode = nix::settings.readOnlyMode;
+        loadConfFile(*builder->settings);
+        loadConfFile(*builder->fetchSettings);
     }
     NIXC_CATCH_ERRS
 }
@@ -188,9 +189,9 @@ EvalState * nix_eval_state_build(nix_c_context * context, nix_eval_state_builder
     try {
         return unsafe_new_with_self<EvalState>([&](auto * self) {
             return EvalState{
-                .fetchSettings = std::move(builder->fetchSettings),
-                .settings = std::move(builder->settings),
-                .state = nix::EvalState(builder->lookupPath, builder->store, self->fetchSettings, self->settings),
+                .fetchSettings = builder->fetchSettings,
+                .settings = builder->settings,
+                .state = nix::EvalState(builder->lookupPath, builder->store, *self->fetchSettings, *self->settings),
             };
         });
     }

--- a/src/libexpr-c/nix_api_expr_internal.h
+++ b/src/libexpr-c/nix_api_expr_internal.h
@@ -13,8 +13,8 @@ extern "C" {
 struct nix_eval_state_builder
 {
     nix::ref<nix::Store> store;
-    nix::EvalSettings settings;
-    nix::fetchers::Settings fetchSettings;
+    nix::EvalSettings * settings;
+    nix::fetchers::Settings * fetchSettings;
     nix::LookupPath lookupPath;
     // TODO: make an EvalSettings setting own this instead?
     bool readOnlyMode;
@@ -22,8 +22,8 @@ struct nix_eval_state_builder
 
 struct EvalState
 {
-    nix::fetchers::Settings fetchSettings;
-    nix::EvalSettings settings;
+    nix::fetchers::Settings * fetchSettings;
+    nix::EvalSettings * settings;
     nix::EvalState state;
 };
 

--- a/src/libexpr/eval-settings.cc
+++ b/src/libexpr/eval-settings.cc
@@ -1,4 +1,5 @@
 #include "nix/util/users.hh"
+#include "nix/util/config-global.hh"
 #include "nix/store/globals.hh"
 #include "nix/store/profiles.hh"
 #include "nix/expr/eval.hh"
@@ -117,5 +118,9 @@ std::filesystem::path getNixDefExpr()
 {
     return settings.useXDGBaseDirectories ? getStateDir() / "defexpr" : getHome() / ".nix-defexpr";
 }
+
+EvalSettings evalSettings{settings.readOnlyMode};
+
+static GlobalConfig::Register rEvalSettings(&evalSettings);
 
 } // namespace nix

--- a/src/libexpr/include/nix/expr/eval-settings.hh
+++ b/src/libexpr/include/nix/expr/eval-settings.hh
@@ -412,4 +412,9 @@ std::filesystem::path getNixDefExpr();
  */
 constexpr size_t evalStackSize = 60 * 1024 * 1024;
 
+/**
+ * EvalSettings instance from libexpr.
+ */
+extern EvalSettings evalSettings;
+
 } // namespace nix

--- a/src/libflake-c/nix_api_flake.cc
+++ b/src/libflake-c/nix_api_flake.cc
@@ -32,7 +32,7 @@ nix_err nix_flake_settings_add_to_eval_state_builder(
 {
     nix_clear_err(context);
     try {
-        settings->settings->configureEvalSettings(builder->settings);
+        settings->settings->configureEvalSettings(*builder->settings);
     }
     NIXC_CATCH_ERRS
 }

--- a/src/libutil/config-global.cc
+++ b/src/libutil/config-global.cc
@@ -61,7 +61,16 @@ GlobalConfig globalConfig;
 
 GlobalConfig::Register::Register(Config * config)
 {
-    configRegistrations().emplace_back(config);
+    auto regs = configRegistrations();
+    if (std::find(regs.begin(), regs.end(), config) == regs.end()) {
+        configRegistrations().emplace_back(config);
+    }
+}
+
+GlobalConfig::Register::Register(Config * config, std::function<void()> && callback)
+    : Register(config)
+{
+    callback();
 }
 
 ExperimentalFeatureSettings experimentalFeatureSettings;

--- a/src/libutil/include/nix/util/config-global.hh
+++ b/src/libutil/include/nix/util/config-global.hh
@@ -26,6 +26,7 @@ struct GlobalConfig : public AbstractConfig
     struct Register
     {
         Register(Config * config);
+        Register(Config * config, std::function<void()> && callback);
     };
 };
 


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Using the Rust bindings (which call into the C bindings) to set eval-related settings was not working.

Since EvalSettings were defined in libcmd, we need to move them to libexpr if libexpr-c wants to use them. Since libcmd enforces a dependency on libflake, we also need to modify config-global to absorb duplicate registrations and support callbacks for customizing behavior that we only need in libcmd.

Note that we add back some of the global setting variables with this, but this does fix the C API.


## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Implementation strategy, since this was slightly nontrivial:

- Move registration for eval (and fetcher settings, which had the same issue but was easier to solve) to libexpr and libfetchers.
- Absorb duplicate config registrations in config-global.cc.
- Add a new GlobalConfig registration constructor allowing the caller to pass a callback; use this to break the hard libflake dependency.
- Use pointers to the global eval and fetcher config in libexpr-c instead of creating new instances that are not bound to Nix's settings.

Upstream PR: https://github.com/NixOS/nix/pull/14917

Note that this was tested using the Rust bindings and setting `eval-cores`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked global configuration registration to avoid duplicate registrations and support a post-registration callback.
  * Moved some settings initialization into registration callbacks for more deterministic setup.

* **New Features**
  * Exposed a global EvalSettings instance for shared configuration.

* **Bug Fixes / API**
  * Updated C API flows to reference shared global settings (switching to referenced usage) when loading and building evaluation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->