### PR TITLE
Merge builtins.wasm and builtins.wasi into one function

### DIFF
--- a/doc/manual/source/protocols/wasm.md
+++ b/doc/manual/source/protocols/wasm.md
@@ -42,7 +42,7 @@ Every Wasm module used in non-WASI mode must export:
 
 ### WASI Mode
 
-WASI mode is automatically used when the module exports a `_start` function.
+WASI mode is automatically used when the module imports a `wasi_snapshot_preview1` function.
 
 Usage:
 ```nix
@@ -357,7 +357,7 @@ Returns a result value to the Nix evaluator from a WASI module. This function is
 **Parameters:**
 - `value` - ID of the Nix value to return as the result of the `builtins.wasm` call
 
-**Note:** Calling this function immediately terminates the WASI module's execution. The module's `_start` function must call `return_to_nix` before finishing; otherwise, an error is raised.
+**Note:** Calling this function immediately terminates the WASI module's execution. The module must call `return_to_nix` before finishing; otherwise, an error is raised.
 
 ### File I/O
 

--- a/src/libexpr/primops/wasm.cc
+++ b/src/libexpr/primops/wasm.cc
@@ -612,7 +612,7 @@ static void prim_wasm(EvalState & state, const PosIdx pos, Value ** args, Value 
         if (instance.pre->useWasi) {
             functionName = "_start";
             if (functionAttr)
-                throw Error("'function' attribute is not allowed for WASI modules (modules with a '_start' export)");
+                throw Error("'function' attribute is not allowed for WASI modules");
         } else {
             if (!functionAttr)
                 throw Error(
@@ -680,7 +680,7 @@ static RegisterPrimOp primop_wasm(
 
       The second argument is the value to pass to the function.
 
-      WASI mode is automatically detected by checking if the module exports a `_start` function.
+      WASI mode is automatically enabled if the module imports from `wasi_snapshot_preview1`.
 
       Example (non-WASI):
       ```nix


### PR DESCRIPTION
## Motivation

The new interface is

```nix
builtins.wasm {
  path = ./path/to/file.wasm;
  function = "fib";
} 33
```

This will allow other Wasm-related configuration to be added in the future (e.g. WASI features, memory limits, caching info, etc).

The argument is separate from the configuration because typically you want to write something like
```nix
let
  fib = builtins.wasm {
    path = ./path/to/file.wasm;
    function = "fib";
  };
in fib 33
```

It now also auto-detects whether a module uses WASI.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked Wasm host docs into a single unified interface describing WASI vs non‑WASI modes, automatic WASI detection, updated examples, and clarified return/error semantics (WASI-only return path). Host imports now documented under the env module; removed prior dual‑interface narrative.

* **Refactor**
  * Unified Wasm invocation into one configurable call accepting a config set (path + function) and an argument. Non‑WASI modules require an init export invoked on instantiation; WASI modules use standard WASI entry/argv semantics. Module caching simplified to per‑path; WASI IO routed through host logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->