### PR TITLE
Refactor enqueueFileTransfer

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -972,26 +972,24 @@ struct curlFileTransfer : public FileTransfer
         return ItemHandle(item.get_ptr());
     }
 
-    ItemHandle
-    enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) noexcept override
+    inline ref<TransferItem>
+    makeTransferItem(const FileTransferRequest & request, Callback<FileTransferResult> callback)
     {
         /* Handle s3:// URIs by converting to HTTPS and optionally adding auth */
         if (request.uri.scheme() == "s3") {
             auto modifiedRequest = request;
             modifiedRequest.setupForS3();
-            auto item = make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback));
-            try {
-                return enqueueItem(item);
-            } catch (const nix::BaseError & e) {
-                // NOTE(cole-h): catches both nix::Error and nix::Interrupted -- enqueueItem calls
-                // writeFull which may throw nix::Interrupted, and the rest of enqueueItem may throw
-                // nix::Error
-                item->fail(e);
-                return ItemHandle(item.get_ptr());
-            }
+            return make_ref<TransferItem>(*this, std::move(modifiedRequest), std::move(callback));
+        } else {
+            return make_ref<TransferItem>(*this, request, std::move(callback));
         }
+    }
 
-        auto item = make_ref<TransferItem>(*this, request, std::move(callback));
+    ItemHandle
+    enqueueFileTransfer(const FileTransferRequest & request, Callback<FileTransferResult> callback) noexcept override
+    {
+        const auto item = makeTransferItem(request, std::move(callback));
+
         try {
             return enqueueItem(item);
         } catch (const nix::BaseError & e) {


### PR DESCRIPTION
## Motivation

The `enqueueFileTransfer` function needs refactoring, even more so after PR #348.

This PR (just one commit) should be added to PR #348.

## Context

I tried to add the change as a suggestion, but the result did not look good in github GUI. So I'm making it a PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. This update includes internal refactoring of file transfer handling to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->