### PR TITLE
Provide the pre-build hook with a JSON serialization of the derivation

### DIFF
--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -1523,7 +1523,7 @@ adl_serializer<DerivationOutput>::from_json(const json & _json, const Experiment
     }
 }
 
-void adl_serializer<Derivation>::to_json(json & res, const Derivation & d)
+void adl_serializer<BasicDerivation>::to_json(json & res, const BasicDerivation & d)
 {
     res = nlohmann::json::object();
 
@@ -1549,24 +1549,6 @@ void adl_serializer<Derivation>::to_json(json & res, const Derivation & d)
             for (auto & input : d.inputSrcs)
                 inputsList.emplace_back(input);
         }
-
-        auto doInput = [&](this const auto & doInput, const auto & inputNode) -> nlohmann::json {
-            auto value = nlohmann::json::object();
-            value["outputs"] = inputNode.value;
-            {
-                auto next = nlohmann::json::object();
-                for (auto & [outputId, childNode] : inputNode.childMap)
-                    next[outputId] = doInput(childNode);
-                value["dynamicOutputs"] = std::move(next);
-            }
-            return value;
-        };
-
-        auto & inputDrvsObj = inputsObj["drvs"];
-        inputDrvsObj = nlohmann::json::object();
-        for (auto & [inputDrv, inputNode] : d.inputDrvs.map) {
-            inputDrvsObj[inputDrv.to_string()] = doInput(inputNode);
-        }
     }
 
     res["system"] = d.platform;
@@ -1576,6 +1558,28 @@ void adl_serializer<Derivation>::to_json(json & res, const Derivation & d)
 
     if (d.structuredAttrs)
         res["structuredAttrs"] = d.structuredAttrs->structuredAttrs;
+}
+
+void adl_serializer<Derivation>::to_json(json & res, const Derivation & d)
+{
+    adl_serializer<BasicDerivation>::to_json(res, static_cast<const BasicDerivation &>(d));
+
+    auto doInput = [&](this const auto & doInput, const auto & inputNode) -> nlohmann::json {
+        auto value = nlohmann::json::object();
+        value["outputs"] = inputNode.value;
+        {
+            auto next = nlohmann::json::object();
+            for (auto & [outputId, childNode] : inputNode.childMap)
+                next[outputId] = doInput(childNode);
+            value["dynamicOutputs"] = std::move(next);
+        }
+        return value;
+    };
+
+    auto & inputDrvsObj = res["inputs"]["drvs"];
+    inputDrvsObj = nlohmann::json::object();
+    for (auto & [inputDrv, inputNode] : d.inputDrvs.map)
+        inputDrvsObj[inputDrv.to_string()] = doInput(inputNode);
 }
 
 Derivation adl_serializer<Derivation>::from_json(const json & _json, const ExperimentalFeatureSettings & xpSettings)

--- a/src/libstore/include/nix/store/derivations.hh
+++ b/src/libstore/include/nix/store/derivations.hh
@@ -614,3 +614,4 @@ constexpr unsigned expectedJsonVersionDerivation = 4;
 
 JSON_IMPL_WITH_XP_FEATURES(nix::DerivationOutput)
 JSON_IMPL_WITH_XP_FEATURES(nix::Derivation)
+JSON_IMPL_WITH_XP_FEATURES(nix::BasicDerivation)

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -1081,10 +1081,24 @@ public:
           captured by the derivation model itself and are too variable between
           different versions of the same system to be hard-coded into nix.
 
-          The hook is passed the derivation path and, if sandboxes are
-          enabled, the sandbox directory. It can then modify the sandbox and
-          send a series of commands to modify various settings to stdout. The
-          currently recognized commands are:
+          The hook receives the derivation to be built as JSON in the file
+          pointed to by the environment variable `NIX_DERIVATION_V4`. See
+          [@docroot@/protocols/json/derivation/index.md](@docroot@/protocols/json/derivation/index.md)
+          for the format. For example, to read the `requiredSystemFeatures`
+          attribute:
+
+          ```sh
+          jq -r '.env.requiredSystemFeatures' < "$NIX_DERIVATION_V4"
+          ```
+
+          > **Deprecated**
+          > Using the derivation store path passed as `argv[1]` to inspect the
+          > derivation is deprecated and not recommended. This path may not
+          > exist when Nix is invoked as a remote builder.
+
+          If sandboxes are enabled, the hook also receives the sandbox
+          directory as `argv[2]`. It can send a series of commands to modify
+          various settings to stdout. The currently recognized commands are:
 
             - `extra-sandbox-paths`\
               Pass a list of files and directories to be included in the

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -22,6 +22,7 @@
 #include "nix/util/terminal.hh"
 #include "nix/store/provenance.hh"
 
+#include <nlohmann/json.hpp>
 #include <queue>
 
 #include <sys/un.h>
@@ -932,8 +933,27 @@ PathsInChroot DerivationBuilderImpl::getPathsInSandbox()
 
         enum BuildHookState { stBegin, stExtraChrootDirs };
 
+        nlohmann::json drvJson = drv;
+
+        auto [tmpFd, drvJsonPath] = createTempFile("nix-drv-json");
+        writeFile(drvJsonPath, drvJson.dump());
+        AutoDelete drvJsonFile(drvJsonPath, false);
+
+        auto hookEnv = getEnv();
+        static_assert(expectedJsonVersionDerivation == 4);
+        hookEnv["NIX_DERIVATION_V4"] = drvJsonPath;
+
+        auto [hookStatus, lines] = runProgram(
+            RunOptions{
+                .program = settings.preBuildHook,
+                .lookupPath = false,
+                .args = getPreBuildHookArgs(),
+                .environment = std::move(hookEnv),
+            });
+        if (!statusOk(hookStatus))
+            throw ExecError(hookStatus, "pre-build hook '%1%' %2%", settings.preBuildHook, statusToString(hookStatus));
+
         auto state = stBegin;
-        auto lines = runProgram(settings.preBuildHook, false, getPreBuildHookArgs());
         auto lastPos = std::string::size_type{0};
         for (auto nlPos = lines.find('\n'); nlPos != std::string::npos; nlPos = lines.find('\n', lastPos)) {
             auto line = lines.substr(lastPos, nlPos - lastPos);

--- a/tests/functional/linux-sandbox.sh
+++ b/tests/functional/linux-sandbox.sh
@@ -102,3 +102,24 @@ nix-sandbox-build symlink-derivation.nix -A test_sandbox_paths \
 expectStderr 1 nix-sandbox-build --option extra-sandbox-paths '/does-not-exist' \
     -E 'with import '"${config_nix}"'; mkDerivation { name = "trivial"; buildCommand = "echo > $out"; }' |
     grepQuiet "path '/does-not-exist' is configured as part of the \`sandbox-paths\` option, but is inaccessible"
+
+# Test pre-build-hook.
+DEST="$TEST_ROOT/hook-output"
+HOOK="$TEST_ROOT/pre-build-hook"
+
+echo foo > "$TEST_ROOT"/fnord
+
+cat > "$HOOK" <<EOF
+#! $SHELL -e
+jq -r .env.name < "\$NIX_DERIVATION_V4" > "$DEST"
+echo "hello from hook!" >&2
+echo "extra-sandbox-paths"
+echo "/foo/bar=$TEST_ROOT/fnord"
+EOF
+chmod +x "$HOOK"
+
+outPath=$(nix-build --no-out-link --sandbox-paths /nix/store --pre-build-hook "$HOOK" symlink-derivation.nix -A test_sandbox_paths_2)
+
+[[ $(cat "$TEST_ROOT/store0/nix/store/$(basename "$outPath")/xyzzy") = foo ]]
+
+[[ "$(cat "$DEST")" == "test-sandbox-paths-2" ]]

--- a/tests/functional/symlink-derivation.nix
+++ b/tests/functional/symlink-derivation.nix
@@ -56,4 +56,12 @@ in
       touch $out
     '';
   };
+
+  test_sandbox_paths_2 = mkDerivation {
+    name = "test-sandbox-paths-2";
+    buildCommand = ''
+      mkdir $out
+      cat /foo/bar > $out/xyzzy
+    '';
+  };
 }


### PR DESCRIPTION
## Motivation

This allows the hook to inspect derivation attributes such as `requiredSystemFeatures`.

The hook already gets the path of the derivation as an argument, but the derivation typically doesn't exist when called as a remote build.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pre-build hooks now receive derivation JSON via the `NIX_DERIVATION_V4` environment variable, enabling structured inspection of derivation details.

* **Documentation**
  * Updated pre-build-hook documentation with usage examples and deprecation guidance for the derivation store path approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->