### PR TITLE
filetransfer: handle exceptions thrown from enqueueItem

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -965,7 +965,8 @@ struct curlFileTransfer : public FileTransfer
         return ItemHandle(static_cast<Item &>(*item));
     }
 
-    ItemHandle enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) override
+    ItemHandle
+    enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) noexcept override
     {
         /* Handle s3:// URIs by converting to HTTPS and optionally adding auth */
         if (request.uri.scheme() == "s3") {
@@ -1047,7 +1048,7 @@ void FileTransferRequest::setupForS3()
 #endif
 }
 
-std::future<FileTransferResult> FileTransfer::enqueueFileTransfer(const FileTransferRequest & request)
+std::future<FileTransferResult> FileTransfer::enqueueFileTransfer(const FileTransferRequest & request) noexcept
 {
     auto promise = std::make_shared<std::promise<FileTransferResult>>();
     enqueueFileTransfer(request, {[promise](std::future<FileTransferResult> fut) {

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -1053,10 +1053,22 @@ struct curlFileTransfer : public FileTransfer
         if (request.uri.scheme() == "s3") {
             auto modifiedRequest = request;
             modifiedRequest.setupForS3();
-            return enqueueItem(make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback)));
+            auto item = make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback));
+            try {
+                return enqueueItem(item);
+            } catch (const nix::Error & e) {
+                item->fail(e);
+                return ItemHandle(item.get_ptr());
+            }
         }
 
-        return enqueueItem(make_ref<TransferItem>(*this, request, std::move(callback)));
+        auto item = make_ref<TransferItem>(*this, request, std::move(callback));
+        try {
+            return enqueueItem(item);
+        } catch (const nix::Error & e) {
+            item->fail(e);
+            return ItemHandle(item.get_ptr());
+        }
     }
 
     void unpauseTransfer(std::weak_ptr<Item> item)

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -1056,7 +1056,10 @@ struct curlFileTransfer : public FileTransfer
             auto item = make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback));
             try {
                 return enqueueItem(item);
-            } catch (const nix::Error & e) {
+            } catch (const nix::BaseError & e) {
+                // NOTE(cole-h): catches both nix::Error and nix::Interrupted -- enqueueItem calls
+                // writeFull which may throw nix::Interrupted, and the rest of enqueueItem may throw
+                // nix::Error
                 item->fail(e);
                 return ItemHandle(item.get_ptr());
             }
@@ -1065,7 +1068,10 @@ struct curlFileTransfer : public FileTransfer
         auto item = make_ref<TransferItem>(*this, request, std::move(callback));
         try {
             return enqueueItem(item);
-        } catch (const nix::Error & e) {
+        } catch (const nix::BaseError & e) {
+            // NOTE(cole-h): catches both nix::Error and nix::Interrupted -- enqueueItem calls
+            // writeFull which may throw nix::Interrupted, and the rest of enqueueItem may throw
+            // nix::Error
             item->fail(e);
             return ItemHandle(item.get_ptr());
         }

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -1046,26 +1046,24 @@ struct curlFileTransfer : public FileTransfer
         return ItemHandle(item.get_ptr());
     }
 
-    ItemHandle
-    enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) noexcept override
+    inline ref<TransferItem>
+    makeTransferItem(const FileTransferRequest & request, Callback<FileTransferResult> callback)
     {
         /* Handle s3:// URIs by converting to HTTPS and optionally adding auth */
         if (request.uri.scheme() == "s3") {
             auto modifiedRequest = request;
             modifiedRequest.setupForS3();
-            auto item = make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback));
-            try {
-                return enqueueItem(item);
-            } catch (const nix::BaseError & e) {
-                // NOTE(cole-h): catches both nix::Error and nix::Interrupted -- enqueueItem calls
-                // writeFull which may throw nix::Interrupted, and the rest of enqueueItem may throw
-                // nix::Error
-                item->fail(e);
-                return ItemHandle(item.get_ptr());
-            }
+            return make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback));
+        } else {
+            return make_ref<TransferItem>(*this, request, std::move(callback));
         }
+    }
 
-        auto item = make_ref<TransferItem>(*this, request, std::move(callback));
+    ItemHandle
+    enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) noexcept override
+    {
+        const auto item = makeTransferItem(request, std::move(callback));
+
         try {
             return enqueueItem(item);
         } catch (const nix::BaseError & e) {

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -714,7 +714,7 @@ struct curlFileTransfer : public FileTransfer
         };
 
         std::priority_queue<ref<TransferItem>, std::vector<ref<TransferItem>>, EmbargoComparator> incoming;
-        std::vector<ref<TransferItem>> unpause;
+        std::vector<std::weak_ptr<Item>> unpause;
     private:
         bool quitting = false;
     public:
@@ -919,8 +919,15 @@ struct curlFileTransfer : public FileTransfer
                 return res;
             }();
 
-            for (auto & item : unpause)
-                item->unpause();
+            for (auto & item : unpause) {
+                /* The transfer might have completed (failed) between it getting
+                   enqueued for unpause and by the time the worker thread picked
+                   it up. */
+                auto ptr = item.lock();
+                if (!ptr)
+                    continue;
+                static_cast<TransferItem &>(*ptr).unpause();
+            }
         }
 
         debug("download thread shutting down");
@@ -962,7 +969,7 @@ struct curlFileTransfer : public FileTransfer
         writeFull(wakeupPipe.writeSide.get(), " ");
 #endif
 
-        return ItemHandle(static_cast<Item &>(*item));
+        return ItemHandle(item.get_ptr());
     }
 
     ItemHandle
@@ -978,7 +985,7 @@ struct curlFileTransfer : public FileTransfer
         return enqueueItem(make_ref<TransferItem>(*this, request, std::move(callback)));
     }
 
-    void unpauseTransfer(ref<TransferItem> item)
+    void unpauseTransfer(std::weak_ptr<Item> item)
     {
         auto state(state_.lock());
         state->unpause.push_back(std::move(item));
@@ -989,7 +996,9 @@ struct curlFileTransfer : public FileTransfer
 
     void unpauseTransfer(ItemHandle handle) override
     {
-        unpauseTransfer(ref{static_cast<TransferItem &>(handle.item.get()).shared_from_this()});
+        /* The transfer might have completed (more likely failed) when we want
+           to wake it up. That's why we must use a weak_ptr throughout. */
+        unpauseTransfer(handle.item);
     }
 };
 

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -979,10 +979,22 @@ struct curlFileTransfer : public FileTransfer
         if (request.uri.scheme() == "s3") {
             auto modifiedRequest = request;
             modifiedRequest.setupForS3();
-            return enqueueItem(make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback)));
+            auto item = make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback));
+            try {
+                return enqueueItem(item);
+            } catch (const nix::Error & e) {
+                item->fail(e);
+                return ItemHandle(item.get_ptr());
+            }
         }
 
-        return enqueueItem(make_ref<TransferItem>(*this, request, std::move(callback)));
+        auto item = make_ref<TransferItem>(*this, request, std::move(callback));
+        try {
+            return enqueueItem(item);
+        } catch (const nix::Error & e) {
+            item->fail(e);
+            return ItemHandle(item.get_ptr());
+        }
     }
 
     void unpauseTransfer(std::weak_ptr<Item> item)

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -1046,7 +1046,8 @@ struct curlFileTransfer : public FileTransfer
         return ItemHandle(item.get_ptr());
     }
 
-    ItemHandle enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) override
+    ItemHandle
+    enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) noexcept override
     {
         /* Handle s3:// URIs by converting to HTTPS and optionally adding auth */
         if (request.uri.scheme() == "s3") {
@@ -1133,7 +1134,7 @@ void FileTransferRequest::setupForS3()
 #endif
 }
 
-std::future<FileTransferResult> FileTransfer::enqueueFileTransfer(const FileTransferRequest & request)
+std::future<FileTransferResult> FileTransfer::enqueueFileTransfer(const FileTransferRequest & request) noexcept
 {
     auto promise = std::make_shared<std::promise<FileTransferResult>>();
     enqueueFileTransfer(request, {[promise](std::future<FileTransferResult> fut) {

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -1066,11 +1066,11 @@ struct curlFileTransfer : public FileTransfer
 
         try {
             return enqueueItem(item);
-        } catch (const nix::BaseError & e) {
+        } catch (const nix::BaseError &) {
             // NOTE(cole-h): catches both nix::Error and nix::Interrupted -- enqueueItem calls
             // writeFull which may throw nix::Interrupted, and the rest of enqueueItem may throw
             // nix::Error
-            item->fail(e);
+            item->failEx(std::current_exception());
             return ItemHandle(item.get_ptr());
         }
     }

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -982,7 +982,10 @@ struct curlFileTransfer : public FileTransfer
             auto item = make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback));
             try {
                 return enqueueItem(item);
-            } catch (const nix::Error & e) {
+            } catch (const nix::BaseError & e) {
+                // NOTE(cole-h): catches both nix::Error and nix::Interrupted -- enqueueItem calls
+                // writeFull which may throw nix::Interrupted, and the rest of enqueueItem may throw
+                // nix::Error
                 item->fail(e);
                 return ItemHandle(item.get_ptr());
             }
@@ -991,7 +994,10 @@ struct curlFileTransfer : public FileTransfer
         auto item = make_ref<TransferItem>(*this, request, std::move(callback));
         try {
             return enqueueItem(item);
-        } catch (const nix::Error & e) {
+        } catch (const nix::BaseError & e) {
+            // NOTE(cole-h): catches both nix::Error and nix::Interrupted -- enqueueItem calls
+            // writeFull which may throw nix::Interrupted, and the rest of enqueueItem may throw
+            // nix::Error
             item->fail(e);
             return ItemHandle(item.get_ptr());
         }

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -279,14 +279,14 @@ public:
      * exception.
      */
     virtual ItemHandle
-    enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) = 0;
+    enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) noexcept = 0;
 
     /**
      * Unpause a transfer that has been previously paused by a dataCallback.
      */
     virtual void unpauseTransfer(ItemHandle handle) = 0;
 
-    std::future<FileTransferResult> enqueueFileTransfer(const FileTransferRequest & request);
+    std::future<FileTransferResult> enqueueFileTransfer(const FileTransferRequest & request) noexcept;
 
     /**
      * Synchronously download a file.

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -354,14 +354,14 @@ public:
      * exception.
      */
     virtual ItemHandle
-    enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) = 0;
+    enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) noexcept = 0;
 
     /**
      * Unpause a transfer that has been previously paused by a dataCallback.
      */
     virtual void unpauseTransfer(ItemHandle handle) = 0;
 
-    std::future<FileTransferResult> enqueueFileTransfer(const FileTransferRequest & request);
+    std::future<FileTransferResult> enqueueFileTransfer(const FileTransferRequest & request) noexcept;
 
     /**
      * Synchronously download a file.

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -262,10 +262,10 @@ public:
      */
     struct ItemHandle
     {
-        std::reference_wrapper<Item> item;
+        std::weak_ptr<Item> item;
         friend struct FileTransfer;
 
-        ItemHandle(Item & item)
+        explicit ItemHandle(std::weak_ptr<Item> item)
             : item(item)
         {
         }


### PR DESCRIPTION
## Motivation

Includes backport of https://github.com/NixOS/nix/pull/15604

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enqueueing file transfers is now non-throwing; failures are recorded per-transfer and returned as failed handles instead of raising exceptions, improving stability for regular and cloud uploads.

* **Refactor**
  * Transfer handle and lifetime management updated to use safer, weaker references for queued/unpaused items, reducing unexpected errors and improving robustness of create/enqueue/unpause flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->