### PR TITLE
Preserve provenance while copying paths to the daemon

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -521,7 +521,9 @@ static void performOp(
                     *store,
                     WorkerProto::ReadConn{
                         .from = source,
-                        .version = {.number = {.major = 1, .minor = 16}},
+                        .version = conn.protoVersion.features.contains(WorkerProto::featureVersionedAddToStoreMultiple)
+                                       ? conn.protoVersion
+                                       : WorkerProto::Version{.number = {.major = 1, .minor = 16}},
                     });
                 info.ultimate = false;
                 EnsureRead wrapper{source, info.narSize};

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -515,7 +515,19 @@ static void performOp(
         logger->startWork();
         {
             FramedSource source(conn.from);
-            store->addMultipleToStore(source, RepairFlag{repair}, dontCheckSigs ? NoCheckSigs : CheckSigs);
+            auto expected = readNum<uint64_t>(source);
+            for (uint64_t i = 0; i < expected; ++i) {
+                auto info = WorkerProto::Serialise<ValidPathInfo>::read(
+                    *store,
+                    WorkerProto::ReadConn{
+                        .from = source,
+                        .version = {.number = {.major = 1, .minor = 16}},
+                    });
+                info.ultimate = false;
+                EnsureRead wrapper{source, info.narSize};
+                store->addToStore(info, wrapper, RepairFlag{repair}, dontCheckSigs ? NoCheckSigs : CheckSigs);
+                wrapper.finish();
+            }
         }
         logger->stopWork();
         break;

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -103,8 +103,6 @@ struct RemoteStore : public virtual Store,
 
     void addToStore(const ValidPathInfo & info, Source & nar, RepairFlag repair, CheckSigsFlag checkSigs) override;
 
-    void addMultipleToStore(Source & source, RepairFlag repair, CheckSigsFlag checkSigs) override;
-
     void
     addMultipleToStore(PathsSource && pathsToCopy, Activity & act, RepairFlag repair, CheckSigsFlag checkSigs) override;
 

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -571,8 +571,6 @@ public:
     /**
      * Import multiple paths into the store.
      */
-    virtual void addMultipleToStore(Source & source, RepairFlag repair = NoRepair, CheckSigsFlag checkSigs = CheckSigs);
-
     virtual void addMultipleToStore(
         PathsSource && pathsToCopy, Activity & act, RepairFlag repair = NoRepair, CheckSigsFlag checkSigs = CheckSigs);
 

--- a/src/libstore/include/nix/store/worker-protocol-connection.hh
+++ b/src/libstore/include/nix/store/worker-protocol-connection.hh
@@ -36,7 +36,6 @@ struct WorkerProto::BasicConnection
         return WorkerProto::ReadConn{
             .from = from,
             .version = protoVersion,
-            .provenance = protoVersion.features.contains(WorkerProto::featureProvenance),
         };
     }
 
@@ -53,7 +52,6 @@ struct WorkerProto::BasicConnection
         return WorkerProto::WriteConn{
             .to = to,
             .version = protoVersion,
-            .provenance = protoVersion.features.contains(WorkerProto::featureProvenance),
         };
     }
 };

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -111,6 +111,7 @@ struct WorkerProto
 
     static constexpr std::string_view featureQueryActiveBuilds = "queryActiveBuilds";
     static constexpr std::string_view featureProvenance = "provenance";
+    static constexpr std::string_view featureVersionedAddToStoreMultiple = "versionedAddToStoreMultiple";
 
     /**
      * A unidirectional read connection, to be used by the read half of the

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -122,7 +122,6 @@ struct WorkerProto
         Source & from;
         const Version & version;
         bool shortStorePaths = false;
-        bool provenance = false;
     };
 
     /**
@@ -134,7 +133,6 @@ struct WorkerProto
         Sink & to;
         const Version & version;
         bool shortStorePaths = false;
-        bool provenance = false;
     };
 
     /**

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -496,7 +496,9 @@ void RemoteStore::addMultipleToStore(
                 *this,
                 WorkerProto::WriteConn{
                     .to = sink,
-                    .version = {.number = {.major = 1, .minor = 16}},
+                    .version = conn->protoVersion.features.contains(WorkerProto::featureVersionedAddToStoreMultiple)
+                                   ? conn->protoVersion
+                                   : WorkerProto::Version{.number = {.major = 1, .minor = 16}},
                 },
                 pathInfo);
             pathSource->drainInto(sink);

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -469,6 +469,13 @@ void RemoteStore::addToStore(const ValidPathInfo & info, Source & source, Repair
 void RemoteStore::addMultipleToStore(
     PathsSource && pathsToCopy, Activity & act, RepairFlag repair, CheckSigsFlag checkSigs)
 {
+    if (getConnection()->protoVersion < WorkerProto::Version{.number = {1, 32}}) {
+        Store::addMultipleToStore(std::move(pathsToCopy), act, repair, checkSigs);
+        return;
+    }
+
+    auto conn(getConnection());
+
     // `addMultipleToStore` is single threaded
     size_t bytesExpected = 0;
     for (auto & [pathInfo, _] : pathsToCopy) {
@@ -497,17 +504,8 @@ void RemoteStore::addMultipleToStore(
         }
     });
 
-    addMultipleToStore(*source, repair, checkSigs);
-}
-
-void RemoteStore::addMultipleToStore(Source & source, RepairFlag repair, CheckSigsFlag checkSigs)
-{
-    if (getConnection()->protoVersion >= WorkerProto::Version{.number = {1, 32}}) {
-        auto conn(getConnection());
-        conn->to << WorkerProto::Op::AddMultipleToStore << repair << !checkSigs;
-        conn.withFramedSink([&](Sink & sink) { source.drainInto(sink); });
-    } else
-        Store::addMultipleToStore(source, repair, checkSigs);
+    conn->to << WorkerProto::Op::AddMultipleToStore << repair << !checkSigs;
+    conn.withFramedSink([&](Sink & sink) { source->drainInto(sink); });
 }
 
 void RemoteStore::registerDrvOutput(const Realisation & info)

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -469,7 +469,7 @@ void RemoteStore::addToStore(const ValidPathInfo & info, Source & source, Repair
 void RemoteStore::addMultipleToStore(
     PathsSource && pathsToCopy, Activity & act, RepairFlag repair, CheckSigsFlag checkSigs)
 {
-    if (getConnection()->protoVersion < WorkerProto::Version{.number = {1, 32}}) {
+    if (getConnection()->protoVersion.number < WorkerProto::Version::Number{1, 32}) {
         Store::addMultipleToStore(std::move(pathsToCopy), act, repair, checkSigs);
         return;
     }

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -224,25 +224,6 @@ void Store::addMultipleToStore(PathsSource && pathsToCopy, Activity & act, Repai
         });
 }
 
-void Store::addMultipleToStore(Source & source, RepairFlag repair, CheckSigsFlag checkSigs)
-{
-    auto expected = readNum<uint64_t>(source);
-    for (uint64_t i = 0; i < expected; ++i) {
-        // FIXME we should not be using the worker protocol here, let
-        // alone the worker protocol with a hard-coded version!
-        auto info = WorkerProto::Serialise<ValidPathInfo>::read(
-            *this,
-            WorkerProto::ReadConn{
-                .from = source,
-                .version = {.number = {.major = 1, .minor = 16}},
-            });
-        info.ultimate = false;
-        EnsureRead wrapper{source, info.narSize};
-        addToStore(info, wrapper, repair, checkSigs);
-        wrapper.finish();
-    }
-}
-
 /*
 The aim of this function is to compute in one pass the correct ValidPathInfo for
 the files that we are trying to add to the store. To accomplish that in one

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -14,9 +14,6 @@
 #include "nix/util/callback.hh"
 #include "nix/util/git.hh"
 #include "nix/util/posix-source-accessor.hh"
-// FIXME this should not be here, see TODO below on
-// `addMultipleToStore`.
-#include "nix/store/worker-protocol.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/environment-variables.hh"
 #include "nix/util/file-system.hh"

--- a/src/libstore/worker-protocol.cc
+++ b/src/libstore/worker-protocol.cc
@@ -353,7 +353,7 @@ UnkeyedValidPathInfo WorkerProto::Serialise<UnkeyedValidPathInfo>::read(const St
         info.sigs = WorkerProto::Serialise<std::set<Signature>>::read(store, conn);
         info.ca = ContentAddress::parseOpt(readString(conn.from));
     }
-    if (conn.provenance)
+    if (conn.version.features.contains(WorkerProto::featureProvenance))
         info.provenance = Provenance::from_json_str_optional(readString(conn.from));
     return info;
 }
@@ -370,7 +370,7 @@ void WorkerProto::Serialise<UnkeyedValidPathInfo>::write(
         WorkerProto::write(store, conn, pathInfo.sigs);
         conn.to << renderContentAddress(pathInfo.ca);
     }
-    if (conn.provenance)
+    if (conn.version.features.contains(WorkerProto::featureProvenance))
         conn.to << (pathInfo.provenance ? pathInfo.provenance->to_json_str() : "");
 }
 

--- a/src/libstore/worker-protocol.cc
+++ b/src/libstore/worker-protocol.cc
@@ -25,6 +25,7 @@ const WorkerProto::Version WorkerProto::latest = {
         {
             std::string{WorkerProto::featureQueryActiveBuilds},
             std::string{WorkerProto::featureProvenance},
+            std::string{WorkerProto::featureVersionedAddToStoreMultiple},
         },
 };
 


### PR DESCRIPTION
## Motivation

Fixes #369.

Depends on #386.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protocol support for versioned bulk store operations.

* **Refactor**
  * Removed legacy API overload for bulk additions; bulk ingest now streams items per request.
  * Improved version-aware protocol negotiation for bulk adds.
  * Removed connection-level provenance option from the worker protocol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->