### PR TITLE
libstore/filetransfer: Fix double callback on enqueueFileTransfer that is shutting down

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -59,7 +59,7 @@ struct curlFileTransfer : public FileTransfer
         char errbuf[CURL_ERROR_SIZE];
         bool active = false;   // whether the handle has been added to the multi object
         bool paused = false;   // whether the request has been paused previously
-        bool enqueued = false; // whether the request has been added the incoming queue
+        bool enqueued = false; // whether the request has been added to the incoming queue
         std::string statusMsg;
 
         unsigned int attempt = 0;


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents spurious "interrupted" errors for transfers that were never queued.
  * Ensures transfer enqueue state is correctly set across all download paths to avoid false failure reports.
  * Improves internal handling so transfer completion and error reporting are more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->