### PR TITLE
Add `nix serve` command

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -147,4 +147,9 @@ scope: {
     # Avoid having two curls in our closure.
     inherit (scope) curl;
   };
+
+  libmicrohttpd = pkgs.libmicrohttpd.overrideDerivation (old: {
+    # Don't pull in gnutls since it's pretty big and we don't need it.
+    configureFlags = [ "--without-gnutls" ];
+  });
 }

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -150,6 +150,6 @@ scope: {
 
   libmicrohttpd = pkgs.libmicrohttpd.overrideDerivation (old: {
     # Don't pull in gnutls since it's pretty big and we don't need it.
-    configureFlags = [ "--without-gnutls" ];
+    configureFlags = old.configureFlags or [ ] ++ [ "--without-gnutls" ];
   });
 }

--- a/src/libfetchers/git-lfs-fetch.cc
+++ b/src/libfetchers/git-lfs-fetch.cc
@@ -8,6 +8,7 @@
 #include "nix/util/util.hh"
 #include "nix/util/hash.hh"
 #include "nix/store/ssh.hh"
+#include "nix/util/deleter.hh"
 
 #include <git2/attr.h>
 #include <git2/config.h>

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -14,6 +14,7 @@
 #include "nix/util/thread-pool.hh"
 #include "nix/util/pool.hh"
 #include "nix/util/executable-path.hh"
+#include "nix/util/deleter.hh"
 
 #include <git2/attr.h>
 #include <git2/blob.h>

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -136,17 +136,6 @@ struct GitRepo
     virtual Hash dereferenceSingletonDirectory(const Hash & oid) = 0;
 };
 
-// A helper to ensure that the `git_*_free` functions get called.
-template<auto del>
-struct Deleter
-{
-    template<typename T>
-    void operator()(T * p) const
-    {
-        del(p);
-    };
-};
-
 // A helper to ensure that we don't leak objects returned by libgit2.
 template<typename T>
 struct Setter

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -127,10 +127,16 @@ struct curlFileTransfer : public FileTransfer
         bool acceptRanges:1 = false;
 
         /**
+         * When retrying, whether to request a range.
+         */
+        bool requestRange:1 = false;
+
+        /**
          * Whether the response has a non-trivial (not "identity") Content-Encoding.
          */
         bool hasContentEncoding:1 = false;
 
+        curl_off_t bytesReceived = 0;
         curl_off_t writtenToSink = 0;
 
         std::chrono::steady_clock::time_point startTime = std::chrono::steady_clock::now();
@@ -175,6 +181,18 @@ struct curlFileTransfer : public FileTransfer
                     /* Only write data to the sink if this is a
                        successful response. */
                     if (successfulStatuses.count(httpStatus)) {
+
+                        auto prevReceived = bytesReceived;
+                        bytesReceived += data.size();
+
+                        /* Discard data that we've already received and sent to the sink in a previous try. */
+                        if (prevReceived < writtenToSink) {
+                            if (writtenToSink - prevReceived >= (curl_off_t) data.size()) {
+                                return;
+                            }
+                            data = data.substr(writtenToSink - prevReceived);
+                        }
+
                         writtenToSink += data.size();
                         PauseTransfer needsPause = this->request.dataCallback(data);
                         if (needsPause == PauseTransfer::Yes) {
@@ -299,6 +317,7 @@ struct curlFileTransfer : public FileTransfer
                 statusMsg = trim(match.str(1));
                 acceptRanges = false;
                 hasContentEncoding = false;
+                bytesReceived = 0;
                 appendCurrentUrl();
             } else {
 
@@ -488,7 +507,7 @@ struct curlFileTransfer : public FileTransfer
                Skip for uploads (Accept-Encoding is meaningless when sending data)
                and when resuming from an offset (byte ranges don't work with
                compressed content). */
-            if (writtenToSink == 0 && !request.data)
+            if (requestRange && !request.data)
                 /* Empty string means to enable all supported (that libcurl has
                    been linked to support) encodings. */
                 curl_easy_setopt(req, CURLOPT_ACCEPT_ENCODING, "");
@@ -566,7 +585,7 @@ struct curlFileTransfer : public FileTransfer
             curl_easy_setopt(req, CURLOPT_NETRC_FILE, fileTransfer.settings.netrcFile.get().c_str());
             curl_easy_setopt(req, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
 
-            if (writtenToSink)
+            if (requestRange)
                 curl_easy_setopt(req, CURLOPT_RESUME_FROM_LARGE, writtenToSink);
 
             /* Note that the underlying strings get copied by libcurl, so the path -> string conversion is ok:
@@ -745,12 +764,14 @@ struct curlFileTransfer : public FileTransfer
                    sink, we can only retry if the server supports
                    ranged requests. */
                 if (err == Transient && attempt < fileTransfer.settings.tries
-                    && (!this->request.dataCallback || writtenToSink == 0 || (acceptRanges && !hasContentEncoding))) {
+                    && !(this->request.dataCallback && hasContentEncoding)) {
                     int ms = retryTimeMs
                              * std::pow(
                                  2.0f, attempt - 1 + std::uniform_real_distribution<>(0.0, 0.5)(fileTransfer.mt19937));
 
                     if (writtenToSink) {
+                        if (acceptRanges)
+                            requestRange = true;
                         warn(
                             "%s; retrying from offset %d in %d ms (attempt %d/%d)",
                             exc.message(),

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -987,7 +987,7 @@ void LocalStore::invalidatePath(State & state, const StorePath & path)
     /* Note that the foreign key constraints on the Refs table take
        care of deleting the references entries for `path'. */
 
-    pathInfoCache->lock()->erase(path);
+    invalidatePathInfoCacheFor(path);
 }
 
 const PublicKeys & LocalStore::getPublicKeys()
@@ -1023,17 +1023,18 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
             auto realPath = toRealPath(info.path);
 
             /* Lock the output path.  But don't lock if we're being called
-            from a build hook (whose parent process already acquired a
-            lock on this path). */
+               from a build hook (whose parent process already acquired a
+               lock on this path). */
             if (!locksHeld.count(printStorePath(info.path)))
                 outputLock.lockPaths({realPath});
 
-            if (repair || !isValidPath(info.path)) {
+            /* The path may have been created by another process in the meantime, so check again. */
+            if (repair || !isValidPathUncached(info.path)) {
 
                 deletePath(realPath);
 
                 /* While restoring the path from the NAR, compute the hash
-                of the NAR. */
+                   of the NAR. */
                 HashSink hashSink(HashAlgorithm::SHA256);
 
                 TeeSource wrapperSource{source, hashSink};
@@ -1104,7 +1105,9 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
                 }
 
                 registerValidPath(info);
-            }
+            } else
+                // We may have a negative cache entry for this path, so get rid of it.
+                invalidatePathInfoCacheFor(info.path);
 
             outputLock.setDeletion(true);
         }
@@ -1222,7 +1225,8 @@ StorePath LocalStore::addToStoreFromDump(
 
         PathLocks outputLock({realPath});
 
-        if (repair || !isValidPath(dstPath)) {
+        /* The path may have been created by another process in the meantime, so check again. */
+        if (repair || !isValidPathUncached(dstPath)) {
 
             deletePath(realPath);
 
@@ -1270,7 +1274,9 @@ StorePath LocalStore::addToStoreFromDump(
             info.narSize = narHash.numBytesDigested;
             info.provenance = provenance;
             registerValidPath(info);
-        }
+        } else
+            // We may have a negative cache entry for this path, so get rid of it.
+            invalidatePathInfoCacheFor(dstPath);
 
         outputLock.setDeletion(true);
     }

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -277,7 +277,7 @@ MissingPaths Store::queryMissing(const std::vector<DerivedPath> & targets)
                         mustBuildDrv(drvPath, *drv);
                 },
                 [&](const DerivedPath::Opaque & bo) {
-                    if (isValidPath(bo.path))
+                    if (maybeQueryPathInfo(bo.path))
                         return;
 
                     SubstitutablePathInfos infos;

--- a/src/libstore/nar-info.cc
+++ b/src/libstore/nar-info.cc
@@ -113,9 +113,12 @@ std::string NarInfo::to_string(const StoreDirConfig & store) const
     res += "URL: " + url + "\n";
     assert(compression != "");
     res += "Compression: " + compression + "\n";
-    assert(fileHash && fileHash->algo == HashAlgorithm::SHA256);
-    res += "FileHash: " + fileHash->to_string(HashFormat::Nix32, true) + "\n";
-    res += "FileSize: " + std::to_string(fileSize) + "\n";
+    if (fileHash) {
+        assert(fileHash->algo == HashAlgorithm::SHA256);
+        res += "FileHash: " + fileHash->to_string(HashFormat::Nix32, true) + "\n";
+    }
+    if (fileSize)
+        res += "FileSize: " + std::to_string(fileSize) + "\n";
     assert(narHash.algo == HashAlgorithm::SHA256);
     res += "NarHash: " + narHash.to_string(HashFormat::Nix32, true) + "\n";
     res += "NarSize: " + std::to_string(narSize) + "\n";

--- a/src/libutil/include/nix/util/deleter.hh
+++ b/src/libutil/include/nix/util/deleter.hh
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace nix {
+
+/**
+ * A helper for `std::unique_ptr` that ensures that C APIs that require manual memory management get properly freed. The
+ * template parameter `del` is a function that takes a pointer and frees it.
+ */
+template<auto del>
+struct Deleter
+{
+    template<typename T>
+    void operator()(T * p) const
+    {
+        del(p);
+    };
+};
+
+} // namespace nix

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -12,6 +12,7 @@
 #include "nix/util/types.hh"
 #include "nix/util/file-descriptor.hh"
 #include "nix/util/file-path.hh"
+#include "nix/util/deleter.hh"
 
 #include <filesystem>
 #include <sys/types.h>
@@ -374,15 +375,7 @@ public:
     }
 };
 
-struct DIRDeleter
-{
-    void operator()(DIR * dir) const
-    {
-        closedir(dir);
-    }
-};
-
-typedef std::unique_ptr<DIR, DIRDeleter> AutoCloseDir;
+typedef std::unique_ptr<DIR, Deleter<closedir>> AutoCloseDir;
 
 /**
  * Create a temporary directory.

--- a/src/libutil/include/nix/util/meson.build
+++ b/src/libutil/include/nix/util/meson.build
@@ -31,6 +31,7 @@ headers = [ config_pub_h ] + files(
   'config-impl.hh',
   'configuration.hh',
   'current-process.hh',
+  'deleter.hh',
   'demangle.hh',
   'english.hh',
   'environment-variables.hh',

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -34,6 +34,9 @@ subdir('nix-meson-build-support/subprojects')
 subdir('nix-meson-build-support/export-all-symbols')
 subdir('nix-meson-build-support/windows-version')
 
+libmicrohttpd = dependency('libmicrohttpd')
+deps_private += libmicrohttpd
+
 configdata = configuration_data()
 
 # The CLI has a more detailed version string than the libraries; see `nixVersion`
@@ -114,6 +117,7 @@ nix_sources = [ config_priv_h ] + files(
   'run.cc',
   'search.cc',
   'self-exe.cc',
+  'serve.cc',
   'sigs.cc',
   'store-copy-log.cc',
   'store-delete.cc',

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -10,6 +10,8 @@
   nix-cmd,
   sentry-native,
 
+  libmicrohttpd,
+
   # Configuration Options
 
   version,
@@ -72,6 +74,7 @@ mkMesonExecutable (finalAttrs: {
     nix-expr
     nix-main
     nix-cmd
+    libmicrohttpd
   ]
   ++ lib.optional (
     stdenv.cc.isClang

--- a/src/nix/serve.cc
+++ b/src/nix/serve.cc
@@ -55,7 +55,19 @@ struct CmdServe : StoreCommand
 
     std::string description() override
     {
-        return "serve a Nix store over the network";
+        return "serve a Nix store as a HTTP binary cache";
+    }
+
+    Category category() override
+    {
+        return catSecondary;
+    }
+
+    std::string doc() override
+    {
+        return
+#include "serve.md"
+            ;
     }
 
     MHD_Result

--- a/src/nix/serve.cc
+++ b/src/nix/serve.cc
@@ -1,7 +1,7 @@
 #include "nix/cmd/command.hh"
 #include "nix/util/file-system.hh"
 #include "nix/util/signals.hh"
-#include "nix/fetchers/git-utils.hh" // for Deleter
+#include "nix/util/deleter.hh"
 #include "nix/store/nar-info.hh"
 
 #include <future>

--- a/src/nix/serve.cc
+++ b/src/nix/serve.cc
@@ -5,6 +5,7 @@
 #include "nix/util/deleter.hh"
 #include "nix/store/nar-info.hh"
 #include "nix/store/binary-cache-store.hh"
+#include "nix/store/log-store.hh"
 
 #include <future>
 #include <regex>
@@ -95,11 +96,12 @@ struct CmdServe : StoreCommand
 
         static const std::regex narInfoUrlRegex{R"(^/([0-9a-z]+)\.narinfo$)"};
         static const std::regex narUrlRegex{R"(^/nar/([0-9a-z]+)-([0-9a-z]+)\.nar$)"};
+        static const std::regex logUrlRegex{R"(^/log/([0-9a-z]+-[0-9a-zA-Z+\-._?=]+)$)"};
 
         if (method != MHD_HTTP_METHOD_GET && method != MHD_HTTP_METHOD_HEAD) {
             std::string_view body = "405 method not allowed\n";
             response.reset(MHD_create_response_from_buffer(body.size(), (void *) body.data(), MHD_RESPMEM_PERSISTENT));
-            MHD_add_response_header(response.get(), "Allow", MHD_HTTP_METHOD_GET);
+            MHD_add_response_header(response.get(), "Allow", "GET, HEAD");
             return MHD_queue_response(connection, MHD_HTTP_METHOD_NOT_ALLOWED, response.get());
         }
 
@@ -186,6 +188,20 @@ struct CmdServe : StoreCommand
 
             response.reset(MHD_create_response_from_callback(MHD_SIZE_UNKNOWN, 65536, reader, state.release(), freeCb));
             MHD_add_response_header(response.get(), "Content-Type", "application/x-nix-nar");
+
+        } else if (std::smatch m; std::regex_match(url, m, logUrlRegex)) {
+            auto * logStore = dynamic_cast<LogStore *>(&store);
+            if (!logStore)
+                return notFound();
+
+            StorePath path{m[1].str()};
+
+            auto log = logStore->getBuildLog(path);
+            if (!log)
+                return notFound();
+
+            response.reset(MHD_create_response_from_buffer(log->size(), log->data(), MHD_RESPMEM_MUST_COPY));
+            MHD_add_response_header(response.get(), "Content-Type", "text/plain; charset=utf-8");
         } else
             return notFound();
 

--- a/src/nix/serve.cc
+++ b/src/nix/serve.cc
@@ -234,6 +234,11 @@ struct CmdServe : StoreCommand
         if (!daemon)
             throw Error("failed to start HTTP daemon on %s:%d", listenAddress, port);
 
+        Finally _stopDaemon{[&] {
+            notice("Shutting down...");
+            MHD_stop_daemon(daemon);
+        }};
+
         auto * info = MHD_get_daemon_info(daemon, MHD_DAEMON_INFO_BIND_PORT);
         uint16_t boundPort = info ? info->port : port;
         notice("Listening on http://%s:%d/", listenAddress, boundPort);
@@ -246,9 +251,6 @@ struct CmdServe : StoreCommand
         std::future<void> interruptFuture = interruptPromise.get_future();
         auto callback = createInterruptCallback([&]() { interruptPromise.set_value(); });
         interruptFuture.get();
-
-        notice("Shutting down...");
-        MHD_stop_daemon(daemon);
     }
 };
 

--- a/src/nix/serve.cc
+++ b/src/nix/serve.cc
@@ -5,6 +5,7 @@
 #include "nix/util/deleter.hh"
 #include "nix/store/nar-info.hh"
 #include "nix/store/binary-cache-store.hh"
+#include "nix/util/environment-variables.hh"
 
 #include <future>
 #include <regex>
@@ -160,6 +161,14 @@ struct CmdServe : StoreCommand
                     read++;
                     state.firstByte.reset();
                 }
+
+                static bool truncate = getEnv("_NIX_TEST_NIX_SERVE_TRUNCATE_NAR").value_or("") == "1";
+                static std::atomic<uint64_t> truncatePoint{200000};
+                if (truncate && pos > truncatePoint) {
+                    truncatePoint += 200000;
+                    return MHD_CONTENT_READER_END_WITH_ERROR;
+                }
+
                 try {
                     read += state.source->read(buf, max);
                     return read;

--- a/src/nix/serve.cc
+++ b/src/nix/serve.cc
@@ -3,6 +3,7 @@
 #include "nix/util/signals.hh"
 #include "nix/util/deleter.hh"
 #include "nix/store/nar-info.hh"
+#include "nix/store/binary-cache-store.hh"
 
 #include <future>
 #include <regex>
@@ -117,11 +118,14 @@ struct CmdServe : StoreCommand
             if (info->narHash.to_string(HashFormat::Nix32, false) != expectedNarHash)
                 return notFound();
 
-            StringSink sink;
-            store.narFromPath(*path, sink);
-            response.reset(MHD_create_response_from_buffer(sink.s.size(), sink.s.data(), MHD_RESPMEM_MUST_COPY));
-            MHD_add_response_header(response.get(), "Content-Type", "application/x-nix-nar");
-
+            try {
+                StringSink sink;
+                store.narFromPath(*path, sink);
+                response.reset(MHD_create_response_from_buffer(sink.s.size(), sink.s.data(), MHD_RESPMEM_MUST_COPY));
+                MHD_add_response_header(response.get(), "Content-Type", "application/x-nix-nar");
+            } catch (SubstituteGone & e) {
+                return notFound();
+            }
         } else
             return notFound();
 

--- a/src/nix/serve.cc
+++ b/src/nix/serve.cc
@@ -1,5 +1,6 @@
 #include "nix/cmd/command.hh"
 #include "nix/util/file-system.hh"
+#include "nix/util/serialise.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/deleter.hh"
 #include "nix/store/nar-info.hh"
@@ -126,14 +127,53 @@ struct CmdServe : StoreCommand
             if (info->narHash.to_string(HashFormat::Nix32, false) != expectedNarHash)
                 return notFound();
 
+            struct State
+            {
+                std::unique_ptr<Source> source;
+                std::optional<char> firstByte;
+            };
+
+            auto state = std::make_unique<State>();
+
+            state->source = sinkToSource([&store, p = *path](Sink & sink) { store.narFromPath(p, sink); });
+
+            // Read the first byte so we can return a 404 if the store path / NAR doesn't exist anymore.
             try {
-                StringSink sink;
-                store.narFromPath(*path, sink);
-                response.reset(MHD_create_response_from_buffer(sink.s.size(), sink.s.data(), MHD_RESPMEM_MUST_COPY));
-                MHD_add_response_header(response.get(), "Content-Type", "application/x-nix-nar");
-            } catch (SubstituteGone & e) {
+                char firstByte;
+                if (state->source->read(&firstByte, 1))
+                    state->firstByte = firstByte;
+            } catch (InvalidPath &) {
                 return notFound();
+            } catch (SubstituteGone &) {
+                return notFound();
+            } catch (EndOfFile &) {
             }
+
+            // Stream the NAR.
+            auto reader = [](void * cls, uint64_t pos, char * buf, size_t max) -> ssize_t {
+                auto & state = *static_cast<State *>(cls);
+                size_t read = 0;
+                if (pos == 0 && state.firstByte) {
+                    *buf++ = *state.firstByte;
+                    pos++;
+                    max--;
+                    read++;
+                    state.firstByte.reset();
+                }
+                try {
+                    read += state.source->read(buf, max);
+                    return read;
+                } catch (EndOfFile &) {
+                    return MHD_CONTENT_READER_END_OF_STREAM;
+                } catch (...) {
+                    return MHD_CONTENT_READER_END_WITH_ERROR;
+                }
+            };
+
+            auto freeCb = [](void * cls) { delete static_cast<State *>(cls); };
+
+            response.reset(MHD_create_response_from_callback(MHD_SIZE_UNKNOWN, 65536, reader, state.release(), freeCb));
+            MHD_add_response_header(response.get(), "Content-Type", "application/x-nix-nar");
         } else
             return notFound();
 

--- a/src/nix/serve.cc
+++ b/src/nix/serve.cc
@@ -18,6 +18,7 @@ using Response = std::unique_ptr<MHD_Response, Deleter<MHD_destroy_response>>;
 struct CmdServe : StoreCommand
 {
     uint16_t port = 8080;
+    std::string listenAddress = "127.0.0.1";
     std::optional<int> priority;
     std::optional<std::filesystem::path> portFile;
 
@@ -29,6 +30,13 @@ struct CmdServe : StoreCommand
             .description = "Port to listen on (default: 8080). Use 0 to dynamically allocate a free port.",
             .labels = {"port"},
             .handler = {&port},
+        });
+        addFlag({
+            .longName = "listen-address",
+            .description = "IP address to listen on (default: `127.0.0.1`). "
+                           "Use `0.0.0.0` or `::` to listen on all interfaces.",
+            .labels = {"address"},
+            .handler = {&listenAddress},
         });
         addFlag({
             .longName = "port-file",
@@ -163,21 +171,32 @@ struct CmdServe : StoreCommand
             return cmd.handleRequest(store, connection, std::string(url), method);
         };
 
+        sockaddr_in addr4{};
+        sockaddr_in6 addr6{};
+        const sockaddr * sockAddr = nullptr;
+        unsigned int flags = MHD_USE_INTERNAL_POLLING_THREAD;
+
+        if (inet_pton(AF_INET, listenAddress.c_str(), &addr4.sin_addr) == 1) {
+            addr4.sin_family = AF_INET;
+            addr4.sin_port = htons(port);
+            sockAddr = (const sockaddr *) &addr4;
+        } else if (inet_pton(AF_INET6, listenAddress.c_str(), &addr6.sin6_addr) == 1) {
+            addr6.sin6_family = AF_INET6;
+            addr6.sin6_port = htons(port);
+            sockAddr = (const sockaddr *) &addr6;
+            flags |= MHD_USE_IPv6;
+        } else
+            throw Error("invalid listen address '%s'", listenAddress);
+
         auto * daemon = MHD_start_daemon(
-            MHD_USE_INTERNAL_POLLING_THREAD | MHD_USE_DUAL_STACK,
-            port,
-            nullptr,
-            nullptr,
-            handler,
-            &ctx,
-            MHD_OPTION_END);
+            flags, port, nullptr, nullptr, handler, &ctx, MHD_OPTION_SOCK_ADDR, sockAddr, MHD_OPTION_END);
 
         if (!daemon)
-            throw Error("failed to start HTTP daemon on port %d", port);
+            throw Error("failed to start HTTP daemon on %s:%d", listenAddress, port);
 
         auto * info = MHD_get_daemon_info(daemon, MHD_DAEMON_INFO_BIND_PORT);
         uint16_t boundPort = info ? info->port : port;
-        notice("Listening on http://[::]:%d/", boundPort);
+        notice("Listening on http://%s:%d/", listenAddress, boundPort);
 
         if (portFile)
             writeFile(*portFile, std::to_string(boundPort) + "\n");

--- a/src/nix/serve.cc
+++ b/src/nix/serve.cc
@@ -1,0 +1,192 @@
+#include "nix/cmd/command.hh"
+#include "nix/util/file-system.hh"
+#include "nix/util/signals.hh"
+#include "nix/fetchers/git-utils.hh" // for Deleter
+#include "nix/store/nar-info.hh"
+
+#include <future>
+#include <regex>
+
+#include <arpa/inet.h>
+#include <microhttpd.h>
+
+using namespace nix;
+
+using Response = std::unique_ptr<MHD_Response, Deleter<MHD_destroy_response>>;
+
+struct CmdServe : StoreCommand
+{
+    uint16_t port = 8080;
+    std::optional<int> priority;
+    std::optional<std::filesystem::path> portFile;
+
+    CmdServe()
+    {
+        addFlag({
+            .longName = "port",
+            .shortName = 'p',
+            .description = "Port to listen on (default: 8080). Use 0 to dynamically allocate a free port.",
+            .labels = {"port"},
+            .handler = {&port},
+        });
+        addFlag({
+            .longName = "port-file",
+            .description = "Write the bound port number to this file.",
+            .labels = {"path"},
+            .handler = {[this](std::string s) { portFile = s; }},
+        });
+        addFlag({
+            .longName = "priority",
+            .description = "Priority of this cache (overrides the store's default).",
+            .labels = {"priority"},
+            .handler = {[this](std::string s) { priority = std::stoi(s); }},
+        });
+    }
+
+    std::string description() override
+    {
+        return "serve a Nix store over the network";
+    }
+
+    MHD_Result
+    handleRequest(Store & store, MHD_Connection * connection, const std::string & url, std::string_view method)
+    try {
+        std::string clientAddr = "unknown";
+        if (auto * info = MHD_get_connection_info(connection, MHD_CONNECTION_INFO_CLIENT_ADDRESS)) {
+            char buf[INET6_ADDRSTRLEN];
+            auto * addr = info->client_addr;
+            const void * src = addr->sa_family == AF_INET6 ? (void *) &((sockaddr_in6 *) addr)->sin6_addr
+                                                           : (void *) &((sockaddr_in *) addr)->sin_addr;
+            if (inet_ntop(addr->sa_family, src, buf, sizeof(buf)))
+                clientAddr = buf;
+        }
+
+        notice("request: client=%s, method=%s, url=%s", clientAddr, method, url);
+
+        Response response;
+
+        auto notFound = [&] {
+            static constexpr std::string_view body = "404 not found\n";
+            response.reset(MHD_create_response_from_buffer(body.size(), (void *) body.data(), MHD_RESPMEM_PERSISTENT));
+            return MHD_queue_response(connection, MHD_HTTP_NOT_FOUND, response.get());
+        };
+
+        static const std::regex narInfoUrlRegex{R"(^/([0-9a-z]+)\.narinfo$)"};
+        static const std::regex narUrlRegex{R"(^/nar/([0-9a-z]+)-([0-9a-z]+)\.nar$)"};
+
+        if (method != MHD_HTTP_METHOD_GET && method != MHD_HTTP_METHOD_HEAD) {
+            std::string_view body = "405 method not allowed\n";
+            response.reset(MHD_create_response_from_buffer(body.size(), (void *) body.data(), MHD_RESPMEM_PERSISTENT));
+            MHD_add_response_header(response.get(), "Allow", MHD_HTTP_METHOD_GET);
+            return MHD_queue_response(connection, MHD_HTTP_METHOD_NOT_ALLOWED, response.get());
+        }
+
+        if (url == "/nix-cache-info") {
+            auto body = std::make_unique<std::string>(
+                        "StoreDir: " + store.storeDir + "\n"
+                        "WantMassQuery: " + (store.config.wantMassQuery ? "1" : "0") + "\n"
+                        "Priority: " + std::to_string(priority.value_or(store.config.priority)) + "\n");
+            response.reset(MHD_create_response_from_buffer(body->size(), body->data(), MHD_RESPMEM_MUST_COPY));
+            MHD_add_response_header(response.get(), "Content-Type", "text/x-nix-cache-info");
+
+        } else if (std::smatch m; std::regex_match(url, m, narInfoUrlRegex)) {
+            auto hashPart = m[1].str();
+            auto path = store.queryPathFromHashPart(hashPart);
+            if (!path)
+                return notFound();
+
+            auto info = store.queryPathInfo(*path);
+            NarInfo ni(*info);
+            ni.compression = "none";
+            // FIXME: would be nicer to use just the NAR hash, but we can't look up NARs by NAR hash.
+            ni.url = "nar/" + std::string(info->path.hashPart()) + "-"
+                     + info->narHash.to_string(HashFormat::Nix32, false) + ".nar";
+            ni.fileSize = info->narSize;
+            auto body = ni.to_string(store);
+            response.reset(MHD_create_response_from_buffer(body.size(), body.data(), MHD_RESPMEM_MUST_COPY));
+            MHD_add_response_header(response.get(), "Content-Type", "text/x-nix-narinfo");
+
+        } else if (std::smatch m; std::regex_match(url, m, narUrlRegex)) {
+            auto hashPart = m[1].str();
+            auto expectedNarHash = m[2].str();
+            auto path = store.queryPathFromHashPart(hashPart);
+            if (!path)
+                return notFound();
+
+            auto info = store.queryPathInfo(*path);
+            if (info->narHash.to_string(HashFormat::Nix32, false) != expectedNarHash)
+                return notFound();
+
+            StringSink sink;
+            store.narFromPath(*path, sink);
+            response.reset(MHD_create_response_from_buffer(sink.s.size(), sink.s.data(), MHD_RESPMEM_MUST_COPY));
+            MHD_add_response_header(response.get(), "Content-Type", "application/x-nix-nar");
+
+        } else
+            return notFound();
+
+        return MHD_queue_response(connection, MHD_HTTP_OK, response.get());
+
+    } catch (const Error & e) {
+        auto body = fmt("500 Internal Server Error\n\nError: %s", e.message());
+        Response response;
+        response.reset(MHD_create_response_from_buffer(body.size(), body.data(), MHD_RESPMEM_MUST_COPY));
+        MHD_add_response_header(response.get(), "Content-Type", "text/plain");
+        return MHD_queue_response(connection, MHD_HTTP_INTERNAL_SERVER_ERROR, response.get());
+    }
+
+    void run(ref<Store> store) override
+    {
+        struct Ctx
+        {
+            Store & store;
+            CmdServe & cmd;
+        };
+
+        Ctx ctx{*store, *this};
+
+        auto handler = [](void * cls,
+                          MHD_Connection * connection,
+                          const char * url,
+                          const char * method,
+                          const char * version,
+                          const char * upload_data,
+                          size_t * upload_data_size,
+                          void ** con_cls) -> MHD_Result {
+            auto & ctx = *static_cast<Ctx *>(cls);
+            auto & store = ctx.store;
+            auto & cmd = ctx.cmd;
+            return cmd.handleRequest(store, connection, std::string(url), method);
+        };
+
+        auto * daemon = MHD_start_daemon(
+            MHD_USE_INTERNAL_POLLING_THREAD | MHD_USE_DUAL_STACK,
+            port,
+            nullptr,
+            nullptr,
+            handler,
+            &ctx,
+            MHD_OPTION_END);
+
+        if (!daemon)
+            throw Error("failed to start HTTP daemon on port %d", port);
+
+        auto * info = MHD_get_daemon_info(daemon, MHD_DAEMON_INFO_BIND_PORT);
+        uint16_t boundPort = info ? info->port : port;
+        notice("Listening on http://[::]:%d/", boundPort);
+
+        if (portFile)
+            writeFile(*portFile, std::to_string(boundPort) + "\n");
+
+        /* Wait for Ctrl-C. */
+        std::promise<void> interruptPromise;
+        std::future<void> interruptFuture = interruptPromise.get_future();
+        auto callback = createInterruptCallback([&]() { interruptPromise.set_value(); });
+        interruptFuture.get();
+
+        notice("Shutting down...");
+        MHD_stop_daemon(daemon);
+    }
+};
+
+static auto rCmdServe = registerCommand<CmdServe>("serve");

--- a/src/nix/serve.md
+++ b/src/nix/serve.md
@@ -1,0 +1,48 @@
+R""(
+
+# Examples
+
+* Serve the local Nix store on the default port (8080), listening on localhost only:
+
+  ```console
+  # nix serve
+  Listening on http://127.0.0.1:8080/
+  ```
+
+* Serve the local store on all interfaces, on port 9000:
+
+  ```console
+  # nix serve --listen-address 0.0.0.0 --port 9000
+  ```
+
+  On another machine, you can then use this server as a substituter:
+
+  ```console
+  # nix copy --from http://other-host:8080 /nix/store/...-hello-2.12.1
+  ```
+
+* Serve a chroot store as a binary cache:
+
+  ```console
+  # nix serve --store /tmp/my-store
+  ```
+
+# Description
+
+`nix serve` runs an HTTP server that exposes a Nix store as a [binary
+cache](@docroot@/glossary.md#gloss-binary-cache). Clients can fetch
+store paths from this server by adding its URL to their list of
+[substituters](@docroot@/command-ref/conf-file.md#conf-substituters).
+
+NARs are served uncompressed.
+
+> **Note**
+>
+> `nix serve` only handles `GET` and `HEAD` requests; it cannot be
+> used to upload paths to the store. It also does not implement
+> authentication or TLS — if you want to expose it to the public
+> internet, run it behind a reverse proxy such as nginx.
+
+To shut down the server, send it a `SIGINT` signal.
+
+)""

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -150,7 +150,7 @@ wait "$pid2"
 # Test whether Nix notices if the NAR doesn't match the hash in the NAR info.
 clearStore
 
-nar=$(find "$cacheDir/nar/" -type f -name "*.nar.xz" | head -n1)
+nar=$cacheDir/$(nix path-info --json --store "file://$cacheDir" "$depPath" | jq -r .[].url)
 mv "$nar" "$nar".good
 mkdir -p "$TEST_ROOT/empty"
 nix-store --dump "$TEST_ROOT/empty" | xz > "$nar"

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -27,6 +27,13 @@ for path in "${paths[@]}"; do
         || [[ "$path" =~ -dependencies-top$ ]]
 done
 
+echo foobar > "$TEST_ROOT/big-file"
+for ((i = 0; i < 16; i++)); do
+    cat "$TEST_ROOT/big-file" "$TEST_ROOT/big-file" > "$TEST_ROOT/big-file.tmp"
+    mv "$TEST_ROOT/big-file.tmp" "$TEST_ROOT/big-file"
+done
+bigFile="$(nix store add-file --store "file://$cacheDir" "$TEST_ROOT/big-file")"
+
 # Test copying build logs to the binary cache.
 expect 1 nix log --store "file://$cacheDir" "$outPath" 2>&1 | grep 'is not available'
 nix store copy-log --to "file://$cacheDir" "$outPath"
@@ -120,8 +127,11 @@ basicDownloadTests "file://$cacheDir"
 
 # Test HttpBinaryCacheStore.
 restartNixServe
-nix store info --store "$httpBinaryCacheUrl"
 basicDownloadTests "$httpBinaryCacheUrl"
+
+# Regression test: queryMissing() should cache narinfos.
+nix path-info -vvvv --store "$httpBinaryCacheUrl" "$bigFile" 2> "$TEST_ROOT/log"
+[[ $(grep -c "downloading.*narinfo'" "$TEST_ROOT/log") -eq 1 ]]
 
 
 # Test that multiple concurrent substitutions do only one download.
@@ -134,7 +144,7 @@ pid2="$!"
 wait "$pid1"
 wait "$pid2"
 [[ $(cat "$TEST_ROOT/log1" "$TEST_ROOT/log2" | grep -c "copying path ") -eq 2 ]]
-[[ $(cat "$TEST_ROOT/log1" "$TEST_ROOT/log2" | grep -c "downloading.*nar") -eq 1 ]]
+[[ $(cat "$TEST_ROOT/log1" "$TEST_ROOT/log2" | grep -c "downloading.*nar'") -eq 1 ]]
 
 
 # Test whether Nix notices if the NAR doesn't match the hash in the NAR info.

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -129,7 +129,18 @@ basicDownloadTests "file://$cacheDir"
 restartNixServe
 basicDownloadTests "$httpBinaryCacheUrl"
 
+
+# Test whether resuming from a binary cache that doesn't support ranged requests works.
+export _NIX_TEST_NIX_SERVE_TRUNCATE_NAR=1
+restartNixServe
+clearStore
+nix-store -r "$bigFile" --substituters "$httpBinaryCacheUrl" 2>&1 | tee "$TEST_ROOT/log"
+[[ $(grep -c "curl error: Transferred a partial file" "$TEST_ROOT/log") -eq 2 ]]
+unset _NIX_TEST_NIX_SERVE_TRUNCATE_NAR
+
+
 # Regression test: queryMissing() should cache narinfos.
+restartNixServe
 nix path-info -vvvv --store "$httpBinaryCacheUrl" "$bigFile" 2> "$TEST_ROOT/log"
 [[ $(grep -c "downloading.*narinfo'" "$TEST_ROOT/log") -eq 1 ]]
 

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -43,33 +43,69 @@ nix log "$outPath" | grep FOO
 cacheDir2="$TEST_ROOT/binary+cache"
 nix copy --to "file://$cacheDir2" "$outPath" && [[ -d "$cacheDir2" ]]
 
+nixServePid=
+
+stopNixServe() {
+    if [[ -n "$nixServePid" ]]; then
+        kill "$nixServePid"
+        wait "$nixServePid"
+        unset nixServePid
+    fi
+}
+
+startNixServe() {
+    local portFile="$TEST_ROOT/nix-serve-port"
+    rm -f "$portFile"
+    nix serve --port 0 --port-file "$portFile" "$@" &
+    nixServePid="$!"
+    while [[ ! -e "$portFile" ]]; do
+        if ! kill -0 "$nixServePid" 2>/dev/null; then
+            echo "nix serve exited before writing $portFile" >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+    nixServePort=$(cat "$portFile")
+    httpBinaryCacheUrl="http://localhost:$nixServePort"
+    trap "stopNixServe" EXIT
+}
+
+restartNixServe() {
+    stopNixServe
+    startNixServe --store "file://$cacheDir"
+}
+
 basicDownloadTests() {
-    # No uploading tests bcause upload with force HTTP doesn't work.
+    binaryCache="$1"
+
+    # No uploading tests because upload with force HTTP doesn't work.
 
     # By default, a binary cache doesn't support "nix-env -qas", but does
     # support installation.
     clearStore
     clearCacheCache
 
-    nix-env --substituters "file://$cacheDir" -f dependencies.nix -qas \* | grep -- "---"
+    nix-env --substituters "$binaryCache" -f dependencies.nix -qas \* | grep -- "---"
 
-    nix-store --substituters "file://$cacheDir" --no-require-sigs -r "$outPath"
+    nix-store --substituters "$binaryCache" --no-require-sigs -r "$outPath"
 
     [ -x "$outPath/program" ]
 
 
     # But with the right configuration, "nix-env -qas" should also work.
-    clearStore
-    clearCacheCache
-    echo "WantMassQuery: 1" >> "$cacheDir/nix-cache-info"
+    if [[ "$binaryCache" == file:// ]]; then
+      clearStore
+      clearCacheCache
+      echo "WantMassQuery: 1" >> "$cacheDir/nix-cache-info"
 
-    nix-env --substituters "file://$cacheDir" -f dependencies.nix -qas \* | grep -- "--S"
-    nix-env --substituters "file://$cacheDir" -f dependencies.nix -qas \* | grep -- "--S"
+      nix-env --substituters "$binaryCache" -f dependencies.nix -qas \* | grep -- "--S"
+      nix-env --substituters "$binaryCache" -f dependencies.nix -qas \* | grep -- "--S"
 
-    x=$(nix-env -f dependencies.nix -qas \* --prebuilt-only)
-    [ -z "$x" ]
+      x=$(nix-env -f dependencies.nix -qas \* --prebuilt-only)
+      [ -z "$x" ]
+    fi
 
-    nix-store --substituters "file://$cacheDir" --no-require-sigs -r "$outPath"
+    nix-store --substituters "$binaryCache" --no-require-sigs -r "$outPath"
 
     nix-store --check-validity "$outPath"
     nix-store -qR "$outPath" | grep input-2
@@ -79,25 +115,26 @@ basicDownloadTests() {
 
 
 # Test LocalBinaryCacheStore.
-basicDownloadTests
+basicDownloadTests "file://$cacheDir"
 
 
 # Test HttpBinaryCacheStore.
-export _NIX_FORCE_HTTP=1
-basicDownloadTests
+restartNixServe
+nix store info --store "$httpBinaryCacheUrl"
+basicDownloadTests "$httpBinaryCacheUrl"
 
 
 # Test that multiple concurrent substitutions do only one download.
 clearStore
 nix-store --init # needed because concurrent creation of the store can give SQLite errors
-_NIX_TEST_CONCURRENT_SUBSTITUTION=1 nix-store -r "$depPath" --substituters "file://$cacheDir" --no-require-sigs -vvvv 2> "$TEST_ROOT/log1" &
+_NIX_TEST_CONCURRENT_SUBSTITUTION=1 nix-store -r "$depPath" --substituters "$httpBinaryCacheUrl" --no-require-sigs -vvvv 2> "$TEST_ROOT/log1" &
 pid1="$!"
-_NIX_TEST_CONCURRENT_SUBSTITUTION=1 nix-store -r "$depPath" --substituters "file://$cacheDir" --no-require-sigs -vvvv 2> "$TEST_ROOT/log2" &
+_NIX_TEST_CONCURRENT_SUBSTITUTION=1 nix-store -r "$depPath" --substituters "$httpBinaryCacheUrl" --no-require-sigs -vvvv 2> "$TEST_ROOT/log2" &
 pid2="$!"
 wait "$pid1"
 wait "$pid2"
 [[ $(cat "$TEST_ROOT/log1" "$TEST_ROOT/log2" | grep -c "copying path ") -eq 2 ]]
-[[ $(cat "$TEST_ROOT/log1" "$TEST_ROOT/log2" | grep -c "downloading.*nar.xz") -eq 1 ]]
+[[ $(cat "$TEST_ROOT/log1" "$TEST_ROOT/log2" | grep -c "downloading.*nar") -eq 1 ]]
 
 
 # Test whether Nix notices if the NAR doesn't match the hash in the NAR info.
@@ -108,7 +145,7 @@ mv "$nar" "$nar".good
 mkdir -p "$TEST_ROOT/empty"
 nix-store --dump "$TEST_ROOT/empty" | xz > "$nar"
 
-expect 1 nix-build --substituters "file://$cacheDir" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" 2>&1 | tee "$TEST_ROOT/log"
+expect 1 nix-build --substituters "$httpBinaryCacheUrl" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" 2>&1 | tee "$TEST_ROOT/log"
 grepQuiet "hash mismatch" "$TEST_ROOT/log"
 
 mv "$nar".good "$nar"
@@ -118,7 +155,7 @@ mv "$nar".good "$nar"
 clearStore
 clearCacheCache
 
-if nix-store --substituters "file://$cacheDir" -r "$outPath"; then
+if nix-store --substituters "$httpBinaryCacheUrl" -r "$outPath"; then
     echo "unsigned binary cache incorrectly accepted"
     exit 1
 fi
@@ -129,7 +166,7 @@ clearStore
 
 mv "$cacheDir/nar" "$cacheDir/nar2"
 
-nix-build --substituters "file://$cacheDir" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" 2>&1 | tee "$TEST_ROOT/log"
+nix-build --substituters "$httpBinaryCacheUrl" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" 2>&1 | tee "$TEST_ROOT/log"
 
 # Verify that missing NARs produce warnings, not errors
 # The build should succeed despite the warnings
@@ -147,9 +184,9 @@ mv "$cacheDir/nar" "$cacheDir/nar2"
 mkdir "$cacheDir/nar"
 for i in $(cd "$cacheDir/nar2" && echo *); do touch "$cacheDir"/nar/"$i"; done
 
-(! nix-build --substituters "file://$cacheDir" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result")
+(! nix-build --substituters "$httpBinaryCacheUrl" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result")
 
-nix-build --substituters "file://$cacheDir" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" --fallback
+nix-build --substituters "$httpBinaryCacheUrl" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" --fallback
 
 rm -rf "$cacheDir/nar"
 mv "$cacheDir/nar2" "$cacheDir/nar"
@@ -161,7 +198,7 @@ clearStore
 
 rm -v "$(grep -l "StorePath:.*dependencies-input-2" "$cacheDir"/*.narinfo)"
 
-nix-build --substituters "file://$cacheDir" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" 2>&1 | tee "$TEST_ROOT/log"
+nix-build --substituters "$httpBinaryCacheUrl" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" 2>&1 | tee "$TEST_ROOT/log"
 grepQuiet "copying path.*input-0" "$TEST_ROOT/log"
 grepQuiet "copying path.*input-2" "$TEST_ROOT/log"
 grepQuiet "copying path.*top" "$TEST_ROOT/log"
@@ -170,8 +207,9 @@ grepQuiet "copying path.*top" "$TEST_ROOT/log"
 # Idem, but without cached .narinfo.
 clearStore
 clearCacheCache
+restartNixServe
 
-nix-build --substituters "file://$cacheDir" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" 2>&1 | tee "$TEST_ROOT/log"
+nix-build --substituters "$httpBinaryCacheUrl" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" 2>&1 | tee "$TEST_ROOT/log"
 grepQuiet "don't know how to build" "$TEST_ROOT/log"
 grepQuiet "building.*input-1" "$TEST_ROOT/log"
 grepQuiet "building.*input-2" "$TEST_ROOT/log"
@@ -195,25 +233,26 @@ badKey=$(nix key convert-secret-to-public < "$TEST_ROOT/sk2")
 nix key generate-secret --key-name foo.nixos.org-1 > "$TEST_ROOT/sk3"
 otherKey=$(nix key convert-secret-to-public < "$TEST_ROOT/sk3")
 
-_NIX_FORCE_HTTP='' nix copy --to "file://$cacheDir"?secret-key="$TEST_ROOT"/sk1 "$outPath"
+nix copy --to "file://$cacheDir"?secret-key="$TEST_ROOT"/sk1 "$outPath"
 
 
 # Downloading should fail if we don't provide a key.
 clearStore
 clearCacheCache
+restartNixServe
 
-(! nix-store -r "$outPath" --substituters "file://$cacheDir")
+(! nix-store -r "$outPath" --substituters "$httpBinaryCacheUrl")
 
 
 # And it should fail if we provide an incorrect key.
 clearStore
 clearCacheCache
 
-(! nix-store -r "$outPath" --substituters "file://$cacheDir" --trusted-public-keys "$badKey")
+(! nix-store -r "$outPath" --substituters "$httpBinaryCacheUrl" --trusted-public-keys "$badKey")
 
 
 # It should succeed if we provide the correct key.
-nix-store -r "$outPath" --substituters "file://$cacheDir" --trusted-public-keys "$otherKey $publicKey"
+nix-store -r "$outPath" --substituters "$httpBinaryCacheUrl" --trusted-public-keys "$otherKey $publicKey"
 
 
 # It should fail if we corrupt the .narinfo.
@@ -234,7 +273,7 @@ clearCacheCache
 
 # If we provide a bad and a good binary cache, it should succeed.
 
-nix-store -r "$outPath" --substituters "file://$cacheDir2 file://$cacheDir" --trusted-public-keys "$publicKey"
+nix-store -r "$outPath" --substituters "file://$cacheDir2 $httpBinaryCacheUrl" --trusted-public-keys "$publicKey"
 
 
 unset _NIX_FORCE_HTTP


### PR DESCRIPTION
## Motivation

This provides a built-in binary cache server, similar to `nix-serve`. It's mostly intended for testing and to serve as a reference implementation of binary caches.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new HTTP server command to serve Nix binary caches with configurable bind address/port.

* **Bug Fixes**
  * Improved store path validity checks and cache invalidation to avoid stale results.
  * Nar metadata output now omits optional fields when absent.

* **Refactor**
  * Introduced a generic RAII deleter utility used for resource cleanup.

* **Tests**
  * Extended functional tests to exercise HTTP-based binary-cache serving, lifecycle, auth, and error cases.

* **Chores**
  * Added runtime packaging support for the HTTP server dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->