### PR TITLE
Store provenance info in the NAR info disk cache

### DIFF
--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -3,6 +3,7 @@
 #include "nix/util/sync.hh"
 #include "nix/store/sqlite.hh"
 #include "nix/store/globals.hh"
+#include "nix/store/provenance.hh"
 
 #include <sqlite3.h>
 #include <nlohmann/json.hpp>
@@ -36,6 +37,7 @@ create table if not exists NARs (
     deriver          text,
     sigs             text,
     ca               text,
+    provenance       text,
     timestamp        integer not null,
     present          integer not null,
     primary key (cache, hashPart),
@@ -86,7 +88,7 @@ public:
 
     Sync<State> _state;
 
-    NarInfoDiskCacheImpl(Path dbPath = (getCacheDir() / "binary-cache-v7.sqlite").string())
+    NarInfoDiskCacheImpl(Path dbPath = (getCacheDir() / "binary-cache-v8.sqlite").string())
     {
         auto state(_state.lock());
 
@@ -109,14 +111,14 @@ public:
         state->insertNAR.create(
             state->db,
             "insert or replace into NARs(cache, hashPart, namePart, url, compression, fileHash, fileSize, narHash, "
-            "narSize, refs, deriver, sigs, ca, timestamp, present) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)");
+            "narSize, refs, deriver, sigs, ca, provenance, timestamp, present) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)");
 
         state->insertMissingNAR.create(
             state->db, "insert or replace into NARs(cache, hashPart, timestamp, present) values (?, ?, ?, 0)");
 
         state->queryNAR.create(
             state->db,
-            "select present, namePart, url, compression, fileHash, fileSize, narHash, narSize, refs, deriver, sigs, ca from NARs where cache = ? and hashPart = ? and ((present = 0 and timestamp > ?) or (present = 1 and timestamp > ?))");
+            "select present, namePart, url, compression, fileHash, fileSize, narHash, narSize, refs, deriver, sigs, ca, provenance from NARs where cache = ? and hashPart = ? and ((present = 0 and timestamp > ?) or (present = 1 and timestamp > ?))");
 
         state->insertRealisation.create(
             state->db,
@@ -279,6 +281,8 @@ public:
                 for (auto & sig : tokenizeString<Strings>(queryNAR.getStr(10), " "))
                     narInfo->sigs.insert(sig);
                 narInfo->ca = ContentAddress::parseOpt(queryNAR.getStr(11));
+                if (experimentalFeatureSettings.isEnabled(Xp::Provenance) && !queryNAR.isNull(12))
+                    narInfo->provenance = Provenance::from_json_str_optional(queryNAR.getStr(12));
 
                 return {oValid, narInfo};
             });
@@ -337,8 +341,10 @@ public:
                         narInfo && narInfo->fileHash)(
                         narInfo ? narInfo->fileSize : 0, narInfo != 0 && narInfo->fileSize)(info->narHash.to_string(
                         HashFormat::Nix32, true))(info->narSize)(concatStringsSep(" ", info->shortRefs()))(
-                        info->deriver ? std::string(info->deriver->to_string()) : "", (bool) info->deriver)(
-                        concatStringsSep(" ", info->sigs))(renderContentAddress(info->ca))(time(0))
+                        info->deriver ? std::string(info->deriver->to_string()) : "",
+                        (bool) info->deriver)(concatStringsSep(" ", info->sigs))(renderContentAddress(info->ca))(
+                        info->provenance ? info->provenance->to_json_str() : "",
+                        experimentalFeatureSettings.isEnabled(Xp::Provenance) && info->provenance)(time(0))
                     .exec();
 
             } else {

--- a/tests/functional/flakes/provenance.sh
+++ b/tests/functional/flakes/provenance.sh
@@ -88,6 +88,12 @@ nix copy --to "file://$binaryCache" "$outPath"
 
 clearStore
 
+export _NIX_FORCE_HTTP=1 # force use of the NAR info disk cache
+
+# Check that provenance is cached correctly.
+[[ $(nix path-info --json --json-format 1 --store "file://$binaryCache" "$outPath" | jq ".\"$outPath\".provenance") != null ]]
+[[ $(nix path-info --json --json-format 1 --store "file://$binaryCache" "$outPath" | jq ".\"$outPath\".provenance") != null ]]
+
 nix copy --from "file://$binaryCache" "$outPath" --no-check-sigs
 
 [[ $(nix path-info --json --json-format 1 "$outPath" | jq ".\"$outPath\".provenance") = $(cat <<EOF
@@ -123,6 +129,8 @@ nix copy --from "file://$binaryCache" "$outPath" --no-check-sigs
 }
 EOF
 ) ]]
+
+unset _NIX_FORCE_HTTP
 
 # Test `nix provenance show`.
 [[ $(nix provenance show "$outPath") = $(cat <<EOF


### PR DESCRIPTION
## Motivation

Note: this bumps the cache version to `binary-cache-v8.sqlite`.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provenance is now stored with NAR metadata and surfaced from the local cache for improved traceability.
  * Database schema upgraded to version 8 to support provenance fields; provenance handling is behind an experimental feature toggle.

* **Tests**
  * Added functional tests that validate provenance is recorded and retrieved across HTTP and cached store workflows, including copy-from-cache scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->