### PR TITLE
Use determinate-specific input names

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,19 @@
 {
   "nodes": {
+    "determinate-nixpkgs": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "revCount": 813814,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.813814%2Brev-ac62194c3917d5f474c1a844b6fd6da2db95077d/019b95ad-fc44-71ef-a5c4-3328eb74a196/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2505"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -19,7 +33,7 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
-          "nixpkgs"
+          "determinate-nixpkgs"
         ]
       },
       "locked": {
@@ -40,7 +54,7 @@
         "flake-compat": "flake-compat",
         "gitignore": [],
         "nixpkgs": [
-          "nixpkgs"
+          "determinate-nixpkgs"
         ]
       },
       "locked": {
@@ -54,20 +68,6 @@
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/cachix/git-hooks.nix/0.1.941"
-      }
-    },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1761597516,
-        "narHash": "sha256-wxX7u6D2rpkJLWkZ2E932SIvDJW8+ON/0Yy8+a5vsDU=",
-        "rev": "daf6dc47aa4b44791372d6139ab7b25269184d55",
-        "revCount": 811874,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.811874%2Brev-daf6dc47aa4b44791372d6139ab7b25269184d55/019a3494-3498-707e-9086-1fb81badc7fe/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2505"
       }
     },
     "nixpkgs-23-11": {
@@ -104,9 +104,9 @@
     },
     "root": {
       "inputs": {
+        "determinate-nixpkgs": "determinate-nixpkgs",
         "flake-parts": "flake-parts",
         "git-hooks-nix": "git-hooks-nix",
-        "nixpkgs": "nixpkgs",
         "nixpkgs-23-11": "nixpkgs-23-11",
         "nixpkgs-regression": "nixpkgs-regression"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "The purely functional package manager";
 
-  inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2505";
+  inputs.determinate-nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2505";
 
   inputs.nixpkgs-regression.url = "github:NixOS/nixpkgs/215d4d0fd80ca5163643b03a33fde804a29cc1e2";
   inputs.nixpkgs-23-11.url = "github:NixOS/nixpkgs/a62e6edd6d5e1fa0329b8653c801147986f8d446";
@@ -10,21 +10,21 @@
   inputs.flake-parts.url = "https://flakehub.com/f/hercules-ci/flake-parts/0.1";
   inputs.git-hooks-nix.url = "https://flakehub.com/f/cachix/git-hooks.nix/0.1.941";
   # work around https://github.com/NixOS/nix/issues/7730
-  inputs.flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
-  inputs.git-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.flake-parts.inputs.nixpkgs-lib.follows = "determinate-nixpkgs";
+  inputs.git-hooks-nix.inputs.nixpkgs.follows = "determinate-nixpkgs";
   # work around 7730 and https://github.com/NixOS/nix/issues/7807
   inputs.git-hooks-nix.inputs.gitignore.follows = "";
 
   outputs =
     inputs@{
       self,
-      nixpkgs,
+      determinate-nixpkgs,
       nixpkgs-regression,
       ...
     }:
 
     let
-      inherit (nixpkgs) lib;
+      inherit (determinate-nixpkgs) lib;
 
       officialRelease = true;
 
@@ -94,7 +94,7 @@
             crossSystem:
             forAllStdenvs (
               stdenv:
-              import nixpkgs {
+              import determinate-nixpkgs {
                 localSystem = {
                   inherit system;
                 };
@@ -314,6 +314,7 @@
         system:
         (import ./ci/gha/tests {
           inherit system;
+          nixpkgs = determinate-nixpkgs;
           pkgs = nixpkgsFor.${system}.native;
           nixFlake = self;
         }).topLevel
@@ -562,7 +563,7 @@
 
           ```console
           nix repl> :lf NixOS/nix
-          nix-repl> ps = lib.makeComponents { pkgs = import inputs.nixpkgs { crossSystem = "riscv64-linux"; }; }
+          nix-repl> ps = lib.makeComponents { pkgs = import inputs.determinate-nixpkgs { crossSystem = "riscv64-linux"; }; }
           nix-repl> ps
           {
             appendPatches = «lambda appendPatches @ ...»;

--- a/packaging/hydra.nix
+++ b/packaging/hydra.nix
@@ -9,7 +9,7 @@
   officialRelease,
 }:
 let
-  inherit (inputs) nixpkgs nixpkgs-regression;
+  inherit (inputs) determinate-nixpkgs nixpkgs-regression;
 
   installScriptFor =
     tarballs:
@@ -167,7 +167,8 @@ rec {
   # System tests.
   tests =
     import ../tests/nixos {
-      inherit lib nixpkgs;
+      inherit lib;
+      nixpkgs = determinate-nixpkgs;
       pkgs = nixpkgsFor.x86_64-linux.native;
       nixComponents = nixpkgsFor.x86_64-linux.native.nixComponents2;
       inherit (self.inputs) nixpkgs-23-11;
@@ -193,7 +194,7 @@ rec {
 
       nixpkgsLibTests = forAllSystems (
         system:
-        import (nixpkgs + "/lib/tests/test-with-nix.nix") {
+        import (determinate-nixpkgs + "/lib/tests/test-with-nix.nix") {
           lib = nixpkgsFor.${system}.native.lib;
           nix = self.packages.${system}.nix-cli;
           pkgs = nixpkgsFor.${system}.native;
@@ -203,7 +204,7 @@ rec {
       nixpkgsLibTestsLazy = forAllSystems (
         system:
         lib.overrideDerivation
-          (import (nixpkgs + "/lib/tests/test-with-nix.nix") {
+          (import (determinate-nixpkgs + "/lib/tests/test-with-nix.nix") {
             lib = nixpkgsFor.${system}.native.lib;
             nix = self.packages.${system}.nix-cli;
             pkgs = nixpkgsFor.${system}.native;


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

I watch my flake.lock pretty closely and don't like duplicate inputs. This renames generic inputs to something specific to Determinate -- since Determinate doesn't want users overriding nixpkgs.

Here's a snippet from my flake.nix which removes duplicate inputs:

```
    # TODO: update to upstream input when PR is merged
    determinate-nixpkgs.url = "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.811874%2Brev-daf6dc47aa4b44791372d6139ab7b25269184d55/019a3494-3498-707e-9086-1fb81badc7fe/source.tar.gz"; 

    determinate-nix = {
      url = "github:heywoodlh/nix-src/fix-input-conflict";
      inputs.determinate-nixpkgs.follows = "determinate-nixpkgs";
      inputs.flake-parts.follows = "flake-parts";
      inputs.git-hooks-nix.follows = "pre-commit-hooks";
    };
    determinate = {
      url = "github:heywoodlh/determinate/fix-input-conflict";
      inputs.determinate-nixpkgs.follows = "determinate-nixpkgs";
      inputs.determinate-nix.follows = "determinate-nix";
    };
```

https://github.com/DeterminateSystems/determinate/pull/157#issue-3872952130

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and package source references to improve compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->