### PR TITLE
Backward compatibility hack for getFlake applied to unsafeDiscardStringContext

### DIFF
--- a/src/libflake/flake-primops.cc
+++ b/src/libflake/flake-primops.cc
@@ -30,6 +30,7 @@
 #include "nix/util/source-path.hh"
 #include "nix/util/types.hh"
 #include "nix/util/util.hh"
+#include "nix/util/mounted-source-accessor.hh"
 
 namespace nix::flake::primops {
 
@@ -74,14 +75,11 @@ PrimOp getFlake(const Settings & settings)
                 if (auto sourcePath = flakeRef.input.getSourcePath();
                     sourcePath && state.store->isInStore(sourcePath->string())) {
                     auto [storePath, subPath] = state.store->toStorePath(sourcePath->string());
-                    for (auto & c : context) {
-                        if (auto p = std::get_if<NixStringContextElem::Path>(&c.raw); p && p->storePath == storePath) {
-                            auto path = state.storePath(storePath) / CanonPath(subPath);
-                            if (!flakeRef.subdir.empty())
-                                path = path / flakeRef.subdir;
-                            callFlake(state, lockFlake(settings, state, path, lockFlags), v);
-                            return;
-                        }
+                    if (auto mount = state.storeFS->getMount(CanonPath(state.store->printStorePath(storePath)))) {
+                        auto path = state.storePath(storePath) / CanonPath(subPath);
+                        if (!flakeRef.subdir.empty())
+                            path = path / flakeRef.subdir;
+                        return callFlake(state, lockFlake(settings, state, path, lockFlags), v);
                     }
                 }
             }

--- a/tests/functional/flakes/get-flake.sh
+++ b/tests/functional/flakes/get-flake.sh
@@ -25,3 +25,22 @@ expectStderr 0 nix eval "$flake1Dir/subflake#x" | grepQuiet "This may become a f
 [[ $(nix eval "$flake1Dir/subflake#x") = 123 ]]
 
 [[ $(nix eval "$flake1Dir/subflake#y") = 123 ]]
+
+# Check backward compatibility with getFlake applied to a store path with discarded string context.
+cat > "$flake1Dir/flake.nix" <<EOF
+{
+  outputs =
+    { self }:
+    let
+      flakeOutputs = builtins.getFlake (
+        builtins.unsafeDiscardStringContext "path:\${self.sourceInfo}?narHash=\${self.narHash}"
+      );
+    in
+    {
+      foo = "bar";
+      inherit flakeOutputs;
+    };
+}
+EOF
+
+[[ $(nix eval --raw "$flake1Dir#flakeOutputs.foo") = bar ]]


### PR DESCRIPTION
## Motivation

Similar to https://github.com/DeterminateSystems/nix-src/pull/402 but with a different kind of string context.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backward-compatibility handling for `builtins.getFlake` with path flake references, using a more direct store filesystem lookup approach.

* **Tests**
  * Added functional test verifying `getFlake` backward compatibility when applied to store-path string contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->