### PR TITLE
Add subcommand 'nix provenance show'

### DIFF
--- a/src/libfetchers/include/nix/fetchers/provenance.hh
+++ b/src/libfetchers/include/nix/fetchers/provenance.hh
@@ -11,6 +11,11 @@ struct TreeProvenance : Provenance
 
     TreeProvenance(const fetchers::Input & input);
 
+    TreeProvenance(ref<nlohmann::json> attrs)
+        : attrs(std::move(attrs))
+    {
+    }
+
     nlohmann::json to_json() const override;
 };
 

--- a/src/libfetchers/provenance.cc
+++ b/src/libfetchers/provenance.cc
@@ -1,5 +1,6 @@
 #include "nix/fetchers/provenance.hh"
 #include "nix/fetchers/attrs.hh"
+#include "nix/util/json-utils.hh"
 
 #include <nlohmann/json.hpp>
 
@@ -23,5 +24,11 @@ nlohmann::json TreeProvenance::to_json() const
         {"attrs", *attrs},
     };
 }
+
+Provenance::Register registerTreeProvenance("tree", [](nlohmann::json json) {
+    auto & obj = getObject(json);
+    auto & attrsJson = valueAt(obj, "attrs");
+    return make_ref<TreeProvenance>(make_ref<nlohmann::json>(attrsJson));
+});
 
 } // namespace nix

--- a/src/libflake/provenance.cc
+++ b/src/libflake/provenance.cc
@@ -1,4 +1,5 @@
 #include "nix/flake/provenance.hh"
+#include "nix/util/json-utils.hh"
 
 #include <nlohmann/json.hpp>
 
@@ -12,5 +13,13 @@ nlohmann::json FlakeProvenance::to_json() const
         {"flakeOutput", flakeOutput},
     };
 }
+
+Provenance::Register registerFlakeProvenance("flake", [](nlohmann::json json) {
+    auto & obj = getObject(json);
+    std::shared_ptr<const Provenance> next;
+    if (auto p = optionalValueAt(obj, "next"); p && !p->is_null())
+        next = Provenance::from_json(*p);
+    return make_ref<FlakeProvenance>(next, getString(valueAt(obj, "flakeOutput")));
+});
 
 } // namespace nix

--- a/src/libstore/provenance.cc
+++ b/src/libstore/provenance.cc
@@ -13,6 +13,15 @@ nlohmann::json BuildProvenance::to_json() const
     };
 }
 
+Provenance::Register registerBuildProvenance("build", [](nlohmann::json json) {
+    auto & obj = getObject(json);
+    std::shared_ptr<const Provenance> next;
+    if (auto p = optionalValueAt(obj, "next"); p && !p->is_null())
+        next = Provenance::from_json(*p);
+    return make_ref<BuildProvenance>(
+        StorePath(getString(valueAt(obj, "drv"))), getString(valueAt(obj, "output")), next);
+});
+
 nlohmann::json CopiedProvenance::to_json() const
 {
     return {

--- a/src/libutil/provenance.cc
+++ b/src/libutil/provenance.cc
@@ -63,4 +63,12 @@ nlohmann::json SubpathProvenance::to_json() const
     };
 }
 
+Provenance::Register registerSubpathProvenance("subpath", [](nlohmann::json json) {
+    auto & obj = getObject(json);
+    std::shared_ptr<const Provenance> next;
+    if (auto p = optionalValueAt(obj, "next"); p && !p->is_null())
+        next = Provenance::from_json(*p);
+    return make_ref<SubpathProvenance>(next, CanonPath(getString(valueAt(obj, "subpath"))));
+});
+
 } // namespace nix

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -94,6 +94,7 @@ nix_sources = [ config_priv_h ] + files(
   'path-info.cc',
   'prefetch.cc',
   'profile.cc',
+  'provenance.cc',
   'ps.cc',
   'realisation.cc',
   'registry.cc',

--- a/src/nix/provenance-show.md
+++ b/src/nix/provenance-show.md
@@ -1,0 +1,28 @@
+R""(
+
+# Examples
+
+* Show the provenance of a store path:
+
+  ```console
+  # nix provenance show /run/current-system
+  /nix/store/k145bdxhdb89i4fkvgdisdz1yh2wiymm-nixos-system-machine-25.05.20251210.d2b1213
+  ← copied from cache.flakehub.com
+  ← built from derivation /nix/store/w3p3xkminq61hs00kihd34w1dglpj5s9-nixos-system-machine-25.05.20251210.d2b1213.drv (output out)
+  ← instantiated from flake output github:my-org/my-repo/6b03eb949597fe96d536e956a2c14da9901dbd21?dir=machine#nixosConfigurations.machine.config.system.build.toplevel
+  ```
+
+# Description
+
+Show the provenance chain of one or more store paths. For each store path, this displays where it came from: what binary cache it was copied from, what flake it was built from, and so on.
+
+The provenance chain shows the history of how the store path came to exist, including:
+
+- **Copied**: The path was copied from another Nix store, typically a binary cache.
+- **Built**: The path was built from a derivation.
+- **Flake evaluation**: The derivation was instantiated during the evaluation of a flake output.
+- **Fetched**: The path was obtained by fetching a source tree.
+
+Note: if you want provenance in JSON format, use the `provenance` field returned by `nix path-info --json`.
+
+)""

--- a/src/nix/provenance.cc
+++ b/src/nix/provenance.cc
@@ -1,0 +1,124 @@
+#include "nix/cmd/command.hh"
+#include "nix/store/store-api.hh"
+#include "nix/store/provenance.hh"
+#include "nix/flake/provenance.hh"
+#include "nix/fetchers/provenance.hh"
+#include "nix/util/provenance.hh"
+
+#include <memory>
+#include <nlohmann/json.hpp>
+
+using namespace nix;
+
+struct CmdProvenance : NixMultiCommand
+{
+    CmdProvenance()
+        : NixMultiCommand("provenance", RegisterCommand::getCommandsFor({"provenance"}))
+    {
+    }
+
+    std::string description() override
+    {
+        return "query and check the provenance of store paths";
+    }
+
+    std::optional<ExperimentalFeature> experimentalFeature() override
+    {
+        return Xp::Provenance;
+    }
+
+    Category category() override
+    {
+        return catUtility;
+    }
+};
+
+static auto rCmdProvenance = registerCommand<CmdProvenance>("provenance");
+
+struct CmdProvenanceShow : StorePathsCommand
+{
+    std::string description() override
+    {
+        return "show the provenance chain of store paths";
+    }
+
+    std::string doc() override
+    {
+        return
+#include "provenance-show.md"
+            ;
+    }
+
+    void displayProvenance(Store & store, const StorePath & path, std::shared_ptr<const Provenance> provenance)
+    {
+        while (provenance) {
+            if (auto copied = std::dynamic_pointer_cast<const CopiedProvenance>(provenance)) {
+                logger->cout("← copied from " ANSI_BOLD "%s" ANSI_NORMAL, copied->from);
+                provenance = copied->next;
+            } else if (auto build = std::dynamic_pointer_cast<const BuildProvenance>(provenance)) {
+                logger->cout(
+                    "← built from derivation " ANSI_BOLD "%s" ANSI_NORMAL " (output " ANSI_BOLD "%s" ANSI_NORMAL ")",
+                    store.printStorePath(build->drvPath),
+                    build->output);
+                provenance = build->next;
+            } else if (auto flake = std::dynamic_pointer_cast<const FlakeProvenance>(provenance)) {
+                // Collapse subpath/tree provenance into the flake provenance for legibility.
+                auto next = flake->next;
+                CanonPath flakePath("/flake.nix");
+                if (auto subpath = std::dynamic_pointer_cast<const SubpathProvenance>(next)) {
+                    next = subpath->next;
+                    flakePath = subpath->subpath;
+                }
+                if (auto tree = std::dynamic_pointer_cast<const TreeProvenance>(next)) {
+                    FlakeRef flakeRef(
+                        fetchers::Input::fromAttrs(fetchSettings, fetchers::jsonToAttrs(*tree->attrs)),
+                        Path(flakePath.parent().value_or(CanonPath::root).rel()));
+                    logger->cout(
+                        "← instantiated from flake output " ANSI_BOLD "%s#%s" ANSI_NORMAL,
+                        flakeRef.to_string(),
+                        flake->flakeOutput);
+                    break;
+                } else {
+                    logger->cout("← instantiated from flake output " ANSI_BOLD "%s" ANSI_NORMAL, flake->flakeOutput);
+                    provenance = flake->next;
+                }
+            } else if (auto tree = std::dynamic_pointer_cast<const TreeProvenance>(provenance)) {
+                auto input = fetchers::Input::fromAttrs(fetchSettings, fetchers::jsonToAttrs(*tree->attrs));
+                logger->cout("← from tree " ANSI_BOLD "%s" ANSI_NORMAL, input.to_string());
+                break;
+            } else if (auto subpath = std::dynamic_pointer_cast<const SubpathProvenance>(provenance)) {
+                logger->cout("← from file " ANSI_BOLD "%s" ANSI_NORMAL, subpath->subpath.abs());
+                provenance = subpath->next;
+            } else {
+                // Unknown or unhandled provenance type
+                auto json = provenance->to_json();
+                auto typeIt = json.find("type");
+                if (typeIt != json.end() && typeIt->is_string())
+                    logger->cout("← " ANSI_RED "unknown provenance type '%s'" ANSI_NORMAL, typeIt->get<std::string>());
+                else
+                    logger->cout("← " ANSI_RED "unknown provenance type" ANSI_NORMAL);
+                break;
+            }
+        }
+    }
+
+    void run(ref<Store> store, StorePaths && storePaths) override
+    {
+        bool first = true;
+
+        for (auto & storePath : storePaths) {
+            auto info = store->queryPathInfo(storePath);
+            if (!first)
+                logger->cout("");
+            first = false;
+            logger->cout(ANSI_BOLD "%s" ANSI_NORMAL, store->printStorePath(info->path));
+
+            if (info->provenance)
+                displayProvenance(*store, storePath, info->provenance);
+            else
+                logger->cout(ANSI_RED "  (no provenance information available)" ANSI_NORMAL);
+        }
+    }
+};
+
+static auto rCmdProvenanceShow = registerCommand2<CmdProvenanceShow>({"provenance", "show"});

--- a/tests/functional/flakes/provenance.sh
+++ b/tests/functional/flakes/provenance.sh
@@ -120,6 +120,15 @@ nix copy --from "file://$binaryCache" "$outPath" --no-check-sigs
 EOF
 ) ]]
 
+# Test `nix provenance show`.
+[[ $(nix provenance show "$outPath") = $(cat <<EOF
+[1m$outPath[0m
+← copied from [1mfile://$binaryCache[0m
+← built from derivation [1m$drvPath[0m (output [1mout[0m)
+← instantiated from flake output [1mgit+file://$flake1Dir?ref=refs/heads/master&rev=$rev#packages.$system.default[0m
+EOF
+) ]]
+
 # Check that --impure does not add provenance.
 clearStore
 nix build --impure --print-out-paths --no-link "$flake1Dir#packages.$system.default"


### PR DESCRIPTION
## Motivation

This adds a subcommand `nix provenance show` that displays the provenance record of a store path in a human-readable form, e.g.
```
# nix provenance show /run/current-system
/nix/store/k145bdxhdb89i4fkvgdisdz1yh2wiymm-nixos-system-machine-25.05.20251210.d2b1213
← copied from cache.flakehub.com
← built from derivation /nix/store/w3p3xkminq61hs00kihd34w1dglpj5s9-nixos-system-machine-25.05.20251210.d2b1213.drv (output out)
← instantiated from flake output nixosConfigurations.machine.config.system.build.toplevel
← from file /machine/flake.nix
← from tree github:my-org/my-repo/6b03eb949597fe96d536e956a2c14da9901dbd21
```
## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `nix provenance show` to print the provenance chain for store paths; now recognizes and displays more provenance kinds (build, flake, subpath, tree, etc.) and nested provenance links.

* **Documentation**
  * Added user documentation for the provenance show feature with examples and JSON output notes.

* **Tests**
  * Added a functional test exercising `nix provenance show` output for flake-based store paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->