### PR TITLE
nix repl: Show Determinate version

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -177,7 +177,7 @@ ReplExitStatus NixRepl::mainLoop()
         if (state->debugRepl) {
             debuggerNotice = " debugger";
         }
-        notice("Nix %1%%2%\nType :? for help.", nixVersion, debuggerNotice);
+        notice("Nix %s\nType :? for help.", version(), debuggerNotice);
     }
 
     isFirstRepl = false;

--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -321,7 +321,7 @@ import $testDir/lang/parse-fail-eof-pos.nix
 badDiff=0
 badExitCode=0
 
-nixVersion="$(nix eval --impure --raw --expr 'builtins.nixVersion')"
+nixVersion="$(nix --version | sed 's/nix //')"
 
 # TODO: write a repl interacter for testing. Papering over the differences between readline / editline and between platforms is a pain.
 


### PR DESCRIPTION
## Motivation

It now shows:

```
$ nix repl
Nix (Determinate Nix 3.15.1) 2.33.0
Type :? for help.
nix-repl> 
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated REPL startup notice formatting for a cleaner version display.

* **Tests**
  * Adjusted the test that verifies REPL version output to align with the new version string format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->