### PR TITLE
getLegacyGitAccessor(): Don't ignore errors

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -834,11 +834,20 @@ struct GitInputScheme : InputScheme
             options.submodules
                 ? [&]() {
                       // Nix < 2.20 used `git checkout` for repos with submodules.
-                      runProgram({.program = "git", .args = {"init", tmpDir, "-b", "master"}});
-                      runProgram({.program = "git", .args = {"-C", tmpDir, "remote", "add", "origin", repoDir}});
-                      runProgram(
-                          {.program = "git", .args = {"-C", tmpDir, "fetch", "--quiet", "origin", rev.gitRev()}});
-                      runProgram({.program = "git", .args = {"-C", tmpDir, "checkout", "--quiet", rev.gitRev()}});
+                      StringSink sink; // don't pollute stdout
+                      runProgram2({.program = "git", .args = {"init", tmpDir, "-b", "master"}, .standardOut = &sink});
+                      runProgram2(
+                          {.program = "git",
+                           .args = {"-C", tmpDir, "remote", "add", "origin", repoDir},
+                           .standardOut = &sink});
+                      runProgram2(
+                          {.program = "git",
+                           .args = {"-C", tmpDir, "fetch", "--quiet", "origin", rev.gitRev()},
+                           .standardOut = &sink});
+                      runProgram2(
+                          {.program = "git",
+                           .args = {"-C", tmpDir, "checkout", "--quiet", rev.gitRev()},
+                           .standardOut = &sink});
                       PathFilter filter = [&](const Path & path) { return baseNameOf(path) != ".git"; };
                       return store.addToStore(
                           "source",


### PR DESCRIPTION
## Motivation

Fix a regression introduced in fbf176d0a874783f4669fc3600a6b3fdf46089e3 that caused `getLegacyGitAccessor()` to ignore errors from Git. This could lead to empty Git exports in the Nix store.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced output clarity for git submodule operations. When fetching git repositories with submodules enabled, the system now executes all necessary git operations without producing unnecessary console output. This results in significantly cleaner build logs and makes it easier to identify actual issues or important information during the fetch process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->