### PR TITLE
Restore resBuildResult fields for failed builds

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -1362,13 +1362,16 @@ Goal::Done DerivationBuildingGoal::doneFailure(BuildError ex)
 
     worker.updateProgress();
 
+    auto res = Goal::doneFailure(ecFailed, std::move(ex));
+
     logger->result(
         getCurActivity(),
         resBuildResult,
         nlohmann::json(KeyedBuildResult(
-            {ex}, DerivedPath::Built{.drvPath = makeConstantStorePathRef(drvPath), .outputs = OutputsSpec::All{}})));
+            buildResult,
+            DerivedPath::Built{.drvPath = makeConstantStorePathRef(drvPath), .outputs = OutputsSpec::All{}})));
 
-    return Goal::doneFailure(ecFailed, std::move(ex));
+    return res;
 }
 
 } // namespace nix

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -30,10 +30,14 @@ PathSubstitutionGoal::~PathSubstitutionGoal()
 
 Goal::Done PathSubstitutionGoal::doneFailure(ExitCode result, BuildResult::Failure failure)
 {
-    logger->result(
-        getCurActivity(), resBuildResult, nlohmann::json(KeyedBuildResult({failure}, DerivedPath::Opaque{storePath})));
+    auto res = Goal::doneFailure(result, std::move(failure));
 
-    return Goal::doneFailure(result, std::move(failure));
+    logger->result(
+        getCurActivity(),
+        resBuildResult,
+        nlohmann::json(KeyedBuildResult(buildResult, DerivedPath::Opaque{storePath})));
+
+    return res;
 }
 
 Goal::Co PathSubstitutionGoal::init()

--- a/tests/functional/logging.sh
+++ b/tests/functional/logging.sh
@@ -41,6 +41,10 @@ grep '{"action":"start","fields":\[".*-dependencies-top.drv","",1,1\],"id":.*,"l
 grep -E '{"action":"result","id":[^,]+,"payload":{"builtOutputs":{"out":{"dependentRealisations":\{\},"id":"[^"]+","outPath":"[^-]+-dependencies-top".*"status":"Built".*"success":true' "$TEST_ROOT/log.json" >&2
 (( $(grep -c '{"action":"msg","level":5,"msg":"executing builder .*"}' "$TEST_ROOT/log.json" ) == 5 ))
 
+rm "$TEST_ROOT/log.json"
+expect 1 nix build -vv --file timeout.nix silent --timeout 1 --no-link --json-log-path "$TEST_ROOT/log.json"
+grep -E '{"action":"result","id":[^,]+,"payload":{"errorMsg":"timed out.*",.*"startTime":[1-9][0-9]*,"status":"TimedOut","stopTime":0,"success":false,' "$TEST_ROOT/log.json" >&2
+
 # Check that all log entries have the same session ID.
 sid=$(head -n1 < "$TEST_ROOT/log.json" | jq -r '.sid')
 [[ -n "$sid" && "$sid" != "null" ]]


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made JSON build-failure logging payloads more consistent so logged results reliably reflect failure details.
  * Ensured timed-out builds record timeout status and error message in JSON logs.

* **Tests**
  * Added functional test coverage verifying JSON logging for timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->