### PR TITLE
 filetransfer: don't allow the queue size to be 0 

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -731,7 +731,10 @@ struct curlFileTransfer : public FileTransfer
 
     std::thread workerThread;
 
-    const size_t maxQueueSize = fileTransferSettings.httpConnections.get() * 5;
+    const size_t maxQueueSize =
+        (fileTransferSettings.httpConnections.get() ? fileTransferSettings.httpConnections.get()
+                                                    : std::max(1U, std::thread::hardware_concurrency()))
+        * 5;
 
     curlFileTransfer()
         : mt19937(rd())


### PR DESCRIPTION
## Motivation

This inadvertently caused file transfers to hang when used in conjunction with `http-connections = 0`: the worker checks if the in-progress items and items we've added to the incoming queue are larger than the max queue size, which was previously defined to be 5x the value of `http-connections. Well, as you can probably tell, 5*0=0, and unless the `.size()` of any of these containers became negative, we would always wait another 100ms instead of processing the incoming queue.

Because `http-connections = 0` is a special value to signal, roughly, "as much possible" (mostly depends on how cURL handles it, but this is probably approximately right), we default to `std::thread::hardware_concurrency()` (as is done in a couple other places; specifically, this is what the ThreadPool constructor does for a value of `0`).

There may be a better fix, but this works for now, and is approximately right.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file transfer queue size calculation with safer defaults for systems without explicit configuration, reducing the risk of potential hangs during file transfer operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->