### PR TITLE
Upstream C store API improvements

### DIFF
--- a/doc/manual/rl-next/c-api-new-store-methods.md
+++ b/doc/manual/rl-next/c-api-new-store-methods.md
@@ -6,3 +6,4 @@ prs: [14766]
 The C API now includes additional methods:
 
 - `nix_store_query_path_from_hash_part()` - Get the full store path given its hash part
+- `nix_store_copy_path()` - Copy a single store path between two stores, allows repairs and configuring signature checking

--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -469,4 +469,26 @@ StorePath * nix_store_query_path_from_hash_part(nix_c_context * context, Store *
     NIXC_CATCH_ERRS_NULL
 }
 
+nix_err nix_store_copy_path(
+    nix_c_context * context, Store * srcStore, Store * dstStore, const StorePath * path, bool repair, bool checkSigs)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        if (srcStore == nullptr)
+            return nix_set_err_msg(context, NIX_ERR_UNKNOWN, "Source store is null");
+
+        if (dstStore == nullptr)
+            return nix_set_err_msg(context, NIX_ERR_UNKNOWN, "Destination store is null");
+
+        if (path == nullptr)
+            return nix_set_err_msg(context, NIX_ERR_UNKNOWN, "Store path is null");
+
+        auto repairFlag = repair ? nix::RepairFlag::Repair : nix::RepairFlag::NoRepair;
+        auto checkSigsFlag = checkSigs ? nix::CheckSigsFlag::CheckSigs : nix::CheckSigsFlag::NoCheckSigs;
+        nix::copyStorePath(*srcStore->ptr, *dstStore->ptr, path->path, repairFlag, checkSigsFlag);
+    }
+    NIXC_CATCH_ERRS
+}
+
 } // extern "C"

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -368,6 +368,19 @@ nix_err nix_derivation_to_json(
  */
 StorePath * nix_store_query_path_from_hash_part(nix_c_context * context, Store * store, const char * hash);
 
+/**
+ * @brief Copy a path from one store to another.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] srcStore nix source store reference
+ * @param[in] dstStore nix destination store reference
+ * @param[in] path The path to copy
+ * @param[in] repair Whether to repair the path
+ * @param[in] checkSigs Whether to check path signatures are trusted before copying
+ */
+nix_err nix_store_copy_path(
+    nix_c_context * context, Store * srcStore, Store * dstStore, const StorePath * path, bool repair, bool checkSigs);
+
 // cffi end
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Motivation

Merge upstream PRs https://github.com/NixOS/nix/pull/14766, https://github.com/NixOS/nix/pull/14768.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new C API methods: one to query the full store path from a hash part, and another to copy a single store path between stores with optional repair and signature-check configuration.

* **Documentation**
  * Added documentation describing the new C API methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->