### PR TITLE
sentry: Log the Nix command / subcommand

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -414,6 +414,7 @@ void mainWrapped(int argc, char ** argv)
         sentry_options_set_auto_session_tracking(options, false);
         sentry_options_set_handler_path(options, CRASHPAD_HANDLER_PATH);
         sentry_init(options);
+        sentry_set_tag("nix_command", argc > 0 ? std::string(baseNameOf(argv[0])).c_str() : "");
         sentryEnabled = true;
     }
 
@@ -569,16 +570,17 @@ void mainWrapped(int argc, char ** argv)
 
     printTalkative("Nix %s", version());
 
+    std::vector<std::string> subcommand;
+    MultiCommand * command = &args;
+    while (command) {
+        if (command && command->command) {
+            subcommand.push_back(command->command->first);
+            command = dynamic_cast<MultiCommand *>(&*command->command->second);
+        } else
+            break;
+    }
+
     if (args.helpRequested) {
-        std::vector<std::string> subcommand;
-        MultiCommand * command = &args;
-        while (command) {
-            if (command && command->command) {
-                subcommand.push_back(command->command->first);
-                command = dynamic_cast<MultiCommand *>(&*command->command->second);
-            } else
-                break;
-        }
         showHelp(subcommand, args);
         return;
     }
@@ -614,6 +616,11 @@ void mainWrapped(int argc, char ** argv)
     if (args.command->second->forceImpureByDefault() && !evalSettings.pureEval.overridden) {
         evalSettings.pureEval = false;
     }
+
+#if HAVE_SENTRY
+    if (sentryEnabled)
+        sentry_set_tag("nix_subcommand", concatStringsSep(" ", subcommand).c_str());
+#endif
 
     try {
         args.command->second->run();


### PR DESCRIPTION

## Motivation

Improve Sentry crash reports.

Note: this only include the command/subcommand (e.g. `nix flake update`), but no other command-line arguments.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced error-tracking so reports include the invoked command name.
  * Added subcommand path context to diagnostics so errors show the full nested command invoked.
  * Adjusted command-path collection to ensure subcommand context is captured consistently, improving issue visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->