### PR TITLE
Fix lookupPathResolved thread safety

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -332,6 +332,7 @@ EvalState::EvalState(
     , importResolutionCache(make_ref<decltype(importResolutionCache)::element_type>())
     , fileEvalCache(make_ref<decltype(fileEvalCache)::element_type>())
     , positionToDocComment(make_ref<decltype(positionToDocComment)::element_type>())
+    , lookupPathResolved(make_ref<decltype(lookupPathResolved)::element_type>())
     , regexCache(makeRegexCache())
 #if NIX_USE_BOEHMGC
     , baseEnvP(std::allocate_shared<Env *>(traceable_allocator<Env *>(), &mem.allocEnv(BASE_ENV_SIZE)))
@@ -3219,16 +3220,15 @@ SourcePath EvalState::findFile(const LookupPath & lookupPath, const std::string_
 std::optional<SourcePath> EvalState::resolveLookupPathPath(const LookupPath::Path & value0, bool initAccessControl)
 {
     auto & value = value0.s;
-    auto i = lookupPathResolved.find(value);
-    if (i != lookupPathResolved.end())
-        return i->second;
+    if (auto cached = getConcurrent(*lookupPathResolved, value))
+        return *cached;
 
     auto finish = [&](std::optional<SourcePath> res) {
         if (res)
             debug("resolved search path element '%s' to '%s'", value, *res);
         else
             debug("failed to resolve search path element '%s'", value);
-        lookupPathResolved.emplace(value, res);
+        lookupPathResolved->emplace(std::string(value), res);
         return res;
     };
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -331,6 +331,7 @@ EvalState::EvalState(
     , srcToStore(make_ref<decltype(srcToStore)::element_type>())
     , importResolutionCache(make_ref<decltype(importResolutionCache)::element_type>())
     , fileEvalCache(make_ref<decltype(fileEvalCache)::element_type>())
+    , positionToDocComment(make_ref<decltype(positionToDocComment)::element_type>())
     , regexCache(makeRegexCache())
 #if NIX_USE_BOEHMGC
     , baseEnvP(std::allocate_shared<Env *>(traceable_allocator<Env *>(), &mem.allocEnv(BASE_ENV_SIZE)))
@@ -3287,18 +3288,20 @@ Expr * EvalState::parse(
     const SourcePath & basePath,
     const std::shared_ptr<StaticEnv> & staticEnv)
 {
-    DocCommentMap tmpDocComments; // Only used when not origin is not a SourcePath
-    auto * docComments = &tmpDocComments;
+    auto tmpDocComments = make_ref<DocCommentMap>();
 
-    if (auto sourcePath = std::get_if<SourcePath>(&origin)) {
-        auto [it, _] = positionToDocComment.lock()->try_emplace(*sourcePath, make_ref<DocCommentMap>());
-        docComments = &*it->second;
-    }
-
-    auto result =
-        parseExprFromBuf(text, length, origin, basePath, mem.exprs, symbols, settings, positions, *docComments, rootFS);
+    auto result = parseExprFromBuf(
+        text, length, origin, basePath, mem.exprs, symbols, settings, positions, *tmpDocComments, rootFS);
 
     result->bindVars(*this, staticEnv);
+
+    if (auto sourcePath = std::get_if<SourcePath>(&origin))
+        /* A single file might appear multiple times in PosTable if it's
+           parsed by scopedImport. If we are the first then emplace into the map, otherwise
+           copy our positions into the existing map. */
+        positionToDocComment->emplace_or_visit(*sourcePath, tmpDocComments, [&tmpDocComments](auto & kv) {
+            kv.second->insert(tmpDocComments->begin(), tmpDocComments->end());
+        });
 
     return result;
 }
@@ -3310,16 +3313,12 @@ DocComment EvalState::getDocCommentForPos(PosIdx pos)
     if (!path)
         return {};
 
-    auto positionToDocComment_ = positionToDocComment.readLock();
-
-    auto table = positionToDocComment_->find(*path);
-    if (table == positionToDocComment_->end())
-        return {};
-
-    auto it = table->second->find(pos);
-    if (it == table->second->end())
-        return {};
-    return it->second;
+    DocComment result;
+    positionToDocComment->visit(*path, [&](const auto & kv) {
+        if (auto it = kv.second->find(pos); it != kv.second->end())
+            result = it->second;
+    });
+    return result;
 }
 
 std::string ExternalValueBase::coerceToString(

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -502,7 +502,7 @@ private:
      * Associate source positions of certain AST nodes with their preceding doc comment, if they have one.
      * Grouped by file.
      */
-    SharedSync<boost::unordered_flat_map<SourcePath, ref<DocCommentMap>>> positionToDocComment;
+    const ref<boost::concurrent_flat_map<SourcePath, ref<DocCommentMap>>> positionToDocComment;
 
     LookupPath lookupPath;
 

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -506,8 +506,7 @@ private:
 
     LookupPath lookupPath;
 
-    // FIXME: make thread-safe.
-    boost::unordered_flat_map<std::string, std::optional<SourcePath>, StringViewHash, std::equal_to<>>
+    const ref<boost::concurrent_flat_map<std::string, std::optional<SourcePath>, StringViewHash, std::equal_to<>>>
         lookupPathResolved;
 
     /**


### PR DESCRIPTION
## Motivation

Cherry-picks upstream https://github.com/NixOS/nix/pull/15488 to make `lookupPathResolved` thread-safe.

Also cherry-picks upstream ff022d8292166f5b73a7ad9a203edb594804efa1. Our `positionToDocComment` was already thread-safe but the upstream version is (probably) more performant.

Fixes #412.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved concurrent access patterns for internal caching mechanisms, enhancing evaluation performance in multi-threaded scenarios.
  * Optimized path resolution caching for faster lookups.

* **Bug Fixes**
  * Strengthened thread safety of internal evaluation state caches to prevent race conditions during parallel operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->