### PR TITLE
boost::thread_resource_error improvements

### DIFF
--- a/src/libexpr/parallel-eval.cc
+++ b/src/libexpr/parallel-eval.cc
@@ -32,8 +32,16 @@ Executor::Executor(const EvalSettings & evalSettings)
 {
     debug("executor using %d threads", evalCores);
     auto state(state_.lock());
+    // FIXME: create worker threads on demand?
     for (size_t n = 0; n < evalCores; ++n)
-        createWorker(*state);
+        try {
+            createWorker(*state);
+        } catch (boost::thread_resource_error & e) {
+            if (n == 0)
+                throw Error("could not create any evaluator worker threads: %s", e.what());
+            warn("could only create %d evaluator worker threads: %s", n, e.what());
+            break;
+        }
 }
 
 Executor::~Executor()

--- a/src/libexpr/parallel-eval.cc
+++ b/src/libexpr/parallel-eval.cc
@@ -17,8 +17,10 @@ thread_local bool Executor::amWorkerThread{false};
 
 unsigned int Executor::getEvalCores(const EvalSettings & evalSettings)
 {
+    /* Note: the default number of cores is currently limited to 32
+       due to scalability bottlenecks. */
     return evalSettings.evalProfilerMode != EvalProfilerMode::disabled ? 1
-           : evalSettings.evalCores == 0UL                             ? Settings::getDefaultCores()
+           : evalSettings.evalCores == 0UL                             ? std::min(32U, Settings::getDefaultCores())
                                                                        : evalSettings.evalCores;
 }
 


### PR DESCRIPTION
## Motivation

* Make boost::thread_resource_error a non-fatal error, so long as there is at least one eval thread. Not sure if this will actually help, since if we're at the process limit, then presumably any other thread/process creation will fail as well.
* Limit the default number of eval cores to 32.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluator worker startup: clearer error when no workers can be created and a warning/report when only a subset start successfully.

* **Chores**
  * Capped default evaluation core allocation (when profiling is disabled) to a practical maximum to avoid excessive core use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->