### PR TITLE
Record builder host name in build provenance

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -15,6 +15,8 @@
 #include <curl/curl.h>
 #include <nlohmann/json.hpp>
 
+#include <limits.h>
+
 #ifndef _WIN32
 #  include <sys/utsname.h>
 #endif
@@ -265,6 +267,20 @@ const ExternalBuilder * Settings::findExternalDerivationBuilderIfSupported(const
         it != externalBuilders.get().end())
         return &*it;
     return nullptr;
+}
+
+std::optional<std::string> Settings::getHostName()
+{
+    if (hostName != "")
+        return hostName;
+
+#ifndef _WIN32
+    char hostname[_POSIX_HOST_NAME_MAX + 1];
+    if (gethostname(hostname, sizeof(hostname)) == 0)
+        return std::string(hostname);
+#endif
+
+    return std::nullopt;
 }
 
 std::string nixVersion = PACKAGE_VERSION;

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -1441,6 +1441,16 @@ public:
      * derivation, or else returns a null pointer.
      */
     const ExternalBuilder * findExternalDerivationBuilderIfSupported(const Derivation & drv);
+
+    Setting<std::string> hostName{
+        this,
+        "",
+        "host-name",
+        R"(
+          The name of this host for recording build provenance. If unset, the Unix host name is used.
+        )"};
+
+    std::optional<std::string> getHostName();
 };
 
 // FIXME: don't use a global variable.

--- a/src/libstore/include/nix/store/provenance.hh
+++ b/src/libstore/include/nix/store/provenance.hh
@@ -19,15 +19,25 @@ struct BuildProvenance : Provenance
     OutputName output;
 
     /**
+     * The hostname of the machine on which the derivation was built, if known.
+     */
+    std::optional<std::string> buildHost;
+
+    /**
      * The provenance of the derivation, if known.
      */
     std::shared_ptr<const Provenance> next;
 
     // FIXME: do we need anything extra for CA derivations?
 
-    BuildProvenance(const StorePath & drvPath, const OutputName & output, std::shared_ptr<const Provenance> next)
+    BuildProvenance(
+        const StorePath & drvPath,
+        const OutputName & output,
+        std::optional<std::string> buildHost,
+        std::shared_ptr<const Provenance> next)
         : drvPath(drvPath)
         , output(output)
+        , buildHost(std::move(buildHost))
         , next(std::move(next))
     {
     }

--- a/src/libstore/provenance.cc
+++ b/src/libstore/provenance.cc
@@ -9,6 +9,7 @@ nlohmann::json BuildProvenance::to_json() const
         {"type", "build"},
         {"drv", drvPath.to_string()},
         {"output", output},
+        {"buildHost", buildHost},
         {"next", next ? next->to_json() : nlohmann::json(nullptr)},
     };
 }
@@ -18,8 +19,12 @@ Provenance::Register registerBuildProvenance("build", [](nlohmann::json json) {
     std::shared_ptr<const Provenance> next;
     if (auto p = optionalValueAt(obj, "next"); p && !p->is_null())
         next = Provenance::from_json(*p);
-    return make_ref<BuildProvenance>(
-        StorePath(getString(valueAt(obj, "drv"))), getString(valueAt(obj, "output")), next);
+    std::optional<std::string> buildHost;
+    if (auto p = optionalValueAt(obj, "buildHost"))
+        buildHost = p->get<std::optional<std::string>>();
+    auto buildProv = make_ref<BuildProvenance>(
+        StorePath(getString(valueAt(obj, "drv"))), getString(valueAt(obj, "output")), buildHost, next);
+    return buildProv;
 });
 
 nlohmann::json CopiedProvenance::to_json() const

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1868,7 +1868,8 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
             newInfo.deriver = drvPath;
             newInfo.ultimate = true;
             if (drvProvenance)
-                newInfo.provenance = std::make_shared<const BuildProvenance>(drvPath, outputName, drvProvenance);
+                newInfo.provenance =
+                    std::make_shared<const BuildProvenance>(drvPath, outputName, settings.getHostName(), drvProvenance);
             store.signPathInfo(newInfo);
 
             finish(newInfo.path);

--- a/src/nix/provenance-show.md
+++ b/src/nix/provenance-show.md
@@ -8,7 +8,7 @@ R""(
   # nix provenance show /run/current-system
   /nix/store/k145bdxhdb89i4fkvgdisdz1yh2wiymm-nixos-system-machine-25.05.20251210.d2b1213
   ← copied from cache.flakehub.com
-  ← built from derivation /nix/store/w3p3xkminq61hs00kihd34w1dglpj5s9-nixos-system-machine-25.05.20251210.d2b1213.drv (output out)
+  ← built from derivation /nix/store/w3p3xkminq61hs00kihd34w1dglpj5s9-nixos-system-machine-25.05.20251210.d2b1213.drv (output out) on build-machine
   ← instantiated from flake output github:my-org/my-repo/6b03eb949597fe96d536e956a2c14da9901dbd21?dir=machine#nixosConfigurations.machine.config.system.build.toplevel
   ```
 

--- a/src/nix/provenance.cc
+++ b/src/nix/provenance.cc
@@ -57,9 +57,11 @@ struct CmdProvenanceShow : StorePathsCommand
                 provenance = copied->next;
             } else if (auto build = std::dynamic_pointer_cast<const BuildProvenance>(provenance)) {
                 logger->cout(
-                    "← built from derivation " ANSI_BOLD "%s" ANSI_NORMAL " (output " ANSI_BOLD "%s" ANSI_NORMAL ")",
+                    "← built from derivation " ANSI_BOLD "%s" ANSI_NORMAL " (output " ANSI_BOLD "%s" ANSI_NORMAL
+                    ") on " ANSI_BOLD "%s" ANSI_NORMAL,
                     store.printStorePath(build->drvPath),
-                    build->output);
+                    build->output,
+                    build->buildHost.value_or("unknown host").c_str());
                 provenance = build->next;
             } else if (auto flake = std::dynamic_pointer_cast<const FlakeProvenance>(provenance)) {
                 // Collapse subpath/tree provenance into the flake provenance for legibility.

--- a/tests/functional/common/init.sh
+++ b/tests/functional/common/init.sh
@@ -52,6 +52,7 @@ gc-reserved-space = 0
 substituters =
 flake-registry = $TEST_ROOT/registry.json
 show-trace = true
+host-name = test-host
 include nix.conf.extra
 trusted-users = $(whoami)
 ${_NIX_TEST_EXTRA_CONFIG:-}

--- a/tests/functional/flakes/provenance.sh
+++ b/tests/functional/flakes/provenance.sh
@@ -18,6 +18,7 @@ builder=$(nix eval --raw "$flake1Dir#packages.$system.default._builder")
 # Building a derivation should have tree+subpath+flake+build provenance.
 [[ $(nix path-info --json --json-format 1 "$outPath" | jq ".\"$outPath\".provenance") = $(cat <<EOF
 {
+  "buildHost": "test-host",
   "drv": "$(basename "$drvPath")",
   "next": {
     "flakeOutput": "packages.$system.default",
@@ -92,6 +93,7 @@ nix copy --from "file://$binaryCache" "$outPath" --no-check-sigs
 {
   "from": "file://$binaryCache",
   "next": {
+    "buildHost": "test-host",
     "drv": "$(basename "$drvPath")",
     "next": {
       "flakeOutput": "packages.$system.default",
@@ -124,7 +126,7 @@ EOF
 [[ $(nix provenance show "$outPath") = $(cat <<EOF
 [1m$outPath[0m
 ← copied from [1mfile://$binaryCache[0m
-← built from derivation [1m$drvPath[0m (output [1mout[0m)
+← built from derivation [1m$drvPath[0m (output [1mout[0m) on [1mtest-host[0m
 ← instantiated from flake output [1mgit+file://$flake1Dir?ref=refs/heads/master&rev=$rev#packages.$system.default[0m
 EOF
 ) ]]


### PR DESCRIPTION
## Motivation

This keeps track where a build was done.

Depends on #340.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hostname tracking to build provenance records, enabling visibility into which build host created each derivation.
  * Provenance display now includes build host information when showing derivation history.
  * New configuration setting to customize the hostname used in provenance tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->