### PR TITLE
Make static packages use libcxx on Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -465,7 +465,6 @@
                 {
                   # These attributes go right into `packages.<system>`.
                   "${pkgName}" = nixpkgsFor.${system}.native.nixComponents2.${pkgName};
-                  "${pkgName}-static" = nixpkgsFor.${system}.native.pkgsStatic.nixComponents2.${pkgName};
                 }
                 // flatMapAttrs (lib.genAttrs stdenvs (_: { })) (
                   stdenvName:
@@ -489,6 +488,15 @@
                     }
                 )
               )
+              // {
+                "${pkgName}-static" =
+                  let
+                    pkgs = nixpkgsFor.${system};
+                  in
+                  (
+                    if pkgs.native.stdenv.hostPlatform.isDarwin then pkgs.nativeForStdenv.libcxxStdenv else pkgs.native
+                  ).pkgsStatic.nixComponents2.${pkgName};
+              }
             )
         // lib.optionalAttrs (builtins.elem system linux64BitSystems) {
           dockerImage =


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal package matrix generation for clearer attribute composition; no user-facing behavior or public interfaces changed.
* **Chores**
  * CI build updated to produce an additional static build artifact, improving coverage of static variants.
  * Build flags for a native library were adjusted to improve compatibility for static builds with certain toolchains.
  * Added a conditional system header include to enable a close-range syscall fallback on Linux/FreeBSD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->