### PR TITLE
Add test for nix_store_build_paths

### DIFF
--- a/src/libstore-tests/nix_api_store.cc
+++ b/src/libstore-tests/nix_api_store.cc
@@ -955,4 +955,55 @@ TEST_F(nix_api_store_test, nix_derivation_clone)
     nix_derivation_free(drv2);
 }
 
+TEST_F(nix_api_store_test, nix_store_build_paths)
+{
+    nix::experimentalFeatureSettings.set("extra-experimental-features", "ca-derivations");
+    nix::settings.substituters = {};
+
+    auto * store = open_local_store();
+
+    std::filesystem::path unitTestData{getenv("_NIX_TEST_UNIT_DATA")};
+    std::ifstream t{unitTestData / "derivation/ca/self-contained.json"};
+    std::stringstream buffer;
+    buffer << t.rdbuf();
+
+    // Replace the hardcoded system with the current system
+    std::string jsonStr = nix::replaceStrings(buffer.str(), "x86_64-linux", nix::settings.thisSystem.get());
+
+    auto * drv = nix_derivation_from_json(ctx, store, jsonStr.c_str());
+    assert_ctx_ok();
+    ASSERT_NE(drv, nullptr);
+
+    auto * drvPath = nix_add_derivation(ctx, store, drv);
+    assert_ctx_ok();
+    ASSERT_NE(drv, nullptr);
+
+    // Realise the derivation - capture the order outputs are returned
+    std::map<std::string, std::string> outputs;
+    std::vector<std::string> output_order;
+    auto cb = LambdaAdapter{.fun = [&](const char * path, const char * result) {
+        ASSERT_NE(path, nullptr);
+        ASSERT_NE(result, nullptr);
+        output_order.push_back(path);
+        outputs.emplace(path, result);
+    }};
+
+    std::vector<StorePath *> paths = {drvPath};
+
+    auto ret = nix_store_build_paths(
+        ctx,
+        store,
+        const_cast<const StorePath **>(paths.data()),
+        paths.size(),
+        decltype(cb)::call_void<const char *, const char *>,
+        static_cast<void *>(&cb));
+    assert_ctx_ok();
+    ASSERT_EQ(ret, NIX_OK);
+    ASSERT_EQ(outputs.size(), 1);
+
+    nix_store_path_free(drvPath);
+    nix_derivation_free(drv);
+    nix_store_free(store);
+}
+
 } // namespace nixC


### PR DESCRIPTION
## Motivation

Adds a test for `nix_store_build_paths`

## Context

In #210, we added `nix_store_build_paths`. While upstreaming in https://github.com/NixOS/nix/pull/15352, a test was added to ensure this function works.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for building derivations with content-addressed storage support, validating JSON derivation loading, creation, storage, and execution with proper output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->