### PR TITLE
Fix chroot helper with Sentry

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -381,6 +381,15 @@ void mainWrapped(int argc, char ** argv)
 {
     savedArgv = argv;
 
+    /* The chroot helper needs to be run before any threads have been
+       started (including Sentry's worker thread). */
+#ifndef _WIN32
+    if (argc > 0 && argv[0] == chrootHelperName) {
+        chrootHelper(argc, argv);
+        return;
+    }
+#endif
+
     bool sentryEnabled = false;
 
 #if HAVE_SENTRY
@@ -416,15 +425,6 @@ void mainWrapped(int argc, char ** argv)
 
     if (!sentryEnabled)
         registerCrashHandler();
-
-    /* The chroot helper needs to be run before any threads have been
-       started. */
-#ifndef _WIN32
-    if (argc > 0 && argv[0] == chrootHelperName) {
-        chrootHelper(argc, argv);
-        return;
-    }
-#endif
 
     initNix();
     initGC();

--- a/tests/functional/shell.sh
+++ b/tests/functional/shell.sh
@@ -65,6 +65,7 @@ path=$(nix eval --raw -f shell-hello.nix hello)
 
 # Note: we need the sandbox paths to ensure that the shell is
 # visible in the sandbox.
+export NIX_SENTRY_ENDPOINT=file://$TEST_ROOT/sentry-endpoint # test whether Sentry is disabled in the chroot helper
 nix shell --sandbox-build-dir /build-tmp \
     --sandbox-paths '/nix? /bin? /lib? /lib64? /usr?' \
     --store "$TEST_ROOT/store0" -f shell-hello.nix hello -c hello | grep 'Hello World'


### PR DESCRIPTION

## Motivation

The chroot helper only works if there are no other threads, but Sentry creates a worker thread. So don't start Sentry in the chroot helper.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Startup sequence adjusted so the environment helper runs earlier during launch, affecting early initialization and startup behavior.

* **Tests**
  * Added a functional test that sets a Sentry endpoint for sandboxed shell runs to validate error-reporting behavior in that environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->