### PR TITLE
Don't pin the rust compiler used to build wasmtime

### DIFF
--- a/packaging/wasmtime.nix
+++ b/packaging/wasmtime.nix
@@ -3,13 +3,13 @@
 {
   lib,
   stdenv,
-  rust_1_89,
+  rustPlatform,
   fetchFromGitHub,
   cmake,
   enableShared ? !stdenv.hostPlatform.isStatic,
   enableStatic ? stdenv.hostPlatform.isStatic,
 }:
-rust_1_89.packages.stable.rustPlatform.buildRustPackage (finalAttrs: {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wasmtime";
   version = "40.0.2";
 


### PR DESCRIPTION
This allows building with nixpkgs versions that do not provide specifically rust_1_89.

## Motivation

I pin nixpkgs in my config, then set `determinate.inputs.nixpkgs.follows = "nixpkgs"`. The nixpkgs I have pinned does not provide `rust_1_89`.

## Context

Added in #309, specifically d049bf3e237577e038f4e1ed1df6252d30dc1dfe. I don't see any specific reasoning in the PR for pinning the compiler version.

Upstream nixpkgs just uses bare `rustPlatform`: https://github.com/NixOS/nixpkgs/blob/18451d41a40765408adb9f3f20e76c151fdfa307/pkgs/by-name/wa/wasmtime/package.nix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build configuration toolchain for improved compatibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->