### PR TITLE
C API: add logger bindings

### DIFF
--- a/src/libutil-c/nix_api_util.cc
+++ b/src/libutil-c/nix_api_util.cc
@@ -1,14 +1,85 @@
 #include "nix_api_util.h"
 #include "nix/util/config-global.hh"
 #include "nix/util/error.hh"
+#include "nix/util/logging.hh"
 #include "nix_api_util_internal.h"
 #include "nix/util/signals.hh"
 #include "nix/util/util.hh"
 
 #include <cxxabi.h>
+#include <sstream>
 #include <typeinfo>
 
 #include "nix_api_util_config.h"
+
+/**
+ * Logger that delegates every supported method to a C callback vtable.
+ */
+class CallbackLogger : public nix::Logger
+{
+public:
+    nix_logger vtable;
+    void * userdata;
+
+    CallbackLogger(const nix_logger & vtable, void * userdata)
+        : vtable(vtable)
+        , userdata(userdata)
+    {
+    }
+
+    ~CallbackLogger() override
+    {
+        if (vtable.destroy)
+            vtable.destroy(userdata);
+    }
+
+    void log(nix::Verbosity lvl, std::string_view s) override
+    {
+        if (!vtable.log)
+            return;
+        std::string buf(s);
+        vtable.log(userdata, static_cast<nix_verbosity>(lvl), buf.c_str());
+    }
+
+    void logEI(const nix::ErrorInfo & ei) override
+    {
+        if (!vtable.log)
+            return;
+        std::ostringstream oss;
+        nix::showErrorInfo(oss, ei, nix::loggerSettings.showTrace.get());
+        auto formatted = oss.str();
+        vtable.log(userdata, static_cast<nix_verbosity>(ei.level), formatted.c_str());
+    }
+
+    void startActivity(
+        nix::ActivityId act,
+        nix::Verbosity lvl,
+        nix::ActivityType type,
+        const std::string & s,
+        const Fields & /*fields*/,
+        nix::ActivityId parent) override
+    {
+        if (!vtable.start_activity)
+            return;
+        vtable.start_activity(
+            userdata, act, static_cast<nix_verbosity>(lvl), static_cast<nix_activity_type>(type), s.c_str(), parent);
+    }
+
+    void stopActivity(nix::ActivityId act) override
+    {
+        if (vtable.stop_activity)
+            vtable.stop_activity(userdata, act);
+    }
+
+    void result(nix::ActivityId act, nix::ResultType type, const Fields & fields) override
+    {
+        if (!vtable.result_string)
+            return;
+        if (fields.empty() || fields[0].type != nix::Logger::Field::tString)
+            return;
+        vtable.result_string(userdata, act, static_cast<nix_result_type>(type), fields[0].s.c_str());
+    }
+};
 
 extern "C" {
 
@@ -175,6 +246,18 @@ nix_err nix_set_verbosity(nix_c_context * context, nix_verbosity level)
         return nix_set_err_msg(context, NIX_ERR_UNKNOWN, "Invalid verbosity level");
     try {
         nix::verbosity = static_cast<nix::Verbosity>(level);
+    }
+    NIXC_CATCH_ERRS
+}
+
+nix_err nix_set_logger(nix_c_context * context, const nix_logger * vtable, void * userdata)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    if (vtable == nullptr)
+        return nix_set_err_msg(context, NIX_ERR_UNKNOWN, "logger vtable is null");
+    try {
+        nix::logger = std::make_unique<CallbackLogger>(*vtable, userdata);
     }
     NIXC_CATCH_ERRS
 }

--- a/src/libutil-c/nix_api_util.h
+++ b/src/libutil-c/nix_api_util.h
@@ -14,6 +14,8 @@
  * Also contains error handling utilities
  */
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -361,6 +363,169 @@ void nix_clear_err(nix_c_context * context);
  * @param[in] level Verbosity level
  */
 nix_err nix_set_verbosity(nix_c_context * context, nix_verbosity level);
+
+/**
+ *  @}
+ */
+
+/** @defgroup logger Logger
+ * @brief Capture Nix log output via C callbacks
+ *
+ * The functions in this section let an embedder replace Nix's global
+ * logger with one driven by user-supplied callbacks. This is the
+ * intended way to surface `builtins.trace` calls, builder output,
+ * warnings, and other diagnostic messages produced by libnixutil,
+ * libnixstore and libnixexpr to a host language.
+ *  @{
+ */
+
+/**
+ * @brief Activity identifier.
+ *
+ * `0` means "no activity" (used as the parent of top-level activities).
+ */
+typedef uint64_t nix_activity_id;
+
+/**
+ * @brief Activity type.
+ *
+ * @note Must be kept in sync with `nix::ActivityType`.
+ */
+enum nix_activity_type {
+    NIX_ACTIVITY_TYPE_UNKNOWN = 0,
+    NIX_ACTIVITY_TYPE_COPY_PATH = 100,
+    NIX_ACTIVITY_TYPE_FILE_TRANSFER = 101,
+    NIX_ACTIVITY_TYPE_REALISE = 102,
+    NIX_ACTIVITY_TYPE_COPY_PATHS = 103,
+    NIX_ACTIVITY_TYPE_BUILDS = 104,
+    NIX_ACTIVITY_TYPE_BUILD = 105,
+    NIX_ACTIVITY_TYPE_OPTIMISE_STORE = 106,
+    NIX_ACTIVITY_TYPE_VERIFY_PATHS = 107,
+    NIX_ACTIVITY_TYPE_SUBSTITUTE = 108,
+    NIX_ACTIVITY_TYPE_QUERY_PATH_INFO = 109,
+    NIX_ACTIVITY_TYPE_POST_BUILD_HOOK = 110,
+    NIX_ACTIVITY_TYPE_BUILD_WAITING = 111,
+    NIX_ACTIVITY_TYPE_FETCH_TREE = 112,
+};
+typedef enum nix_activity_type nix_activity_type;
+
+/**
+ * @brief Activity result type.
+ *
+ * @note Must be kept in sync with `nix::ResultType`.
+ */
+enum nix_result_type {
+    NIX_RESULT_TYPE_FILE_LINKED = 100,
+    NIX_RESULT_TYPE_BUILD_LOG_LINE = 101,
+    NIX_RESULT_TYPE_UNTRUSTED_PATH = 102,
+    NIX_RESULT_TYPE_CORRUPTED_PATH = 103,
+    NIX_RESULT_TYPE_SET_PHASE = 104,
+    NIX_RESULT_TYPE_PROGRESS = 105,
+    NIX_RESULT_TYPE_SET_EXPECTED = 106,
+    NIX_RESULT_TYPE_POST_BUILD_LOG_LINE = 107,
+    NIX_RESULT_TYPE_FETCH_STATUS = 108,
+    NIX_RESULT_TYPE_HASH_MISMATCH = 109,
+    NIX_RESULT_TYPE_BUILD_RESULT = 110,
+};
+typedef enum nix_result_type nix_result_type;
+
+/**
+ * @brief Vtable of callbacks for a custom logger.
+ *
+ * Any field may be NULL; missing callbacks are treated as no-ops.
+ *
+ * @warning Callbacks may be invoked concurrently from multiple threads
+ * (notably during parallel builds). Implementations are responsible
+ * for their own synchronization.
+ *
+ * @warning Callbacks must not throw exceptions across the C boundary.
+ */
+typedef struct nix_logger
+{
+    /**
+     * @brief Ordinary log message.
+     *
+     * Receives `builtins.trace` output, warnings, errors (after
+     * formatting), and any message produced through the `printError` /
+     * `printInfo` / `debug` / etc. macros in the C++ API.
+     *
+     * @param[in] userdata The user-supplied opaque pointer.
+     * @param[in] level Verbosity level of the message.
+     * @param[in] msg NUL-terminated message body. Borrowed; must not be freed.
+     */
+    void (*log)(void * userdata, nix_verbosity level, const char * msg);
+
+    /**
+     * @brief An activity (e.g. a build, a substitution) has started.
+     *
+     * @param[in] userdata The user-supplied opaque pointer.
+     * @param[in] activity_id Unique identifier for the new activity.
+     * @param[in] level Verbosity level associated with this activity.
+     * @param[in] type Activity type. See ::nix_activity_type.
+     * @param[in] s NUL-terminated description (may be empty, never NULL). Borrowed.
+     * @param[in] parent_id ID of the parent activity, or `0` if none.
+     */
+    void (*start_activity)(
+        void * userdata,
+        nix_activity_id activity_id,
+        nix_verbosity level,
+        nix_activity_type type,
+        const char * s,
+        nix_activity_id parent_id);
+
+    /**
+     * @brief An activity has stopped.
+     */
+    void (*stop_activity)(void * userdata, nix_activity_id activity_id);
+
+    /**
+     * @brief An activity reported a result whose first field is a string.
+     *
+     * Covers in particular:
+     * - ::NIX_RESULT_TYPE_BUILD_LOG_LINE — a line of builder output
+     * - ::NIX_RESULT_TYPE_POST_BUILD_LOG_LINE — a line of post-build hook output
+     * - ::NIX_RESULT_TYPE_SET_PHASE — current build phase
+     *
+     * Result types whose first field is not a string (such as
+     * ::NIX_RESULT_TYPE_PROGRESS) are not delivered through this
+     * callback.
+     *
+     * @param[in] userdata The user-supplied opaque pointer.
+     * @param[in] activity_id The activity reporting this result.
+     * @param[in] type The result type.
+     * @param[in] msg The string field, NUL-terminated. Borrowed.
+     */
+    void (*result_string)(void * userdata, nix_activity_id activity_id, nix_result_type type, const char * msg);
+
+    /**
+     * @brief Called when the logger is destroyed.
+     *
+     * Invoked when the logger is replaced by a subsequent call to
+     * ::nix_set_logger, or when Nix's global logger is torn
+     * down at program exit. Use this to free resources owned by
+     * `userdata`.
+     */
+    void (*destroy)(void * userdata);
+} nix_logger;
+
+/**
+ * @brief Replace the global Nix logger with one driven by C callbacks.
+ *
+ * After this call, log messages, activities and supported results
+ * produced anywhere in Nix are routed to the supplied callbacks.
+ *
+ * The vtable is copied; only the function pointers it contains need to
+ * remain valid for the lifetime of the logger. `userdata` is borrowed
+ * and passed unmodified to every callback. When the logger is later
+ * destroyed (by another call to this function, or at program shutdown),
+ * `vtable->destroy(userdata)` is invoked if non-NULL.
+ *
+ * @param[out] context Optional, stores error information.
+ * @param[in] vtable Required, callback vtable.
+ * @param[in] userdata Optional opaque pointer passed to every callback.
+ * @return NIX_OK on success, an error code otherwise.
+ */
+nix_err nix_set_logger(nix_c_context * context, const nix_logger * vtable, void * userdata);
 
 /**
  *  @}

--- a/src/libutil-tests/nix_api_util.cc
+++ b/src/libutil-tests/nix_api_util.cc
@@ -1,5 +1,7 @@
 #include "nix/util/config-global.hh"
 #include "nix/util/args.hh"
+#include "nix/util/finally.hh"
+#include "nix/util/logging.hh"
 #include "nix_api_util.h"
 #include "nix/util/tests/nix_api_util.hh"
 #include "nix/util/tests/string_callback.hh"
@@ -7,6 +9,9 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
 
 #include "util-tests-config.hh"
 
@@ -75,6 +80,132 @@ TEST_F(nix_api_util_context, nix_err_code)
     ASSERT_EQ(nix_err_code(ctx), NIX_OK);
     nix_set_err_msg(ctx, NIX_ERR_UNKNOWN, "unknown test error");
     ASSERT_EQ(nix_err_code(ctx), NIX_ERR_UNKNOWN);
+}
+
+struct LogCapture
+{
+    std::vector<std::pair<nix_verbosity, std::string>> logs;
+    std::vector<std::tuple<nix_activity_id, nix_verbosity, nix_activity_type, std::string, nix_activity_id>> starts;
+    std::vector<nix_activity_id> stops;
+    std::vector<std::tuple<nix_activity_id, nix_result_type, std::string>> results;
+    bool destroyed = false;
+};
+
+extern "C" void capture_log(void * userdata, nix_verbosity level, const char * msg)
+{
+    auto * c = static_cast<LogCapture *>(userdata);
+    c->logs.emplace_back(level, msg);
+}
+
+extern "C" void capture_start_activity(
+    void * userdata,
+    nix_activity_id id,
+    nix_verbosity level,
+    nix_activity_type type,
+    const char * s,
+    nix_activity_id parent)
+{
+    auto * c = static_cast<LogCapture *>(userdata);
+    c->starts.emplace_back(id, level, type, s, parent);
+}
+
+extern "C" void capture_stop_activity(void * userdata, nix_activity_id id)
+{
+    auto * c = static_cast<LogCapture *>(userdata);
+    c->stops.push_back(id);
+}
+
+extern "C" void capture_result_string(void * userdata, nix_activity_id id, nix_result_type type, const char * msg)
+{
+    auto * c = static_cast<LogCapture *>(userdata);
+    c->results.emplace_back(id, type, msg);
+}
+
+extern "C" void capture_destroy(void * userdata)
+{
+    auto * c = static_cast<LogCapture *>(userdata);
+    c->destroyed = true;
+}
+
+const nix_logger captureLoggerVtable{
+    .log = capture_log,
+    .start_activity = capture_start_activity,
+    .stop_activity = capture_stop_activity,
+    .result_string = capture_result_string,
+    .destroy = capture_destroy,
+};
+
+TEST_F(nix_api_util_context, nix_set_logger_rejects_null_vtable)
+{
+    ASSERT_EQ(nix_set_logger(ctx, nullptr, nullptr), NIX_ERR_UNKNOWN);
+}
+
+TEST_F(nix_api_util_context, nix_set_logger_routes_log_calls)
+{
+    LogCapture capture;
+    // Restore the default logger before `capture` goes out of scope so
+    // the destroy callback runs while `capture` is still alive.
+    Finally restoreLogger([] { nix::logger = nix::makeSimpleLogger(); });
+
+    ASSERT_EQ(nix_set_logger(ctx, &captureLoggerVtable, &capture), NIX_OK);
+
+    nix::logger->log(nix::lvlInfo, "hello world");
+    nix::logger->warn("be careful");
+
+    ASSERT_EQ(capture.logs.size(), 2u);
+    EXPECT_EQ(capture.logs[0].first, NIX_LVL_INFO);
+    EXPECT_EQ(capture.logs[0].second, "hello world");
+    EXPECT_EQ(capture.logs[1].first, NIX_LVL_WARN);
+    // warn() prefixes "warning: " (with ANSI escapes).
+    EXPECT_NE(capture.logs[1].second.find("be careful"), std::string::npos);
+}
+
+TEST_F(nix_api_util_context, nix_set_logger_routes_activities_and_results)
+{
+    LogCapture capture;
+    Finally restoreLogger([] { nix::logger = nix::makeSimpleLogger(); });
+
+    ASSERT_EQ(nix_set_logger(ctx, &captureLoggerVtable, &capture), NIX_OK);
+
+    nix::ActivityId actId;
+    {
+        nix::Activity act(*nix::logger, nix::lvlInfo, nix::actBuild, "building foo");
+        actId = act.id;
+        nix::logger->result(act.id, nix::resBuildLogLine, nix::Logger::Fields{"line of build output"});
+        // Integer-valued result; should be filtered out by result_string.
+        act.progress(10, 100);
+    }
+
+    ASSERT_EQ(capture.starts.size(), 1u);
+    EXPECT_EQ(std::get<0>(capture.starts[0]), actId);
+    EXPECT_EQ(std::get<1>(capture.starts[0]), NIX_LVL_INFO);
+    EXPECT_EQ(std::get<2>(capture.starts[0]), NIX_ACTIVITY_TYPE_BUILD);
+    EXPECT_EQ(std::get<3>(capture.starts[0]), "building foo");
+
+    ASSERT_EQ(capture.results.size(), 1u) << "result_string should only fire for string-valued results";
+    EXPECT_EQ(std::get<0>(capture.results[0]), actId);
+    EXPECT_EQ(std::get<1>(capture.results[0]), NIX_RESULT_TYPE_BUILD_LOG_LINE);
+    EXPECT_EQ(std::get<2>(capture.results[0]), "line of build output");
+
+    ASSERT_EQ(capture.stops.size(), 1u);
+    EXPECT_EQ(capture.stops[0], actId);
+}
+
+TEST_F(nix_api_util_context, nix_set_logger_invokes_destroy_when_replaced)
+{
+    // Both captures must outlive the Finally so that the logger held
+    // by `nix::logger` at teardown can call destroy on a live capture.
+    LogCapture capture;
+    LogCapture capture2;
+    Finally restoreLogger([] { nix::logger = nix::makeSimpleLogger(); });
+
+    ASSERT_EQ(nix_set_logger(ctx, &captureLoggerVtable, &capture), NIX_OK);
+    EXPECT_FALSE(capture.destroyed);
+
+    // Replacing the logger must fire destroy on the old userdata.
+    ASSERT_EQ(nix_set_logger(ctx, &captureLoggerVtable, &capture2), NIX_OK);
+    EXPECT_TRUE(capture.destroyed);
+    EXPECT_FALSE(capture2.destroyed);
 }
 
 } // namespace nixC


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Bind the C++ logger into C

## Context

This is useful for programs embedding Nix but use a different logger.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a custom logger subsystem enabling embedding hosts to intercept and route Nix logging and tracing output through configurable callbacks, with full support for activity lifecycle management and detailed result tracking.

* **Tests**
  * Added comprehensive test suite validating custom logger registration, callback routing, activity lifecycle capture, and proper resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->