### PR TITLE
Add a session ID to JSON log messages

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -299,7 +299,7 @@ struct ClientSettings
                     trusted || name == settings.getWorkerSettings().buildTimeout.name
                     || name == settings.getWorkerSettings().maxSilentTime.name
                     || name == settings.getWorkerSettings().pollInterval.name || name == "connect-timeout"
-                    || (name == "builders" && value == "")) {
+                    || name == loggerSettings.sessionId.name || (name == "builders" && value == "")) {
                     settings.set(name, value);
                     fileTransferSettings.set(name, value);
                 } else if (setSubstituters(settings.getWorkerSettings().substituters))

--- a/src/libutil/include/nix/util/logging.hh
+++ b/src/libutil/include/nix/util/logging.hh
@@ -68,6 +68,15 @@ struct LoggerSettings : Config
           Concurrent writes to the same file by multiple Nix processes are not supported and
           may result in interleaved or corrupted log records.
         )"};
+
+    Setting<std::string> sessionId{
+        this,
+        "",
+        "session-id",
+        R"(
+          An identifier for the current Nix session, which is included in JSON log output to
+          allow grouping of log messages from the same session. This defaults to a random UUID.
+        )"};
 };
 
 extern LoggerSettings loggerSettings;

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -14,6 +14,10 @@
 #include <nlohmann/json.hpp>
 #include <iostream>
 
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
 namespace nix {
 
 LoggerSettings loggerSettings;
@@ -211,6 +215,16 @@ void to_json(nlohmann::json & json, std::shared_ptr<const Pos> pos)
     }
 }
 
+static std::string getSessionId()
+{
+    if (!loggerSettings.sessionId.get().empty())
+        return loggerSettings.sessionId.get();
+
+    // Generate a random UUID as the session ID.
+    static std::string uuid = boost::uuids::to_string(boost::uuids::random_generator()());
+    return uuid;
+}
+
 struct JSONLogger : Logger
 {
     Descriptor fd;
@@ -248,8 +262,10 @@ struct JSONLogger : Logger
 
     Sync<State> _state;
 
-    void write(const nlohmann::json & json)
+    void write(nlohmann::json json)
     {
+        json["sid"] = getSessionId();
+
         auto line = (includeNixPrefix ? "@nix " : "")
                     + json.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace) + "\n";
 
@@ -275,7 +291,7 @@ struct JSONLogger : Logger
         json["action"] = "msg";
         json["level"] = lvl;
         json["msg"] = s;
-        write(json);
+        write(std::move(json));
     }
 
     void logEI(const ErrorInfo & ei) override
@@ -302,7 +318,7 @@ struct JSONLogger : Logger
             json["trace"] = traces;
         }
 
-        write(json);
+        write(std::move(json));
     }
 
     void startActivity(
@@ -321,7 +337,7 @@ struct JSONLogger : Logger
         json["text"] = s;
         json["parent"] = parent;
         addFields(json, fields);
-        write(json);
+        write(std::move(json));
     }
 
     void stopActivity(ActivityId act) override
@@ -329,7 +345,7 @@ struct JSONLogger : Logger
         nlohmann::json json;
         json["action"] = "stop";
         json["id"] = act;
-        write(json);
+        write(std::move(json));
     }
 
     void result(ActivityId act, ResultType type, const Fields & fields) override
@@ -339,7 +355,7 @@ struct JSONLogger : Logger
         json["id"] = act;
         json["type"] = type;
         addFields(json, fields);
-        write(json);
+        write(std::move(json));
     }
 
     void result(ActivityId act, ResultType type, const nlohmann::json & j) override
@@ -349,7 +365,7 @@ struct JSONLogger : Logger
         json["id"] = act;
         json["type"] = type;
         json["payload"] = j;
-        write(json);
+        write(std::move(json));
     }
 };
 

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -15,7 +15,7 @@
 #include <iostream>
 
 #include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/time_generator_v7.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
 namespace nix {
@@ -220,8 +220,8 @@ static std::string getSessionId()
     if (!loggerSettings.sessionId.get().empty())
         return loggerSettings.sessionId.get();
 
-    // Generate a random UUID as the session ID.
-    static std::string uuid = boost::uuids::to_string(boost::uuids::random_generator()());
+    // Generate a UUIDv7 as the session ID.
+    static std::string uuid = boost::uuids::to_string(boost::uuids::time_generator_v7()());
     return uuid;
 }
 

--- a/tests/functional/logging.sh
+++ b/tests/functional/logging.sh
@@ -35,11 +35,17 @@ if isDaemonNewer "2.26"; then
 fi
 
 # Test json-log-path.
-if [[ "$NIX_REMOTE" != "daemon" ]]; then
-    clearStore
-    nix build -vv --file dependencies.nix --no-link --json-log-path "$TEST_ROOT/log.json" 2>&1 | grepQuiet 'building.*dependencies-top.drv'
-    jq < "$TEST_ROOT/log.json"
-    grep '{"action":"start","fields":\[".*-dependencies-top.drv","",1,1\],"id":.*,"level":3,"parent":0' "$TEST_ROOT/log.json" >&2
-    grep -E '{"action":"result","id":[^,]+,"payload":{"builtOutputs":{"out":{"dependentRealisations":\{\},"id":"[^"]+","outPath":"[^-]+-dependencies-top".*"status":"Built".*"success":true' "$TEST_ROOT/log.json" >&2
-    (( $(grep -c '{"action":"msg","level":5,"msg":"executing builder .*"}' "$TEST_ROOT/log.json" ) == 5 ))
-fi
+clearStore
+nix build -vv --file dependencies.nix --no-link --json-log-path "$TEST_ROOT/log.json" 2>&1 | grepQuiet 'building.*dependencies-top.drv'
+grep '{"action":"start","fields":\[".*-dependencies-top.drv","",1,1\],"id":.*,"level":3,"parent":0' "$TEST_ROOT/log.json" >&2
+grep -E '{"action":"result","id":[^,]+,"payload":{"builtOutputs":{"out":{"dependentRealisations":\{\},"id":"[^"]+","outPath":"[^-]+-dependencies-top".*"status":"Built".*"success":true' "$TEST_ROOT/log.json" >&2
+(( $(grep -c '{"action":"msg","level":5,"msg":"executing builder .*"}' "$TEST_ROOT/log.json" ) == 5 ))
+
+# Check that all log entries have the same session ID.
+sid=$(head -n1 < "$TEST_ROOT/log.json" | jq -r '.sid')
+[[ -n "$sid" && "$sid" != "null" ]]
+(( $(jq -s --arg sid "$sid" '[.[] | select(.sid != $sid)] | length' < "$TEST_ROOT/log.json") == 0 ))
+
+# Test whether setting an explicit session ID works.
+nix store info --json-log-path "$TEST_ROOT/log2.json" --session-id "foo"
+(( $(jq -s --arg sid foo '[.[] | select(.sid != $sid)] | length' < "$TEST_ROOT/log2.json") == 0 ))

--- a/tests/functional/logging.sh
+++ b/tests/functional/logging.sh
@@ -35,11 +35,18 @@ if isDaemonNewer "2.26"; then
 fi
 
 # Test json-log-path.
-if [[ "$NIX_REMOTE" != "daemon" ]]; then
-    clearStore
-    nix build -vv --file dependencies.nix --no-link --json-log-path "$TEST_ROOT/log.json" 2>&1 | grepQuiet 'building.*dependencies-top.drv'
-    jq < "$TEST_ROOT/log.json"
-    grep '{"action":"start","fields":\[".*-dependencies-top.drv","",1,1\],"id":.*,"level":3,"parent":0' "$TEST_ROOT/log.json" >&2
-    grep -E '{"action":"result","id":[^,]+,"payload":{"builtOutputs":{"out":{"dependentRealisations":\{\},"id":"[^"]+","outPath":"[^-]+-dependencies-top".*"status":"Built".*"success":true' "$TEST_ROOT/log.json" >&2
-    (( $(grep -c '{"action":"msg","level":5,"msg":"executing builder .*"}' "$TEST_ROOT/log.json" ) == 5 ))
-fi
+clearStore
+nix build -vv --file dependencies.nix --no-link --json-log-path "$TEST_ROOT/log.json" 2>&1 | grepQuiet 'building.*dependencies-top.drv'
+grep '{"action":"start","fields":\[".*-dependencies-top.drv","",1,1\],"id":.*,"level":3,"parent":0' "$TEST_ROOT/log.json" >&2
+grep -E '{"action":"result","id":[^,]+,"payload":{"builtOutputs":{"out":{"dependentRealisations":\{\},"id":"[^"]+","outPath":"[^-]+-dependencies-top".*"status":"Built".*"success":true' "$TEST_ROOT/log.json" >&2
+(( $(grep -c '{"action":"msg","level":5,"msg":"executing builder .*"}' "$TEST_ROOT/log.json" ) == 5 ))
+
+# Check that all log entries have the same session ID.
+sid=$(head -n1 < "$TEST_ROOT/log.json" | jq -r '.sid')
+[[ -n "$sid" && "$sid" != "null" ]]
+(( $(jq -s --arg sid "$sid" '[.[] | select(.sid != $sid)] | length' < "$TEST_ROOT/log.json") == 0 ))
+
+# Test whether setting an explicit session ID works.
+nix store info --json-log-path "$TEST_ROOT/log2.json" --session-id "foo"
+(( $(jq -s 'length' < "$TEST_ROOT/log2.json") > 0 ))
+(( $(jq -s --arg sid foo '[.[] | select(.sid != $sid)] | length' < "$TEST_ROOT/log2.json") == 0 ))


### PR DESCRIPTION


## Motivation

This allows a log processor to see which messages belong to the same session. What constitutes a session is up to the user. By default, every Nix command invocation is its own session (a random UUID like `31d57f8c-5de0-46ca-8684-81f1e61999aa`), but you can use the `session-id` setting to give a group of invocations the same session.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session tracking for JSON logs: new `--session-id` option and configuration field; a session identifier (random by default) is embedded as `.sid` in every JSON log entry for session correlation.
* **Behavior**
  * Client-supplied session id is now accepted and propagated into related settings when provided by untrusted clients.
* **Tests**
  * Functional tests validate presence and consistency of `.sid`, including explicit `--session-id` usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->