### PR TITLE
builtins.getFlake: Support path values

### DIFF
--- a/src/libflake/flake-primops.cc
+++ b/src/libflake/flake-primops.cc
@@ -35,36 +35,39 @@ namespace nix::flake::primops {
 PrimOp getFlake(const Settings & settings)
 {
     auto prim_getFlake = [&settings](EvalState & state, const PosIdx pos, Value ** args, Value & v) {
-        NixStringContext context;
-        std::string flakeRefS(
-            state.forceString(*args[0], context, pos, "while evaluating the argument passed to builtins.getFlake"));
-        auto rewrites = state.realiseContext(context);
-        flakeRefS = state.devirtualize(rewriteStrings(flakeRefS, rewrites), context);
-        if (hasContext(context))
-            // FIXME: this should really be an error.
-            warn(
-                "In 'builtins.getFlake', the flakeref '%s' has string context, but that's not allowed. This may become a fatal error in the future.",
-                flakeRefS);
-        auto flakeRef = nix::parseFlakeRef(state.fetchSettings, flakeRefS, {}, true);
-        if (state.settings.pureEval && !flakeRef.input.isLocked(state.fetchSettings))
-            throw Error(
-                "cannot call 'getFlake' on unlocked flake reference '%s', at %s (use --impure to override)",
-                flakeRefS,
-                state.positions[pos]);
+        state.forceValue(*args[0], pos);
 
-        callFlake(
-            state,
-            lockFlake(
-                settings,
-                state,
-                flakeRef,
-                LockFlags{
-                    .updateLockFile = false,
-                    .writeLockFile = false,
-                    .useRegistries = !state.settings.pureEval && settings.useRegistries,
-                    .allowUnlocked = !state.settings.pureEval,
-                }),
-            v);
+        LockFlags lockFlags{
+            .updateLockFile = false,
+            .writeLockFile = false,
+            .useRegistries = !state.settings.pureEval && settings.useRegistries,
+            .allowUnlocked = !state.settings.pureEval,
+        };
+
+        if (args[0]->type() == nPath) {
+            auto path = state.realisePath(pos, *args[0]);
+            callFlake(state, lockFlake(settings, state, path, lockFlags), v);
+        } else {
+            NixStringContext context;
+            std::string flakeRefS(
+                state.forceString(*args[0], context, pos, "while evaluating the argument passed to builtins.getFlake"));
+            auto rewrites = state.realiseContext(context);
+            flakeRefS = state.devirtualize(rewriteStrings(flakeRefS, rewrites), context);
+            if (hasContext(context))
+                // FIXME: this should really be an error.
+                warn(
+                    "In 'builtins.getFlake', the flakeref '%s' has string context, but that's not allowed. This may become a fatal error in the future.",
+                    flakeRefS);
+
+            auto flakeRef = nix::parseFlakeRef(state.fetchSettings, flakeRefS, {}, true);
+            if (state.settings.pureEval && !flakeRef.input.isLocked(state.fetchSettings))
+                throw Error(
+                    "cannot call 'getFlake' on unlocked flake reference '%s', at %s (use --impure to override)",
+                    flakeRefS,
+                    state.positions[pos]);
+
+            callFlake(state, lockFlake(settings, state, flakeRef, lockFlags), v);
+        }
     };
 
     return PrimOp{

--- a/src/libflake/include/nix/flake/flake.hh
+++ b/src/libflake/include/nix/flake/flake.hh
@@ -226,8 +226,15 @@ struct LockFlags
     bool requireLockable = true;
 };
 
+/*
+ * Compute an in-memory lock file for the specified top-level flake, and optionally write it to file, if the flake is
+ * writable.
+ */
 LockedFlake
 lockFlake(const Settings & settings, EvalState & state, const FlakeRef & flakeRef, const LockFlags & lockFlags);
+
+LockedFlake
+lockFlake(const Settings & settings, EvalState & state, const SourcePath & flakeDir, const LockFlags & lockFlags);
 
 void callFlake(EvalState & state, const LockedFlake & lockedFlake, Value & v);
 

--- a/tests/functional/flakes/get-flake.sh
+++ b/tests/functional/flakes/get-flake.sh
@@ -9,9 +9,13 @@ cat > "$flake1Dir/subflake/flake.nix" <<EOF
 {
   outputs = { self }:
     let
+      # Bad, legacy way of getting a flake from an input.
       parentFlake = builtins.getFlake (builtins.flakeRefToString { type = "path"; path = self.sourceInfo.outPath; narHash = self.narHash; });
+      # Better way using a path value.
+      parentFlake2 = builtins.getFlake ./..;
     in {
       x = parentFlake.number;
+      y = parentFlake2.number;
     };
 }
 EOF
@@ -19,3 +23,5 @@ git -C "$flake1Dir" add subflake/flake.nix
 
 expectStderr 0 nix eval "$flake1Dir/subflake#x" | grepQuiet "This may become a fatal error in the future"
 [[ $(nix eval "$flake1Dir/subflake#x") = 123 ]]
+
+[[ $(nix eval "$flake1Dir/subflake#y") = 123 ]]


### PR DESCRIPTION
## Motivation

This allows doing
```nix
builtins.getFlake ./..
```
instead of the hacky 
```
builtins.getFlake (builtins.flakeRefToString { type = "path"; path = self.sourceInfo.outPath; narHash = self.narHash; });
```

Depends on https://github.com/DeterminateSystems/nix-src/pull/337.

Issue #302.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New ways to lock a flake using a directory or explicit flake input, giving more flexible lock workflows.

* **Refactor**
  * Optimized flake resolution to handle path-based and string-based inputs with shared preparatory logic, preserving behavior.

* **Tests**
  * Added functional coverage for the new path-based flake resolution alongside the legacy method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->