### PR TITLE
Don't destroy _fileTransfer on shutdown

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -1055,11 +1055,11 @@ ref<curlFileTransfer> makeCurlFileTransfer(const FileTransferSettings & settings
     return make_ref<curlFileTransfer>(settings);
 }
 
-static Sync<std::shared_ptr<curlFileTransfer>> _fileTransfer;
+static auto * const _fileTransfer = new Sync<std::shared_ptr<curlFileTransfer>>;
 
 ref<FileTransfer> getFileTransfer()
 {
-    auto fileTransfer(_fileTransfer.lock());
+    auto fileTransfer(_fileTransfer->lock());
 
     if (!*fileTransfer || (*fileTransfer)->state_.lock()->isQuitting())
         *fileTransfer = makeCurlFileTransfer().get_ptr();
@@ -1069,7 +1069,7 @@ ref<FileTransfer> getFileTransfer()
 
 std::shared_ptr<FileTransfer> resetFileTransfer()
 {
-    auto fileTransfer(_fileTransfer.lock());
+    auto fileTransfer(_fileTransfer->lock());
     std::shared_ptr<curlFileTransfer> prev;
     fileTransfer->swap(prev);
     return prev;


### PR DESCRIPTION


## Motivation

This is responsible for a lot of crash reports in Sentry (presumably due to destructor ordering issues). Since there is no cleanup done by this class that we care about, just leak it.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal file transfer synchronization mechanism for better resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->