### PR TITLE
restoreProcessContext(): Reset Mach exception ports

### DIFF
--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -12,6 +12,7 @@
 
 #ifdef __APPLE__
 #  include <mach-o/dyld.h>
+#  include <mach/mach.h>
 #endif
 
 #ifdef __linux__
@@ -115,6 +116,15 @@ void restoreProcessContext(bool restoreMounts)
             setrlimit(RLIMIT_STACK, &limit);
         }
     }
+#endif
+
+#ifdef __APPLE__
+    /* Reset the Mach exception ports. Otherwise, if a crashpad_handler is attached to this process, it will be
+       inherited across execve() and receive spurious crash reports from unrelated programs (e.g. in `nix run`).
+       FIXME: it would be better to have Sentry tell crashpad_handler to quit, but it doesn't appear to have an API for
+       that. */
+    task_set_exception_ports(
+        mach_task_self(), EXC_MASK_ALL | EXC_MASK_CRASH, MACH_PORT_NULL, EXCEPTION_DEFAULT, THREAD_STATE_NONE);
 #endif
 }
 

--- a/tests/functional/sentry.sh
+++ b/tests/functional/sentry.sh
@@ -15,6 +15,18 @@ if ! [[ -d $sentryDir ]]; then
     skipTest "not built with sentry support"
 fi
 
+waitForCrashDump() {
+    local i
+    for ((i = 0; i < 10; i++)); do
+        envelopes=("$sentryDir"/pending/*.dmp)
+        if [[ -e "${envelopes[0]}" ]]; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    return 1
+}
+
 for type in segfault assert logic-error; do
     if [[ $type = logic-error && $(uname) = Darwin ]]; then continue; fi
 
@@ -22,8 +34,17 @@ for type in segfault assert logic-error; do
 
     (! nix __crash "$type")
 
-    envelopes=("$sentryDir"/pending/*.dmp)
-    if [[ ! -e "${envelopes[0]}" ]]; then
+    if ! waitForCrashDump; then
         fail "No crash dump found in $sentryDir after crash"
     fi
 done
+
+rm -rf "$sentryDir"
+
+if nix shell --file ./simple.nix --command bash -c 'kill -SEGV $$'; then
+    fail "Command did not segfault"
+fi
+
+if waitForCrashDump; then
+    fail "Unexpected crash dump"
+fi


### PR DESCRIPTION


## Motivation

When Nix execs another program (like in `nix run` or `nix develop`), Sentry's `crashpad_handler` remains running. Sentry doesn't seem to have an API to cause `crashpad_handler` to quit. On Linux, this isn't a problem. However, macOS uses Mach exception ports to communicate crashes to `crashpad_handler`, and these remain valid across exec() and are inherited by child processes. So this causes Sentry crash reports for non-Nix processes. The workaround is to reset the exception ports to their default state.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed spurious crash reporting on macOS by clearing inherited crash handler configuration after process restoration.

* **Tests**
  * Enhanced crash reporting tests with improved dump detection and validation to ensure proper behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->