### PR TITLE
BinaryCacheStore::queryPathInfoUncached(): Ensure noexcept

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -435,37 +435,41 @@ void BinaryCacheStore::narFromPath(const StorePath & storePath, Sink & sink)
 void BinaryCacheStore::queryPathInfoUncached(
     const StorePath & storePath, Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept
 {
-    auto uri = config.getReference().render(/*FIXME withParams=*/false);
-    auto storePathS = printStorePath(storePath);
-    auto act = std::make_shared<Activity>(
-        *logger,
-        lvlTalkative,
-        actQueryPathInfo,
-        fmt("querying info about '%s' on '%s'", storePathS, uri),
-        Logger::Fields{storePathS, uri});
-    PushActivity pact(act->id);
-
-    auto narInfoFile = narInfoFileFor(storePath);
-
     auto callbackPtr = std::make_shared<decltype(callback)>(std::move(callback));
 
-    getFile(narInfoFile, {[=, this](std::future<std::optional<std::string>> fut) {
-                try {
-                    auto data = fut.get();
+    try {
+        auto uri = config.getReference().render(/*FIXME withParams=*/false);
+        auto storePathS = printStorePath(storePath);
+        auto act = std::make_shared<Activity>(
+            *logger,
+            lvlTalkative,
+            actQueryPathInfo,
+            fmt("querying info about '%s' on '%s'", storePathS, uri),
+            Logger::Fields{storePathS, uri});
+        PushActivity pact(act->id);
 
-                    if (!data)
-                        return (*callbackPtr)({});
+        auto narInfoFile = narInfoFileFor(storePath);
 
-                    stats.narInfoRead++;
+        getFile(narInfoFile, {[=, this](std::future<std::optional<std::string>> fut) {
+                    try {
+                        auto data = fut.get();
 
-                    (*callbackPtr)(
-                        (std::shared_ptr<ValidPathInfo>) std::make_shared<NarInfo>(*this, *data, narInfoFile));
+                        if (!data)
+                            return (*callbackPtr)({});
 
-                    (void) act; // force Activity into this lambda to ensure it stays alive
-                } catch (...) {
-                    callbackPtr->rethrow();
-                }
-            }});
+                        stats.narInfoRead++;
+
+                        (*callbackPtr)(
+                            (std::shared_ptr<ValidPathInfo>) std::make_shared<NarInfo>(*this, *data, narInfoFile));
+
+                        (void) act; // force Activity into this lambda to ensure it stays alive
+                    } catch (...) {
+                        callbackPtr->rethrow();
+                    }
+                }});
+    } catch (...) {
+        callbackPtr->rethrow();
+    }
 }
 
 StorePath BinaryCacheStore::addToStore(


### PR DESCRIPTION
## Motivation

Make sure we don't throw an exception, since that will terminate the program.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for binary cache operations, ensuring exceptions are properly caught and handled through a more robust control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->