### PR TITLE
 Upload crash info to Sentry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       - run: nix build .#^debug,out
       - name: Upload debug info to Sentry
         run: ./maintainers/upload-debug-info-to-sentry.py --debug-dir ./result-debug ./result/bin/nix
-        if: contains(inputs.system, 'linux') && env.SENTRY_AUTH_TOKEN != ''
+        if: env.SENTRY_AUTH_TOKEN != ''
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.sentry_auth_token }}
           SENTRY_ORG: ${{ secrets.sentry_org }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       - run: nix build .#^debug,out
       - name: Upload debug info to Sentry
         run: ./maintainers/upload-debug-info-to-sentry.py --debug-dir ./result-debug ./result/bin/nix
-        if: contains(inputs.system, 'linux') && secrets.sentry_auth_token != ''
+        if: contains(inputs.system, 'linux') && env.SENTRY_AUTH_TOKEN != ''
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.sentry_auth_token }}
           SENTRY_ORG: ${{ secrets.sentry_org }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,9 @@ jobs:
       - run: nix build .#packages.${{ inputs.system }}.default .#packages.${{ inputs.system }}.binaryTarball --no-link -L
       - run: nix build .#packages.${{ inputs.system }}.binaryTarball --out-link tarball
       - run: nix build .#^debug,out
-      - run: ./maintainers/upload-debug-info-to-sentry.py --debug-dir ./result-debug ./result/bin/nix
+      - name: Upload debug info to Sentry
+        run: ./maintainers/upload-debug-info-to-sentry.py --debug-dir ./result-debug ./result/bin/nix
+        if: contains(inputs.system, 'linux') && secrets.sentry_auth_token != ''
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.sentry_auth_token }}
           SENTRY_ORG: ${{ secrets.sentry_org }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,12 @@ on:
         required: false
       manual_netlify_site_id:
         required: false
+      sentry_auth_token:
+        required: false
+      sentry_org:
+        required: false
+      sentry_project:
+        required: false
 
 jobs:
   build:
@@ -52,6 +58,12 @@ jobs:
       - uses: DeterminateSystems/flakehub-cache-action@main
       - run: nix build .#packages.${{ inputs.system }}.default .#packages.${{ inputs.system }}.binaryTarball --no-link -L
       - run: nix build .#packages.${{ inputs.system }}.binaryTarball --out-link tarball
+      - run: nix build .#^debug,out
+      - run: ./maintainers/upload-debug-info-to-sentry.py --debug-dir ./result-debug ./result/bin/nix
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.sentry_auth_token }}
+          SENTRY_ORG: ${{ secrets.sentry_org }}
+          SENTRY_PROJECT: ${{ secrets.sentry_project }}
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.system }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
     secrets:
       manual_netlify_auth_token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       manual_netlify_site_id: ${{ secrets.NETLIFY_SITE_ID }}
+      sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      sentry_org: ${{ secrets.SENTRY_ORG }}
+      sentry_project: ${{ secrets.SENTRY_PROJECT }}
 
   build_aarch64-linux:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,10 @@ jobs:
       runner: UbuntuLatest32Cores128GArm
       runner_for_virt: UbuntuLatest32Cores128GArm
       runner_small: UbuntuLatest32Cores128GArm
+    secrets:
+      sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      sentry_org: ${{ secrets.SENTRY_ORG }}
+      sentry_project: ${{ secrets.SENTRY_PROJECT }}
 
   build_aarch64-darwin:
     uses: ./.github/workflows/build.yml
@@ -73,6 +77,10 @@ jobs:
       runner: namespace-profile-mac-m2-12c28g
       runner_for_virt: namespace-profile-mac-m2-12c28g
       runner_small: macos-latest-xlarge
+    secrets:
+      sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      sentry_org: ${{ secrets.SENTRY_ORG }}
+      sentry_project: ${{ secrets.SENTRY_PROJECT }}
 
   success:
     runs-on: ubuntu-latest

--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -76,7 +76,11 @@ let
       subcommands = if length categories > 1 then listCategories else listSubcommands details.commands;
 
       categories = sort (x: y: x.id < y.id) (
-        unique (map (cmd: { inherit (cmd.category) id description; }) (attrValues details.commands))
+        unique (
+          map (cmd: { inherit (cmd.category) id description; }) (
+            builtins.filter (cmd: cmd.category.id != 103) (attrValues details.commands)
+          )
+        )
       );
 
       listCategories = concatStrings (map showCategory categories);

--- a/maintainers/upload-debug-info-to-sentry.py
+++ b/maintainers/upload-debug-info-to-sentry.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+NAR_DIR = "/tmp/nars"
+DEBUG_INFO_DIR = "/tmp/debug-info"
+
+
+def get_dynamic_libraries(executable: str) -> list[str]:
+    result = subprocess.run(["ldd", executable], capture_output=True, text=True, check=True)
+    libs = []
+    for line in result.stdout.splitlines():
+        # ldd output lines look like:
+        #   libfoo.so.1 => /nix/store/.../libfoo.so.1 (0x...)
+        #   /lib64/ld-linux-x86-64.so.2 (0x...)
+        m = re.search(r"=> (/\S+)", line)
+        if m:
+            libs.append(m.group(1))
+        elif line.strip().startswith("/"):
+            path = line.strip().split()[0]
+            libs.append(path)
+    return libs
+
+
+def get_build_id(path: str) -> str | None:
+    result = subprocess.run(["readelf", "-n", path], capture_output=True, text=True)
+    m = re.search(r"Build ID:\s+([0-9a-f]+)", result.stdout)
+    return m.group(1) if m else None
+
+
+def download_nar(build_id: str, archive: str) -> str:
+    """Download a NAR to /tmp/nars and return the local path. Skips if already present."""
+    base_url = f"https://cache.nixos.org/debuginfo/{build_id}"
+    nar_url = urllib.parse.urljoin(base_url, archive)
+    filename = nar_url.split("/")[-1]
+    local_path = os.path.join(NAR_DIR, filename)
+    if not os.path.exists(local_path):
+        os.makedirs(NAR_DIR, exist_ok=True)
+        print(f"    downloading {nar_url} ...", file=sys.stderr)
+        urllib.request.urlretrieve(nar_url, local_path)
+    else:
+        print(f"    already have {filename}", file=sys.stderr)
+    return local_path
+
+
+def extract_debug_symbols(nar_path: str, member: str, build_id: str) -> str:
+    """Extract a member from a .nar.xz into /tmp/debug-info/<build_id>.debug. Returns the output path."""
+    out_path = os.path.join(DEBUG_INFO_DIR, f"{build_id}.debug")
+    if os.path.exists(out_path):
+        print(f"    already extracted {out_path}", file=sys.stderr)
+        return out_path
+    os.makedirs(DEBUG_INFO_DIR, exist_ok=True)
+    print(f"    extracting {member} -> {out_path} ...", file=sys.stderr)
+    xz = subprocess.Popen(["xz", "-d"], stdin=open(nar_path, "rb"), stdout=subprocess.PIPE)
+    nar_cat = subprocess.run(
+        ["nix", "nar", "cat", "/dev/stdin", member],
+        stdin=xz.stdout,
+        capture_output=True,
+        check=True,
+    )
+    xz.wait()
+    with open(out_path, "wb") as f:
+        f.write(nar_cat.stdout)
+    return out_path
+
+
+def find_debug_file_in_dirs(build_id: str, debug_dirs: list[str]) -> str | None:
+    """Look for a .debug file by build ID under <dir>/lib/debug/.build-id/NN/NNN.debug."""
+    subpath = os.path.join("lib", "debug", ".build-id", build_id[:2], build_id[2:] + ".debug")
+    for d in debug_dirs:
+        candidate = os.path.join(d, subpath)
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def fetch_debuginfo(build_id: str) -> dict | None:
+    url = f"https://cache.nixos.org/debuginfo/{build_id}"
+    try:
+        with urllib.request.urlopen(url) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        raise
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Upload ELF debug symbols to Sentry."
+    )
+    parser.add_argument("executable", help="Path to the ELF executable (e.g. ./result/bin/nix)")
+    parser.add_argument("--project", help="Sentry project ID")
+    parser.add_argument("--debug-dir", action="append", default=[], metavar="DIR",
+                        help="Directory to search for debug files (may be repeated)")
+    args = parser.parse_args()
+
+    debug_files = []
+
+    libs = [args.executable] + get_dynamic_libraries(args.executable)
+    print("ELF files to process:", file=sys.stderr)
+    for lib in libs:
+        build_id = get_build_id(lib)
+        if build_id is None:
+            print(f"  {lib} (no build ID)", file=sys.stderr)
+            continue
+
+        local = find_debug_file_in_dirs(build_id, args.debug_dir)
+        if local:
+            print(f"  {lib} ({build_id}): found locally at {local}", file=sys.stderr)
+            debug_files.append(local)
+            continue
+
+        debuginfo = fetch_debuginfo(build_id)
+        if debuginfo is None:
+            print(f"  {lib} ({build_id}, no debug info in cache)", file=sys.stderr)
+            continue
+        print(f"  {lib} ({build_id}): member={debuginfo['member']}", file=sys.stderr)
+        nar_path = download_nar(build_id, debuginfo["archive"])
+        debug_file = extract_debug_symbols(nar_path, debuginfo["member"], build_id)
+        debug_files.append(debug_file)
+
+    if debug_files:
+        print(f"Uploading {len(debug_files)} debug file(s) to Sentry...", file=sys.stderr)
+        cmd = ["sentry-cli", "debug-files", "upload"]
+        if args.project:
+            cmd += ["--project", args.project]
+        subprocess.run(cmd + debug_files, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/maintainers/upload-debug-info-to-sentry.py
+++ b/maintainers/upload-debug-info-to-sentry.py
@@ -4,6 +4,7 @@
 import argparse
 import json
 import os
+import platform
 import re
 import subprocess
 import sys
@@ -16,19 +17,30 @@ DEBUG_INFO_DIR = "/tmp/debug-info"
 
 
 def get_dynamic_libraries(executable: str) -> list[str]:
-    result = subprocess.run(["ldd", executable], capture_output=True, text=True, check=True)
-    libs = []
-    for line in result.stdout.splitlines():
-        # ldd output lines look like:
-        #   libfoo.so.1 => /nix/store/.../libfoo.so.1 (0x...)
-        #   /lib64/ld-linux-x86-64.so.2 (0x...)
-        m = re.search(r"=> (/\S+)", line)
-        if m:
-            libs.append(m.group(1))
-        elif line.strip().startswith("/"):
-            path = line.strip().split()[0]
-            libs.append(path)
-    return libs
+    if platform.system() == "Darwin":
+        result = subprocess.run(["otool", "-L", executable], capture_output=True, text=True, check=True)
+        libs = []
+        for line in result.stdout.splitlines()[1:]:  # skip first line (the binary path itself)
+            # otool -L output lines look like:
+            #   /nix/store/.../libfoo.dylib (compatibility version X.Y.Z, current version A.B.C)
+            m = re.match(r"\s+(\S+)\s+\(", line)
+            if m:
+                libs.append(m.group(1))
+        return libs
+    else:
+        result = subprocess.run(["ldd", executable], capture_output=True, text=True, check=True)
+        libs = []
+        for line in result.stdout.splitlines():
+            # ldd output lines look like:
+            #   libfoo.so.1 => /nix/store/.../libfoo.so.1 (0x...)
+            #   /lib64/ld-linux-x86-64.so.2 (0x...)
+            m = re.search(r"=> (/\S+)", line)
+            if m:
+                libs.append(m.group(1))
+            elif line.strip().startswith("/"):
+                path = line.strip().split()[0]
+                libs.append(path)
+        return libs
 
 
 def get_build_id(path: str) -> str | None:
@@ -96,45 +108,53 @@ def fetch_debuginfo(build_id: str) -> dict | None:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Upload ELF debug symbols to Sentry."
+        description="Upload debug symbols to Sentry."
     )
-    parser.add_argument("executable", help="Path to the ELF executable (e.g. ./result/bin/nix)")
+    parser.add_argument("executable", help="Path to the executable (e.g. ./result/bin/nix)")
     parser.add_argument("--project", help="Sentry project ID")
     parser.add_argument("--debug-dir", action="append", default=[], metavar="DIR",
-                        help="Directory to search for debug files (may be repeated)")
+                        help="Directory to search for debug files (may be repeated, Linux only)")
     args = parser.parse_args()
 
-    debug_files = []
-
     libs = [args.executable] + get_dynamic_libraries(args.executable)
-    print("ELF files to process:", file=sys.stderr)
-    for lib in libs:
-        build_id = get_build_id(lib)
-        if build_id is None:
-            print(f"  {lib} (no build ID)", file=sys.stderr)
-            continue
 
-        local = find_debug_file_in_dirs(build_id, args.debug_dir)
-        if local:
-            print(f"  {lib} ({build_id}): found locally at {local}", file=sys.stderr)
-            debug_files.append(local)
-            continue
+    if platform.system() == "Darwin":
+        # On macOS there are no separate debug info files; upload the binaries directly.
+        print("Files to upload:", file=sys.stderr)
+        for lib in libs:
+            print(f"  {lib}", file=sys.stderr)
+        files_to_upload = libs
+    else:
+        debug_files = []
+        print("ELF files to process:", file=sys.stderr)
+        for lib in libs:
+            build_id = get_build_id(lib)
+            if build_id is None:
+                print(f"  {lib} (no build ID)", file=sys.stderr)
+                continue
 
-        debuginfo = fetch_debuginfo(build_id)
-        if debuginfo is None:
-            print(f"  {lib} ({build_id}, no debug info in cache)", file=sys.stderr)
-            continue
-        print(f"  {lib} ({build_id}): member={debuginfo['member']}", file=sys.stderr)
-        nar_path = download_nar(build_id, debuginfo["archive"])
-        debug_file = extract_debug_symbols(nar_path, debuginfo["member"], build_id)
-        debug_files.append(debug_file)
+            local = find_debug_file_in_dirs(build_id, args.debug_dir)
+            if local:
+                print(f"  {lib} ({build_id}): found locally at {local}", file=sys.stderr)
+                debug_files.append(local)
+                continue
 
-    if debug_files:
-        print(f"Uploading {len(debug_files)} debug file(s) to Sentry...", file=sys.stderr)
+            debuginfo = fetch_debuginfo(build_id)
+            if debuginfo is None:
+                print(f"  {lib} ({build_id}, no debug info in cache)", file=sys.stderr)
+                continue
+            print(f"  {lib} ({build_id}): member={debuginfo['member']}", file=sys.stderr)
+            nar_path = download_nar(build_id, debuginfo["archive"])
+            debug_file = extract_debug_symbols(nar_path, debuginfo["member"], build_id)
+            debug_files.append(debug_file)
+        files_to_upload = debug_files
+
+    if files_to_upload:
+        print(f"Uploading {len(files_to_upload)} file(s) to Sentry...", file=sys.stderr)
         cmd = ["sentry-cli", "debug-files", "upload"]
         if args.project:
             cmd += ["--project", args.project]
-        subprocess.run(cmd + debug_files, check=True)
+        subprocess.run(cmd + files_to_upload, check=True)
 
 
 if __name__ == "__main__":

--- a/maintainers/upload-debug-info-to-sentry.py
+++ b/maintainers/upload-debug-info-to-sentry.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/env nix
+#!nix shell --inputs-from . nixpkgs#sentry-cli --command python3
 
 import argparse
 import json

--- a/nix-meson-build-support/common/assert-fail/meson.build
+++ b/nix-meson-build-support/common/assert-fail/meson.build
@@ -24,9 +24,9 @@ can_wrap_assert_fail = cxx.links(
   name : 'linker can wrap __assert_fail',
 )
 
-#if can_wrap_assert_fail
-#  deps_other += declare_dependency(
-#    sources : 'wrap-assert-fail.cc',
-#    link_args : wrap_assert_fail_args,
-#  )
-#endif
+if can_wrap_assert_fail
+  deps_other += declare_dependency(
+    sources : 'wrap-assert-fail.cc',
+    link_args : wrap_assert_fail_args,
+  )
+endif

--- a/nix-meson-build-support/common/assert-fail/meson.build
+++ b/nix-meson-build-support/common/assert-fail/meson.build
@@ -24,9 +24,9 @@ can_wrap_assert_fail = cxx.links(
   name : 'linker can wrap __assert_fail',
 )
 
-if can_wrap_assert_fail
-  deps_other += declare_dependency(
-    sources : 'wrap-assert-fail.cc',
-    link_args : wrap_assert_fail_args,
-  )
-endif
+#if can_wrap_assert_fail
+#  deps_other += declare_dependency(
+#    sources : 'wrap-assert-fail.cc',
+#    link_args : wrap_assert_fail_args,
+#  )
+#endif

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -148,7 +148,7 @@ scope: {
     idnSupport = !stdenv.hostPlatform.isStatic;
   };
 
-  sentry-native = pkgs.sentry-native.override {
+  sentry-native = (pkgs.callPackage ./sentry-native.nix { }).override {
     # Avoid having two curls in our closure.
     inherit (scope) curl;
   };

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -147,4 +147,9 @@ scope: {
     pslSupport = !stdenv.hostPlatform.isStatic;
     idnSupport = !stdenv.hostPlatform.isStatic;
   };
+
+  sentry-native = pkgs.sentry-native.override {
+    # Avoid having two curls in our closure.
+    inherit (scope) curl;
+  };
 }

--- a/packaging/dev-shell.nix
+++ b/packaging/dev-shell.nix
@@ -290,7 +290,8 @@ pkgs.nixComponents2.nix-util.overrideAttrs (
       map (transformFlag "perl") (ignoreCrossFile pkgs.nixComponents2.nix-perl-bindings.mesonFlags)
     )
     ++ map (transformFlag "libexpr") (ignoreCrossFile pkgs.nixComponents2.nix-expr.mesonFlags)
-    ++ map (transformFlag "libcmd") (ignoreCrossFile pkgs.nixComponents2.nix-cmd.mesonFlags);
+    ++ map (transformFlag "libcmd") (ignoreCrossFile pkgs.nixComponents2.nix-cmd.mesonFlags)
+    ++ map (transformFlag "nix") (ignoreCrossFile pkgs.nixComponents2.nix-cli.mesonFlags);
 
     nativeBuildInputs =
       let

--- a/packaging/everything.nix
+++ b/packaging/everything.nix
@@ -159,7 +159,13 @@ stdenv.mkDerivation (finalAttrs: {
     let
       devPaths = lib.mapAttrsToList (_k: lib.getDev) finalAttrs.finalPackage.libs;
       debugPaths = lib.map (lib.getOutput "debug") (
-        lib.attrValues finalAttrs.finalPackage.libs ++ [ nix-cli curl boehmgc sentry-native ]
+        lib.attrValues finalAttrs.finalPackage.libs
+        ++ [
+          nix-cli
+          curl
+          boehmgc
+          sentry-native
+        ]
       );
     in
     ''

--- a/packaging/everything.nix
+++ b/packaging/everything.nix
@@ -102,6 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
     "doc"
     "man"
+    "debug"
   ];
 
   /**
@@ -153,9 +154,12 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase =
     let
       devPaths = lib.mapAttrsToList (_k: lib.getDev) finalAttrs.finalPackage.libs;
+      debugPaths = lib.map (lib.getOutput "debug") (
+        lib.attrValues finalAttrs.finalPackage.libs ++ [ nix-cli ]
+      );
     in
     ''
-      mkdir -p $out $dev/nix-support
+      mkdir -p $out $dev/nix-support $debug/lib/debug
 
       # Custom files
       echo $libs >> $dev/nix-support/propagated-build-inputs
@@ -166,6 +170,12 @@ stdenv.mkDerivation (finalAttrs: {
 
       for lib in ${lib.escapeShellArgs devPaths}; do
         lndir $lib $dev
+      done
+
+      for d in ${lib.escapeShellArgs debugPaths}; do
+        if [[ -d $d/lib/debug ]]; then
+          lndir $d/lib/debug $debug/lib/debug
+        fi
       done
 
       # Forwarded outputs

--- a/packaging/everything.nix
+++ b/packaging/everything.nix
@@ -44,6 +44,10 @@
   testers,
 
   patchedSrc ? null,
+
+  curl,
+  boehmgc,
+  sentry-native,
 }:
 
 let
@@ -155,7 +159,7 @@ stdenv.mkDerivation (finalAttrs: {
     let
       devPaths = lib.mapAttrsToList (_k: lib.getDev) finalAttrs.finalPackage.libs;
       debugPaths = lib.map (lib.getOutput "debug") (
-        lib.attrValues finalAttrs.finalPackage.libs ++ [ nix-cli ]
+        lib.attrValues finalAttrs.finalPackage.libs ++ [ nix-cli curl boehmgc sentry-native ]
       );
     in
     ''

--- a/packaging/everything.nix
+++ b/packaging/everything.nix
@@ -164,8 +164,8 @@ stdenv.mkDerivation (finalAttrs: {
           nix-cli
           curl
           boehmgc
-          sentry-native
         ]
+        ++ lib.optional (stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isStatic) sentry-native
       );
     in
     ''

--- a/packaging/sentry-native.nix
+++ b/packaging/sentry-native.nix
@@ -5,6 +5,8 @@
   cmake,
   curl,
   pkg-config,
+  python3,
+  darwin,
 }:
 
 stdenv.mkDerivation rec {
@@ -18,10 +20,22 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  dontFixCmake = true;
+
   nativeBuildInputs = [
     cmake
     pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    python3
+    darwin.bootstrap_cmds
   ];
+
+  postPatch = ''
+    # Borrowed from psutil: stick to the old SDK name for now.
+    substituteInPlace external/crashpad/util/mac/mac_util.cc \
+      --replace-fail kIOMainPortDefault kIOMasterPortDefault
+  '';
 
   buildInputs = [
     curl

--- a/packaging/sentry-native.nix
+++ b/packaging/sentry-native.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  cmake,
+  curl,
+  pkg-config,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sentry-native";
+  version = "0.13.5";
+
+  src = fetchgit {
+    url = "https://github.com/getsentry/sentry-native";
+    tag = version;
+    hash = "sha256-vDBI6lB1DMLleAgRCfsHvTSdtmXOzvJSaNAt+NwOd3c=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+  ];
+
+  cmakeBuildType = "RelWithDebInfo";
+
+  cmakeFlags = [ ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+}

--- a/src/libcmd/include/nix/cmd/command.hh
+++ b/src/libcmd/include/nix/cmd/command.hh
@@ -24,6 +24,7 @@ static constexpr Command::Category catHelp = -1;
 static constexpr Command::Category catSecondary = 100;
 static constexpr Command::Category catUtility = 101;
 static constexpr Command::Category catNixInstallation = 102;
+static constexpr Command::Category catUndocumented = 103;
 
 static constexpr auto installablesCategory =
     "Options that change the interpretation of [installables](@docroot@/command-ref/new-cli/nix.md#installables)";

--- a/src/libcmd/include/nix/cmd/command.hh
+++ b/src/libcmd/include/nix/cmd/command.hh
@@ -24,7 +24,6 @@ static constexpr Command::Category catHelp = -1;
 static constexpr Command::Category catSecondary = 100;
 static constexpr Command::Category catUtility = 101;
 static constexpr Command::Category catNixInstallation = 102;
-static constexpr Command::Category catUndocumented = 103;
 
 static constexpr auto installablesCategory =
     "Options that change the interpretation of [installables](@docroot@/command-ref/new-cli/nix.md#installables)";

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -13,6 +13,7 @@
 #include "nix/util/environment-variables.hh"
 
 #include <nlohmann/json.hpp>
+#include <thread>
 
 namespace nix::fetchers {
 

--- a/src/libmain/unix/stack.cc
+++ b/src/libmain/unix/stack.cc
@@ -45,7 +45,7 @@ static void sigsegvHandler(int signo, siginfo_t * info, void * ctx)
 
 void detectStackOverflow()
 {
-#if defined(SA_SIGINFO) && defined(SA_ONSTACK)
+#if defined(SA_SIGINFO) && defined(SA_ONSTACK) && 0
     /* Install a SIGSEGV handler to detect stack overflows.  This
        requires an alternative stack, otherwise the signal cannot be
        delivered when we're out of stack space. */

--- a/src/libmain/unix/stack.cc
+++ b/src/libmain/unix/stack.cc
@@ -10,6 +10,8 @@
 
 namespace nix {
 
+static struct sigaction savedSigsegvAction;
+
 static void sigsegvHandler(int signo, siginfo_t * info, void * ctx)
 {
     /* Detect stack overflows by comparing the faulting address with
@@ -34,18 +36,14 @@ static void sigsegvHandler(int signo, siginfo_t * info, void * ctx)
         }
     }
 
-    /* Restore default behaviour (i.e. segfault and dump core). */
-    struct sigaction act;
-    sigfillset(&act.sa_mask);
-    act.sa_handler = SIG_DFL;
-    act.sa_flags = 0;
-    if (sigaction(SIGSEGV, &act, 0))
+    /* Restore the original SIGSEGV handler. */
+    if (sigaction(SIGSEGV, &savedSigsegvAction, 0))
         abort();
 }
 
 void detectStackOverflow()
 {
-#if defined(SA_SIGINFO) && defined(SA_ONSTACK) && 0
+#if defined(SA_SIGINFO) && defined(SA_ONSTACK)
     /* Install a SIGSEGV handler to detect stack overflows.  This
        requires an alternative stack, otherwise the signal cannot be
        delivered when we're out of stack space. */
@@ -63,7 +61,7 @@ void detectStackOverflow()
     sigfillset(&act.sa_mask);
     act.sa_sigaction = sigsegvHandler;
     act.sa_flags = SA_SIGINFO | SA_ONSTACK;
-    if (sigaction(SIGSEGV, &act, 0))
+    if (sigaction(SIGSEGV, &act, &savedSigsegvAction))
         throw SysError("resetting SIGSEGV");
 #endif
 }

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -671,6 +671,8 @@ nlohmann::json MultiCommand::toJSON()
         auto command = commandFun();
         auto j = command->toJSON();
         auto cat = nlohmann::json::object();
+        if (command->category() == Command::catUndocumented)
+            continue;
         cat["id"] = command->category();
         cat["description"] = trim(categories[command->category()]);
         cat["experimental-feature"] = command->experimentalFeature();

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -632,7 +632,7 @@ MultiCommand::MultiCommand(std::string_view commandName, const Commands & comman
          }},
          .completer = {[&](AddCompletions & completions, size_t, std::string_view prefix) {
              for (auto & [name, command] : commands)
-                 if (hasPrefix(name, prefix))
+                 if (hasPrefix(name, prefix) && !hasPrefix(name, "__"))
                      completions.add(name);
          }}});
 

--- a/src/libutil/include/nix/util/args.hh
+++ b/src/libutil/include/nix/util/args.hh
@@ -374,6 +374,7 @@ struct Command : virtual public Args
     using Category = int;
 
     static constexpr Category catDefault = 0;
+    static constexpr Category catUndocumented = 1;
 
     virtual std::optional<ExperimentalFeature> experimentalFeature();
 

--- a/src/nix/crash.cc
+++ b/src/nix/crash.cc
@@ -45,4 +45,4 @@ struct CmdCrash : Command
     }
 };
 
-static auto rCrash = registerCommand<CmdCrash>("crash");
+static auto rCrash = registerCommand<CmdCrash>("__crash");

--- a/src/nix/crash.cc
+++ b/src/nix/crash.cc
@@ -1,5 +1,7 @@
 #include "nix/cmd/command.hh"
 
+#include <bitset>
+
 using namespace nix;
 
 struct CmdCrash : Command

--- a/src/nix/crash.cc
+++ b/src/nix/crash.cc
@@ -1,0 +1,48 @@
+#include "nix/cmd/command.hh"
+
+using namespace nix;
+
+struct CmdCrash : Command
+{
+    std::string type;
+
+    CmdCrash()
+    {
+        expectArg("type", &type);
+    }
+
+    Category category() override
+    {
+        return catUndocumented;
+    }
+
+    std::string description() override
+    {
+        return "crash the program to test crash reporting";
+    }
+
+    void run() override
+    {
+        if (type == "segfault") {
+            printError("Triggering a segfault...");
+            volatile int * p = nullptr;
+            *p = 123;
+        }
+
+        else if (type == "assert") {
+            printError("Triggering an assertion failure...");
+            assert(false && "This is an assertion failure");
+        }
+
+        else if (type == "logic-error") {
+            printError("Triggering a C++ logic error...");
+            std::bitset<4>{"012"};
+        }
+
+        else {
+            throw Error("unknown crash type '%s'", type);
+        }
+    }
+};
+
+static auto rCrash = registerCommand<CmdCrash>("crash");

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -121,10 +121,10 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs, virtual RootArgs
         categories.clear();
         categories[catHelp] = "Help commands";
         categories[Command::catDefault] = "Main commands";
+        categories[Command::catUndocumented] = "Undocumented commands";
         categories[catSecondary] = "Infrequently used commands";
         categories[catUtility] = "Utility/scripting commands";
         categories[catNixInstallation] = "Commands for upgrading or troubleshooting your Nix installation";
-        categories[catUndocumented] = "Undocumented commands";
 
         addFlag({
             .longName = "help",

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 #include <regex>
 #include <nlohmann/json.hpp>
+#include <sentry.h>
 
 #ifndef _WIN32
 #  include <sys/socket.h>
@@ -378,7 +379,24 @@ void mainWrapped(int argc, char ** argv)
 {
     savedArgv = argv;
 
-    registerCrashHandler();
+    bool sentryEnabled = false;
+
+    if (getEnv("NIX_DISABLE_SENTRY").value_or("") != "1") {
+        sentry_options_t * options = sentry_options_new();
+        sentry_options_set_dsn(
+            options, "https://ca42fa4b6b08ae1caf3d96b998af6bac@o4506062689927168.ingest.us.sentry.io/4511151087878144");
+        sentry_options_set_database_path(options, (getCacheDir() / "sentry").string().c_str());
+        sentry_options_set_release(options, fmt("nix@%s", determinateNixVersion).c_str());
+        sentry_options_set_traces_sample_rate(options, 0);
+        sentry_options_set_auto_session_tracking(options, false);
+        sentry_init(options);
+        sentryEnabled = true;
+    }
+
+    Finally cleanupSentry([]() { sentry_shutdown(); });
+
+    if (!sentryEnabled)
+        registerCrashHandler();
 
     /* The chroot helper needs to be run before any threads have been
        started. */

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -121,6 +121,7 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs, virtual RootArgs
         categories[catSecondary] = "Infrequently used commands";
         categories[catUtility] = "Utility/scripting commands";
         categories[catNixInstallation] = "Commands for upgrading or troubleshooting your Nix installation";
+        categories[catUndocumented] = "Undocumented commands";
 
         addFlag({
             .longName = "help",

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -400,7 +400,10 @@ void mainWrapped(int argc, char ** argv)
         sentryEnabled = true;
     }
 
-    Finally cleanupSentry([]() { sentry_shutdown(); });
+    Finally cleanupSentry([&]() {
+        if (sentryEnabled)
+            sentry_shutdown();
+    });
 #endif
 
     if (!sentryEnabled)

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -384,14 +384,18 @@ void mainWrapped(int argc, char ** argv)
     bool sentryEnabled = false;
 
 #if HAVE_SENTRY
-    if (getEnv("NIX_DISABLE_SENTRY").value_or("") != "1") {
+    auto sentryEndpoint =
+        getEnv("NIX_SENTRY_ENDPOINT")
+            .value_or(
+                "https://ca42fa4b6b08ae1caf3d96b998af6bac@o4506062689927168.ingest.us.sentry.io/4511151087878144");
+    if (sentryEndpoint != "") {
         sentry_options_t * options = sentry_options_new();
-        sentry_options_set_dsn(
-            options, "https://ca42fa4b6b08ae1caf3d96b998af6bac@o4506062689927168.ingest.us.sentry.io/4511151087878144");
+        sentry_options_set_dsn(options, sentryEndpoint.c_str());
         sentry_options_set_database_path(options, (getCacheDir() / "sentry").string().c_str());
         sentry_options_set_release(options, fmt("nix@%s", determinateNixVersion).c_str());
         sentry_options_set_traces_sample_rate(options, 0);
         sentry_options_set_auto_session_tracking(options, false);
+        sentry_options_set_handler_path(options, CRASHPAD_HANDLER_PATH);
         sentry_init(options);
         sentryEnabled = true;
     }

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -384,13 +384,18 @@ void mainWrapped(int argc, char ** argv)
     bool sentryEnabled = false;
 
 #if HAVE_SENTRY
-    auto sentryEndpoint =
-        getEnv("NIX_SENTRY_ENDPOINT")
-            .value_or(
-                "https://ca42fa4b6b08ae1caf3d96b998af6bac@o4506062689927168.ingest.us.sentry.io/4511151087878144");
-    if (sentryEndpoint != "") {
+    auto sentryEndpoint = getEnv("NIX_SENTRY_ENDPOINT");
+
+    if (!sentryEndpoint && getEnv("DETSYS_IDS_TELEMETRY") != "disabled") {
+        try {
+            sentryEndpoint = trim(readFile(settings.nixConfDir / "sentry-endpoint"));
+        } catch (...) {
+        }
+    }
+
+    if (sentryEndpoint && sentryEndpoint != "") {
         sentry_options_t * options = sentry_options_new();
-        sentry_options_set_dsn(options, sentryEndpoint.c_str());
+        sentry_options_set_dsn(options, sentryEndpoint->c_str());
         sentry_options_set_database_path(options, (getCacheDir() / "sentry").string().c_str());
         sentry_options_set_release(options, fmt("nix@%s", determinateNixVersion).c_str());
         sentry_options_set_traces_sample_rate(options, 0);

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -29,7 +29,9 @@
 #include <sys/types.h>
 #include <regex>
 #include <nlohmann/json.hpp>
-#include <sentry.h>
+#if HAVE_SENTRY
+#  include <sentry.h>
+#endif
 
 #ifndef _WIN32
 #  include <sys/socket.h>
@@ -381,6 +383,7 @@ void mainWrapped(int argc, char ** argv)
 
     bool sentryEnabled = false;
 
+#if HAVE_SENTRY
     if (getEnv("NIX_DISABLE_SENTRY").value_or("") != "1") {
         sentry_options_t * options = sentry_options_new();
         sentry_options_set_dsn(
@@ -394,6 +397,7 @@ void mainWrapped(int argc, char ** argv)
     }
 
     Finally cleanupSentry([]() { sentry_shutdown(); });
+#endif
 
     if (!sentryEnabled)
         registerCrashHandler();

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -388,8 +388,11 @@ void mainWrapped(int argc, char ** argv)
 
     if (!sentryEndpoint && getEnv("DETSYS_IDS_TELEMETRY") != "disabled") {
         try {
-            sentryEndpoint = trim(readFile(settings.nixConfDir / "sentry-endpoint"));
+            auto p = settings.nixConfDir / "sentry-endpoint";
+            if (pathExists(p))
+                sentryEndpoint = trim(readFile(p));
         } catch (...) {
+            ignoreExceptionExceptInterrupt();
         }
     }
 

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -50,6 +50,9 @@ mandir = get_option('mandir')
 mandir = fs.is_absolute(mandir) ? mandir : prefix / mandir
 configdata.set_quoted('NIX_MAN_DIR', mandir)
 
+sentry_required = get_option('sentry')
+configdata.set('HAVE_SENTRY', sentry_required.enabled().to_int())
+
 config_priv_h = configure_file(
   configuration : configdata,
   output : 'cli-config-private.hh',
@@ -191,7 +194,7 @@ this_exe = executable(
   sources,
   dependencies : deps_private_subproject + deps_private + deps_other,
   include_directories : include_dirs,
-  link_args : linker_export_flags + [ '-lsentry' ],
+  link_args : linker_export_flags + (sentry_required.enabled() ? [ '-lsentry' ] : []),
   install : true,
   cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
 )

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -191,7 +191,7 @@ this_exe = executable(
   sources,
   dependencies : deps_private_subproject + deps_private + deps_other,
   include_directories : include_dirs,
-  link_args : linker_export_flags,
+  link_args : linker_export_flags + [ '-lsentry' ],
   install : true,
   cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
 )

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -68,6 +68,7 @@ nix_sources = [ config_priv_h ] + files(
   'config.cc',
   'copy.cc',
   'crash-handler.cc',
+  'crash.cc',
   'derivation-add.cc',
   'derivation-show.cc',
   'derivation.cc',

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -52,6 +52,14 @@ configdata.set_quoted('NIX_MAN_DIR', mandir)
 
 sentry_required = get_option('sentry')
 configdata.set('HAVE_SENTRY', sentry_required.enabled().to_int())
+if sentry_required.enabled()
+  crashpad_handler_path = get_option('crashpad-handler')
+  assert(
+    crashpad_handler_path != '',
+    'crashpad-handler path must be set when sentry is enabled',
+  )
+  configdata.set_quoted('CRASHPAD_HANDLER_PATH', crashpad_handler_path)
+endif
 
 config_priv_h = configure_file(
   configuration : configdata,

--- a/src/nix/meson.options
+++ b/src/nix/meson.options
@@ -14,3 +14,10 @@ option(
   value : 'auto',
   description : 'Enable Sentry crash reporting',
 )
+
+option(
+  'crashpad-handler',
+  type : 'string',
+  value : '',
+  description : 'Path to the crashpad_handler binary (required when sentry is enabled)',
+)

--- a/src/nix/meson.options
+++ b/src/nix/meson.options
@@ -7,3 +7,10 @@ option(
   value : 'etc/profile.d',
   description : 'the path to install shell profile files',
 )
+
+option(
+  'sentry',
+  type : 'feature',
+  value : 'auto',
+  description : 'Enable Sentry crash reporting',
+)

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -17,7 +17,7 @@
 
 let
   inherit (lib) fileset;
-  enableSentry = stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isStatic;
+  enableSentry = !stdenv.hostPlatform.isStatic;
 in
 
 mkMesonExecutable (finalAttrs: {

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -8,6 +8,7 @@
   nix-expr,
   nix-main,
   nix-cmd,
+  sentry-native,
 
   # Configuration Options
 
@@ -70,6 +71,7 @@ mkMesonExecutable (finalAttrs: {
     nix-expr
     nix-main
     nix-cmd
+    sentry-native
   ]
   ++ lib.optional (
     stdenv.cc.isClang

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -17,7 +17,7 @@
 
 let
   inherit (lib) fileset;
-  enableSentry = !stdenv.hostPlatform.isStatic;
+  enableSentry = stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isStatic;
 in
 
 mkMesonExecutable (finalAttrs: {

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -83,7 +83,10 @@ mkMesonExecutable (finalAttrs: {
 
   mesonFlags = [
     (lib.mesonEnable "sentry" enableSentry)
-  ];
+  ]
+  ++ lib.optional enableSentry (
+    lib.mesonOption "crashpad-handler" "${sentry-native}/bin/crashpad_handler"
+  );
 
   postInstall = lib.optionalString stdenv.hostPlatform.isStatic ''
     mkdir -p $out/nix-support

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -17,6 +17,7 @@
 
 let
   inherit (lib) fileset;
+  enableSentry = !stdenv.hostPlatform.isStatic;
 in
 
 mkMesonExecutable (finalAttrs: {
@@ -71,16 +72,17 @@ mkMesonExecutable (finalAttrs: {
     nix-expr
     nix-main
     nix-cmd
-    sentry-native
   ]
   ++ lib.optional (
     stdenv.cc.isClang
     && stdenv.hostPlatform.isStatic
     && stdenv.cc.libcxx != null
     && stdenv.cc.libcxx.isLLVM
-  ) llvmPackages.libunwind;
+  ) llvmPackages.libunwind
+  ++ lib.optional enableSentry sentry-native;
 
   mesonFlags = [
+    (lib.mesonEnable "sentry" enableSentry)
   ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isStatic ''

--- a/tests/functional/common/init.sh
+++ b/tests/functional/common/init.sh
@@ -3,6 +3,9 @@
 # for shellcheck
 : "${test_nix_conf_dir?}" "${test_nix_conf?}"
 
+# Don't upload crashes from tests to Sentry.
+export NIX_DISABLE_SENTRY=1
+
 if isTestOnNixOS; then
 
   mkdir -p "$test_nix_conf_dir" "$TEST_HOME"

--- a/tests/functional/common/init.sh
+++ b/tests/functional/common/init.sh
@@ -4,7 +4,7 @@
 : "${test_nix_conf_dir?}" "${test_nix_conf?}"
 
 # Don't upload crashes from tests to Sentry.
-export NIX_DISABLE_SENTRY=1
+export NIX_SENTRY_ENDPOINT=
 
 if isTestOnNixOS; then
 

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -176,6 +176,7 @@ suites = [
       'symlinks.sh',
       'external-builders.sh',
       'wasm.sh',
+      'sentry.sh',
     ],
     'workdir' : meson.current_source_dir(),
   },

--- a/tests/functional/sentry.sh
+++ b/tests/functional/sentry.sh
@@ -10,7 +10,7 @@ sentryDir="$TEST_HOME/.cache/nix/sentry"
 
 nix --version
 if ! [[ -d $sentryDir ]]; then
-    skip "not built with sentry support"
+    skipTest "not built with sentry support"
 fi
 
 for type in segfault assert logic-error; do

--- a/tests/functional/sentry.sh
+++ b/tests/functional/sentry.sh
@@ -4,7 +4,7 @@ source common.sh
 
 # Enable sentry with a fake endpoint.
 unset NIX_SENTRY_ENDPOINT
-echo -n "file://$TEST_ROOT/sentry-endpoint" > "$NIX_CONF_DIR/sentry-endpoint"
+echo -n "file://$TEST_ROOT/sentry-endpoint" > "$test_nix_conf_dir/sentry-endpoint"
 
 ulimit -c 0
 

--- a/tests/functional/sentry.sh
+++ b/tests/functional/sentry.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+unset NIX_DISABLE_SENTRY
+
+ulimit -c 0
+
+sentryDir="$TEST_HOME/.cache/nix/sentry"
+
+nix --version
+if ! [[ -d $sentryDir ]]; then
+    skip "not built with sentry support"
+fi
+
+for type in segfault assert logic-error; do
+    rm -rf "$sentryDir"
+
+    (! nix crash "$type")
+
+    [[ -e $sentryDir/last_crash ]]
+
+    envelopes=("$sentryDir"/*.run/*.envelope)
+    if [[ ! -e "${envelopes[0]}" ]]; then
+        fail "No crash dump found in $sentryDir after crash"
+    fi
+done

--- a/tests/functional/sentry.sh
+++ b/tests/functional/sentry.sh
@@ -2,7 +2,8 @@
 
 source common.sh
 
-unset NIX_DISABLE_SENTRY
+# This doesn't actually work, but it prevents sentry from uploading for real.
+export NIX_SENTRY_ENDPOINT=file://$TEST_ROOT/sentry-endpoint
 
 ulimit -c 0
 
@@ -20,7 +21,7 @@ for type in segfault assert logic-error; do
 
     [[ -e $sentryDir/last_crash ]]
 
-    envelopes=("$sentryDir"/*.run/*.envelope)
+    envelopes=("$sentryDir"/pending/*.dmp)
     if [[ ! -e "${envelopes[0]}" ]]; then
         fail "No crash dump found in $sentryDir after crash"
     fi

--- a/tests/functional/sentry.sh
+++ b/tests/functional/sentry.sh
@@ -2,8 +2,9 @@
 
 source common.sh
 
-# This doesn't actually work, but it prevents sentry from uploading for real.
-export NIX_SENTRY_ENDPOINT=file://$TEST_ROOT/sentry-endpoint
+# Enable sentry with a fake endpoint.
+unset NIX_SENTRY_ENDPOINT
+echo -n "file://$TEST_ROOT/sentry-endpoint" > "$NIX_CONF_DIR/sentry-endpoint"
 
 ulimit -c 0
 

--- a/tests/functional/sentry.sh
+++ b/tests/functional/sentry.sh
@@ -16,7 +16,7 @@ fi
 for type in segfault assert logic-error; do
     rm -rf "$sentryDir"
 
-    (! nix crash "$type")
+    (! nix __crash "$type")
 
     [[ -e $sentryDir/last_crash ]]
 

--- a/tests/functional/sentry.sh
+++ b/tests/functional/sentry.sh
@@ -15,11 +15,11 @@ if ! [[ -d $sentryDir ]]; then
 fi
 
 for type in segfault assert logic-error; do
+    if [[ $type = logic-error && $(uname) = Darwin ]]; then continue; fi
+
     rm -rf "$sentryDir"
 
     (! nix __crash "$type")
-
-    [[ -e $sentryDir/last_crash ]]
 
     envelopes=("$sentryDir"/pending/*.dmp)
     if [[ ! -e "${envelopes[0]}" ]]; then


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Sentry crash reporting with build-time toggle, conditional initialization, and a new debug output artifact.
  * Tool to collect and upload debug symbols to Sentry.
  * Test-only crash command to trigger crash scenarios.

* **Tests**
  * Functional tests added to validate crash reporting and uploaded crash artifacts; test init disables real upload.

* **Documentation**
  * Manpage generation now omits undocumented commands.

* **Packaging / CI**
  * Packaging adds optional Sentry-native packaging and debug output wiring; CI workflow accepts optional Sentry secrets and conditionally uploads debug info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->