### PR TITLE
Fix crash in `nix repl` loading an invalid WASM file twice

### DIFF
--- a/src/libexpr/primops/wasm.cc
+++ b/src/libexpr/primops/wasm.cc
@@ -533,20 +533,29 @@ static void regFuns(Linker & linker, bool useWasi)
     }
 }
 
+template<typename T>
+struct LazyMakeRef
+{
+    ref<T> p;
+
+    template<typename... Args>
+    LazyMakeRef(Args &&... args)
+        : p(make_ref<T>(std::move(args...)))
+    {
+    }
+};
+
 static NixWasmInstance instantiateWasm(EvalState & state, const SourcePath & wasmPath)
 {
     // FIXME: make this a weak Boehm GC pointer so that it can be freed during GC.
     // FIXME: move to EvalState?
     // Note: InstancePre in Rust is Send+Sync so it should be safe to share between threads.
-    static boost::concurrent_flat_map<SourcePath, std::shared_ptr<NixWasmInstancePre>> instancesPre;
+    static boost::concurrent_flat_map<SourcePath, LazyMakeRef<NixWasmInstancePre>> instancesPre;
 
     std::shared_ptr<NixWasmInstancePre> instancePre;
 
     instancesPre.try_emplace_and_cvisit(
-        wasmPath,
-        nullptr,
-        [&](auto & i) { instancePre = i.second = std::make_shared<NixWasmInstancePre>(wasmPath); },
-        [&](auto & i) { instancePre = i.second; });
+        wasmPath, wasmPath, [&](auto & i) { instancePre = i.second.p; }, [&](auto & i) { instancePre = i.second.p; });
 
     return NixWasmInstance{state, ref(instancePre)};
 }


### PR DESCRIPTION


## Motivation

We now ensure that there are never any null pointers in `instancesPre`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized WASM module instance caching to improve initialization performance and reduce memory overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->