### PR TITLE
fixup: don't check accessibility of embedded sandbox shell

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -884,7 +884,11 @@ PathsInChroot DerivationBuilderImpl::getPathsInSandbox()
     PathsInChroot pathsInChroot = defaultPathsInChroot;
 
     for (auto & p : pathsInChroot)
-        if (!p.second.optional && !maybeLstat(p.second.source))
+        if (!p.second.optional
+#if HAVE_EMBEDDED_SANDBOX_SHELL
+            && p.second.source != SANDBOX_SHELL
+#endif
+            && !maybeLstat(p.second.source))
             throw SysError(
                 "path '%s' is configured as part of the `sandbox-paths` option, but is inaccessible", p.second.source);
 


### PR DESCRIPTION
It's just a placeholder value that gets replaced with the actual embedded sandbox shell.

Without this, the static tests were failing like so:

    nix-functional-tests-static-x86_64-unknown-linux-musl> + drvPath=/nix/store/fcv4wnnq92j5kcd9h2pv62zdlibi93ws-hermetic.drv
    nix-functional-tests-static-x86_64-unknown-linux-musl> ++ nix-store --store /build/nix-test/local-overlay-store/stale-file-handle/stores/store-a --realise /nix/store/fcv4wnnq92j5kcd9h2pv62zdlibi93ws-hermetic.drv
    nix-functional-tests-static-x86_64-unknown-linux-musl> these 4 derivations will be built:
    nix-functional-tests-static-x86_64-unknown-linux-musl>   /nix/store/a7a8i4xq2fsvvj83vx00i2syivx7hvpl-hermetic-input-2.drv
    nix-functional-tests-static-x86_64-unknown-linux-musl>   /nix/store/laasqwvh1blw8hjylawbvm02qa4dwa9h-hermetic-input-1.drv
    nix-functional-tests-static-x86_64-unknown-linux-musl>   /nix/store/y8lskgg8s81sc97p7mz3bwpxasx28mbi-hermetic-input-3.drv
    nix-functional-tests-static-x86_64-unknown-linux-musl>   /nix/store/fcv4wnnq92j5kcd9h2pv62zdlibi93ws-hermetic.drv
    nix-functional-tests-static-x86_64-unknown-linux-musl> error: path '__embedded_sandbox_shell__' is configured as part of the `sandbox-paths` option, but is inaccessible: No such file or directory
    nix-functional-tests-static-x86_64-unknown-linux-musl> + pathInLowerStore=
    nix-functional-tests-static-x86_64-unknown-linux-musl>
    nix-functional-tests-static-x86_64-unknown-linux-musl>
    nix-functional-tests-static-x86_64-unknown-linux-musl> 192/209 nix-functional-tests:local-overlay-store / verify                            FAIL            0.66s   exit status 1

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue causing false accessibility validation errors when an embedded sandbox shell is present, preventing unnecessary build failures and improving reliability during sandboxed builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->