### PR TITLE
Build provenance improvements

### DIFF
--- a/src/libstore/include/nix/store/provenance.hh
+++ b/src/libstore/include/nix/store/provenance.hh
@@ -24,6 +24,11 @@ struct BuildProvenance : Provenance
     std::optional<std::string> buildHost;
 
     /**
+     * The system type of the derivation.
+     */
+    std::string system;
+
+    /**
      * The provenance of the derivation, if known.
      */
     std::shared_ptr<const Provenance> next;
@@ -34,10 +39,12 @@ struct BuildProvenance : Provenance
         const StorePath & drvPath,
         const OutputName & output,
         std::optional<std::string> buildHost,
+        std::string system,
         std::shared_ptr<const Provenance> next)
         : drvPath(drvPath)
         , output(output)
         , buildHost(std::move(buildHost))
+        , system(std::move(system))
         , next(std::move(next))
     {
     }

--- a/src/libstore/provenance.cc
+++ b/src/libstore/provenance.cc
@@ -10,6 +10,7 @@ nlohmann::json BuildProvenance::to_json() const
         {"drv", drvPath.to_string()},
         {"output", output},
         {"buildHost", buildHost},
+        {"system", system},
         {"next", next ? next->to_json() : nlohmann::json(nullptr)},
     };
 }
@@ -23,7 +24,11 @@ Provenance::Register registerBuildProvenance("build", [](nlohmann::json json) {
     if (auto p = optionalValueAt(obj, "buildHost"))
         buildHost = p->get<std::optional<std::string>>();
     auto buildProv = make_ref<BuildProvenance>(
-        StorePath(getString(valueAt(obj, "drv"))), getString(valueAt(obj, "output")), buildHost, next);
+        StorePath(getString(valueAt(obj, "drv"))),
+        getString(valueAt(obj, "output")),
+        buildHost,
+        getString(valueAt(obj, "system")),
+        next);
     return buildProv;
 });
 

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1868,8 +1868,8 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
             newInfo.deriver = drvPath;
             newInfo.ultimate = true;
             if (experimentalFeatureSettings.isEnabled(Xp::Provenance))
-                newInfo.provenance =
-                    std::make_shared<const BuildProvenance>(drvPath, outputName, settings.getHostName(), drvProvenance);
+                newInfo.provenance = std::make_shared<const BuildProvenance>(
+                    drvPath, outputName, settings.getHostName(), drv.platform, drvProvenance);
             store.signPathInfo(newInfo);
 
             finish(newInfo.path);

--- a/src/nix/provenance-show.md
+++ b/src/nix/provenance-show.md
@@ -8,7 +8,7 @@ R""(
   # nix provenance show /run/current-system
   /nix/store/k145bdxhdb89i4fkvgdisdz1yh2wiymm-nixos-system-machine-25.05.20251210.d2b1213
   ← copied from cache.flakehub.com
-  ← built from derivation /nix/store/w3p3xkminq61hs00kihd34w1dglpj5s9-nixos-system-machine-25.05.20251210.d2b1213.drv (output out) on build-machine
+  ← built from derivation /nix/store/w3p3xkminq61hs00kihd34w1dglpj5s9-nixos-system-machine-25.05.20251210.d2b1213.drv (output out) on build-machine for x86_64-linux
   ← instantiated from flake output github:my-org/my-repo/6b03eb949597fe96d536e956a2c14da9901dbd21?dir=machine#nixosConfigurations.machine.config.system.build.toplevel
   ```
 

--- a/src/nix/provenance.cc
+++ b/src/nix/provenance.cc
@@ -58,10 +58,11 @@ struct CmdProvenanceShow : StorePathsCommand
             } else if (auto build = std::dynamic_pointer_cast<const BuildProvenance>(provenance)) {
                 logger->cout(
                     "← built from derivation " ANSI_BOLD "%s" ANSI_NORMAL " (output " ANSI_BOLD "%s" ANSI_NORMAL
-                    ") on " ANSI_BOLD "%s" ANSI_NORMAL,
+                    ") on " ANSI_BOLD "%s" ANSI_NORMAL " for " ANSI_BOLD "%s" ANSI_NORMAL,
                     store.printStorePath(build->drvPath),
                     build->output,
-                    build->buildHost.value_or("unknown host").c_str());
+                    build->buildHost.value_or("unknown host").c_str(),
+                    build->system);
                 provenance = build->next;
             } else if (auto flake = std::dynamic_pointer_cast<const FlakeProvenance>(provenance)) {
                 // Collapse subpath/tree provenance into the flake provenance for legibility.

--- a/tests/functional/flakes/provenance.sh
+++ b/tests/functional/flakes/provenance.sh
@@ -40,6 +40,7 @@ builder=$(nix eval --raw "$flake1Dir#packages.$system.default._builder")
     "type": "flake"
   },
   "output": "out",
+  "system": "$system",
   "type": "build"
 }
 EOF
@@ -115,6 +116,7 @@ nix copy --from "file://$binaryCache" "$outPath" --no-check-sigs
       "type": "flake"
     },
     "output": "out",
+    "system": "$system",
     "type": "build"
   },
   "type": "copied"
@@ -126,7 +128,7 @@ EOF
 [[ $(nix provenance show "$outPath") = $(cat <<EOF
 [1m$outPath[0m
 ← copied from [1mfile://$binaryCache[0m
-← built from derivation [1m$drvPath[0m (output [1mout[0m) on [1mtest-host[0m
+← built from derivation [1m$drvPath[0m (output [1mout[0m) on [1mtest-host[0m for [1m$system[0m
 ← instantiated from flake output [1mgit+file://$flake1Dir?ref=refs/heads/master&rev=$rev#packages.$system.default[0m
 EOF
 ) ]]


### PR DESCRIPTION
## Motivation

* Always record build provenance for built paths, since it contains useful info (such as the build host) even if we don't know where the .drv file came from.

* Add a `system` field to the build provenance.  This makes it possible to see what system type a store path is built for. This information previously wasn't readily available from the Nix  database or binary cache. Note: this field is mandatory so it's a breaking change.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build provenance now tracks and displays the target system for builds, showing the platform in text output (e.g., "for x86_64-linux") and including it in JSON representations for enhanced build reproducibility visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->