### PR TITLE
Increase the open file soft limit to the hard limit

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -15,6 +15,7 @@
 #include <cstdlib>
 #include <sys/time.h>
 #include <sys/stat.h>
+#include <sys/resource.h>
 #include <unistd.h>
 #include <signal.h>
 #ifdef __linux__
@@ -116,6 +117,26 @@ std::string getArg(const std::string & opt, Strings::iterator & i, const Strings
 static void sigHandler(int signo) {}
 #endif
 
+/**
+ * Increase the open file soft limit to the hard limit. On some
+ * platforms (macOS), the default soft limit is very low, but the hard
+ * limit is high. So let's just raise it the maximum permitted.
+ */
+void bumpFileLimit()
+{
+#ifndef _WIN32
+    struct rlimit limit;
+    if (getrlimit(RLIMIT_NOFILE, &limit) != 0)
+        return;
+
+    if (limit.rlim_cur < limit.rlim_max) {
+        limit.rlim_cur = limit.rlim_max;
+        // Ignore errors, this is best effort.
+        setrlimit(RLIMIT_NOFILE, &limit);
+    }
+#endif
+}
+
 void initNix(bool loadConfig)
 {
     /* Turn on buffering for cerr. */
@@ -183,6 +204,8 @@ void initNix(bool loadConfig)
        now.  In particular, store objects should be readable by
        everybody. */
     umask(0022);
+
+    bumpFileLimit();
 }
 
 LegacyArgs::LegacyArgs(


### PR DESCRIPTION
## Motivation

On some platforms (macOS), the default soft limit is very low, but the hard limit is high. So let's just raise it the maximum permitted.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved system-level file descriptor handling on non-Windows platforms to raise the soft limit up to the hard limit where possible.
  * Applied automatically during application initialization as a best-effort step; failures are ignored to avoid impacting startup.
  * Aims to support higher concurrent file operations without changing existing initialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->