### PR TITLE
packaging: fix build with lowdown

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -30,17 +30,22 @@ scope: {
         NIX_CFLAGS_COMPILE = "-DINITIAL_MARK_STACK_SIZE=1048576";
       });
 
-  lowdown = pkgs.lowdown.overrideAttrs (prevAttrs: rec {
-    version = "2.0.2";
-    src = pkgs.fetchurl {
-      url = "https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${version}.tar.gz";
-      hash = "sha512-cfzhuF4EnGmLJf5EGSIbWqJItY3npbRSALm+GarZ7SMU7Hr1xw0gtBFMpOdi5PBar4TgtvbnG4oRPh+COINGlA==";
-    };
-    nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [ pkgs.buildPackages.bmake ];
-    postInstall =
-      lib.replaceStrings [ "lowdown.so.1" "lowdown.1.dylib" ] [ "lowdown.so.2" "lowdown.2.dylib" ]
-        (prevAttrs.postInstall or "");
-  });
+  lowdown =
+    if lib.versionAtLeast pkgs.lowdown.version "2.0.2" then
+      pkgs.lowdown
+    else
+      pkgs.lowdown.overrideAttrs (prevAttrs: rec {
+        version = "2.0.2";
+        src = pkgs.fetchurl {
+          url = "https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${version}.tar.gz";
+          hash = "sha512-cfzhuF4EnGmLJf5EGSIbWqJItY3npbRSALm+GarZ7SMU7Hr1xw0gtBFMpOdi5PBar4TgtvbnG4oRPh+COINGlA==";
+        };
+        patches = [ ];
+        nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [ pkgs.buildPackages.bmake ];
+        postInstall =
+          lib.replaceStrings [ "lowdown.so.1" "lowdown.1.dylib" ] [ "lowdown.so.2" "lowdown.2.dylib" ]
+            (prevAttrs.postInstall or "");
+      });
 
   # TODO: Remove this when https://github.com/NixOS/nixpkgs/pull/442682 is included in a stable release
   toml11 =


### PR DESCRIPTION
This PR resolves a build failure caused by a `lowdown` patch from `nixpkgs` (NixOS/nixpkgs#468178). The patch, intended for `lowdown-2.0.4` on Cygwin, is incompatible with the `lowdown-2.0.2` required by this project.

To fix the build failure, the `lowdown` package is now only overridden if the version provided by `nixpkgs` is older than `2.0.2`. When the override occurs, the incompatible patch is not applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized dependency management to conditionally use system package versions when compatible, falling back to pinned versions when necessary.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->