### PR TITLE
libstore: Improve SSH connection sharing

### DIFF
--- a/src/libstore/include/nix/store/ssh.hh
+++ b/src/libstore/include/nix/store/ssh.hh
@@ -39,7 +39,7 @@ private:
 
     Sync<State> state_;
 
-    void addCommonSSHOpts(Strings & args);
+    void addCommonSSHOpts(Strings & args, Path socketPath);
     bool isMasterRunning(Path socketPath);
 
 #ifndef _WIN32 // TODO re-enable on Windows, once we can start processes.


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

I've been experiencing errors when attempting remote store builds:

```console
$ nix build --eval-store auto --store ssh-ng://remote-store.example flake#output
error: unexpected end-of-file
error: cannot open connection to remote store 'ssh-ng://remote-store.example': error: protocol mismatch, got 'started
              oixd
```

This only happens with `DeterminateSystemd/nix-src`, not with upstream Nix.

The underlying issue is my default `ControlMaster`/`ControlPath` configuration for SSH connection sharing. 

I've looked into the `SSHMaster` connection code in Nix and identified some oddities. `SSHMaster::isMasterRunning` doesn't specify the control socket that needs to be checked and thus falls back to the one that I've configured, the lifetime of which is not managed by Nix. Nix shouldn't try to interact with those sockets because checking for such a master's existence and then acting on it is inherently racy.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

I fixed the `SSHMaster::isMasterRunning` function by adding a `socketPath` parameter. This function should only be called when `useMaster` is `true`, which I've now checked by `assert`.

This then caught another bug: The condition `!useMaster && !isMasterRunning()` in `SSHMaster::startCommand` is nonsensical; it will only check `isMasterRunning` if `useMaster` is `false`.

I also ensured that Nix explicitly disables connection sharing when `SSHMaster::useMaster` is `false` by adding `-S none`.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved SSH master management to consistently use a specified socket path for control connections.
  * Startup and readiness checks updated for more reliable detection of existing master processes.
  * Non-master mode now reports "none" instead of an empty value for clearer status reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->