### PR TITLE
Add setting narinfo-cache-meta-ttl

### DIFF
--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -1057,6 +1057,17 @@ public:
           mismatch if the build isn't reproducible.
         )"};
 
+    Setting<unsigned int> ttlNarInfoCacheMeta{
+        this,
+        7 * 24 * 3600,
+        "narinfo-cache-meta-ttl",
+        R"(
+          The TTL in seconds for caching binary cache metadata (i.e.
+          `/nix-cache-info`). This determines how long information about a
+          binary cache (such as its store directory, priority, and whether it
+          wants mass queries) is considered valid before being refreshed.
+        )"};
+
     Setting<bool> printMissing{
         this, true, "print-missing", "Whether to print what paths need to be built or downloaded."};
 

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -67,9 +67,6 @@ public:
     /* How often to purge expired entries from the cache. */
     const int purgeInterval = 24 * 3600;
 
-    /* How long to cache binary cache info (i.e. /nix-cache-info) */
-    const int cacheInfoTtl = 7 * 24 * 3600;
-
     struct Cache
     {
         int id;
@@ -184,7 +181,7 @@ private:
     {
         auto i = state.caches.find(uri);
         if (i == state.caches.end()) {
-            auto queryCache(state.queryCache.use()(uri)(time(0) - cacheInfoTtl));
+            auto queryCache(state.queryCache.use()(uri)(time(0) - settings.ttlNarInfoCacheMeta));
             if (!queryCache.next())
                 return std::nullopt;
             auto cache = Cache{

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -94,6 +94,8 @@ static void disableNet()
         settings.useSubstitutes = false;
     if (!settings.tarballTtl.overridden)
         settings.tarballTtl = std::numeric_limits<unsigned int>::max();
+    if (!settings.ttlNarInfoCacheMeta.overridden)
+        settings.ttlNarInfoCacheMeta = std::numeric_limits<unsigned int>::max();
     if (!fileTransferSettings.tries.overridden)
         fileTransferSettings.tries = 0;
     if (!fileTransferSettings.connectTimeout.overridden)
@@ -568,6 +570,7 @@ void mainWrapped(int argc, char ** argv)
         settings.tarballTtl = 0;
         settings.ttlNegativeNarInfoCache = 0;
         settings.ttlPositiveNarInfoCache = 0;
+        settings.ttlNarInfoCacheMeta = 0;
     }
 
     if (args.command->second->forceImpureByDefault() && !evalSettings.pureEval.overridden) {


### PR DESCRIPTION

## Motivation

This makes the current hard-coded 7-day `nix-cache-info` TTL configurable, making `--offline` and `--refresh` do the right thing.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable TTL for NarInfo metadata cache (narinfo-cache-meta-ttl), defaulting to 7 days.

* **Bug Fixes**
  * Improved offline and refresh behavior to correctly invalidate NarInfo metadata cache when requested.

* **Tests**
  * Added functional tests verifying NarInfo metadata caching with HTTP and the effect of --refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->