### PR TITLE
Record provenance for unlocked inputs and impure evaluations

### DIFF
--- a/src/libcmd/installable-flake.cc
+++ b/src/libcmd/installable-flake.cc
@@ -219,12 +219,10 @@ FlakeRef InstallableFlake::nixpkgsFlakeRef() const
 
 std::shared_ptr<const Provenance> InstallableFlake::makeProvenance(std::string_view attrPath) const
 {
-    if (!evalSettings.pureEval)
-        return nullptr;
     auto provenance = getLockedFlake()->flake.provenance;
     if (!provenance)
         return nullptr;
-    return std::make_shared<const FlakeProvenance>(provenance, std::string(attrPath));
+    return std::make_shared<const FlakeProvenance>(provenance, std::string(attrPath), evalSettings.pureEval);
 }
 
 } // namespace nix

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -338,8 +338,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(const Settings
                 {{"hash", store.queryPathInfo(*storePath)->narHash.to_string(HashFormat::SRI, true)}});
         }
 
-        if (isLocked(settings))
-            accessor->provenance = std::make_shared<TreeProvenance>(*this);
+        accessor->provenance = std::make_shared<TreeProvenance>(*this);
 
         // FIXME: ideally we would use the `showPath()` of the
         // "real" accessor for this fetcher type.
@@ -365,8 +364,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(const Settings
         else
             accessor->fingerprint = result.getFingerprint(store);
 
-        if (result.isLocked(settings))
-            accessor->provenance = std::make_shared<TreeProvenance>(result);
+        accessor->provenance = std::make_shared<TreeProvenance>(result);
 
         return {accessor, std::move(result)};
     } catch (Error & e) {

--- a/src/libflake/include/nix/flake/provenance.hh
+++ b/src/libflake/include/nix/flake/provenance.hh
@@ -8,10 +8,12 @@ struct FlakeProvenance : Provenance
 {
     std::shared_ptr<const Provenance> next;
     std::string flakeOutput;
+    bool pure = true;
 
-    FlakeProvenance(std::shared_ptr<const Provenance> next, std::string flakeOutput)
+    FlakeProvenance(std::shared_ptr<const Provenance> next, std::string flakeOutput, bool pure)
         : next(std::move(next))
-        , flakeOutput(std::move(flakeOutput)) {};
+        , flakeOutput(std::move(flakeOutput))
+        , pure(pure) {};
 
     nlohmann::json to_json() const override;
 };

--- a/src/libflake/provenance.cc
+++ b/src/libflake/provenance.cc
@@ -11,7 +11,7 @@ nlohmann::json FlakeProvenance::to_json() const
         {"type", "flake"},
         {"next", next ? next->to_json() : nlohmann::json(nullptr)},
         {"flakeOutput", flakeOutput},
-    };
+        {"pure", pure}};
 }
 
 Provenance::Register registerFlakeProvenance("flake", [](nlohmann::json json) {
@@ -19,7 +19,10 @@ Provenance::Register registerFlakeProvenance("flake", [](nlohmann::json json) {
     std::shared_ptr<const Provenance> next;
     if (auto p = optionalValueAt(obj, "next"); p && !p->is_null())
         next = Provenance::from_json(*p);
-    return make_ref<FlakeProvenance>(next, getString(valueAt(obj, "flakeOutput")));
+    bool pure = true;
+    if (auto p = optionalValueAt(obj, "pure"))
+        pure = getBoolean(*p);
+    return make_ref<FlakeProvenance>(next, getString(valueAt(obj, "flakeOutput")), pure);
 });
 
 } // namespace nix

--- a/src/nix/provenance.cc
+++ b/src/nix/provenance.cc
@@ -79,7 +79,9 @@ struct CmdProvenanceShow : StorePathsCommand
                         fetchers::Input::fromAttrs(fetchSettings, fetchers::jsonToAttrs(*tree->attrs)),
                         Path(flakePath.parent().value_or(CanonPath::root).rel()));
                     logger->cout(
-                        "← instantiated from flake output " ANSI_BOLD "%s#%s" ANSI_NORMAL,
+                        "← %sinstantiated from %sflake output " ANSI_BOLD "%s#%s" ANSI_NORMAL,
+                        flake->pure ? "" : ANSI_RED "impurely" ANSI_NORMAL " ",
+                        flakeRef.input.isLocked(fetchSettings) ? "" : ANSI_RED "unlocked" ANSI_NORMAL " ",
                         flakeRef.to_string(),
                         flake->flakeOutput);
                     break;
@@ -89,7 +91,10 @@ struct CmdProvenanceShow : StorePathsCommand
                 }
             } else if (auto tree = std::dynamic_pointer_cast<const TreeProvenance>(provenance)) {
                 auto input = fetchers::Input::fromAttrs(fetchSettings, fetchers::jsonToAttrs(*tree->attrs));
-                logger->cout("← from tree " ANSI_BOLD "%s" ANSI_NORMAL, input.to_string());
+                logger->cout(
+                    "← from %stree " ANSI_BOLD "%s" ANSI_NORMAL,
+                    input.isLocked(fetchSettings) ? "" : ANSI_RED "unlocked" ANSI_NORMAL " ",
+                    input.to_string());
                 break;
             } else if (auto subpath = std::dynamic_pointer_cast<const SubpathProvenance>(provenance)) {
                 logger->cout("← from file " ANSI_BOLD "%s" ANSI_NORMAL, subpath->subpath.abs());


### PR DESCRIPTION
## Motivation

Example output of `nix provenance show`:

```
/tmp/nix-shell.c1UHuB/nix-test/flakes/provenance/store/p823ak1m2pg2narq0mby78pys5v7y63v-simple
← built from derivation /tmp/nix-shell.c1UHuB/nix-test/flakes/provenance/store/ckzp98sn9ck87gmrsivi6dki6wi8q0lr-simple.drv (output out) on test-host for x86_64-linux
← with derivation metadata
    Licenses:
        - lgpl21
← impurely instantiated from unlocked flake output git+file:///tmp/nix-shell.c1UHuB/nix-test/flakes/provenance/flake1#packages.x86_64-linux.default
```


<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provenance tracking now includes purity and lock status indicators for flake sources
  * Enhanced provenance display output shows whether flakes and sources are locked or unlocked

* **Tests**
  * Updated test cases to validate new provenance metadata and display formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->