### PR TITLE
parseString(): Fix out-of-bounds read

### DIFF
--- a/src/libstore-tests/derivation/external-formats.cc
+++ b/src/libstore-tests/derivation/external-formats.cc
@@ -15,6 +15,14 @@ TEST_F(DerivationTest, BadATerm_version)
         parseDerivation(*store, readFile(goldenMaster("bad-version.drv")), "whatever", mockXpSettings), FormatError);
 }
 
+TEST_F(DerivationTest, UnterminatedString)
+{
+    ASSERT_THROW(
+        parseDerivation(
+            *store, "Derive([(\"out\",\"/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-foo", "bar", mockXpSettings),
+        FormatError);
+}
+
 TEST_F(DynDerivationTest, BadATerm_oldVersionDynDeps)
 {
     ASSERT_THROW(

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -241,6 +241,7 @@ static BackedStringView parseString(StringViewStream & str)
     size_t start = 0;
     size_t end = str.remaining.size();
     const auto data = str.remaining.data();
+    bool foundClose = false;
     while (start < end) {
         auto idx = str.remaining.find('"', start);
         if (idx == std::string_view::npos) {
@@ -251,10 +252,13 @@ static BackedStringView parseString(StringViewStream & str)
             ;
         if ((idx - pos) % 2 == 0) { // even number of backslashes
             end = idx;
+            foundClose = true;
             break;
         }
         start = idx + 1;
     }
+    if (!foundClose)
+        throw FormatError("unterminated string in derivation");
 
     start = 0;
     const auto content = str.remaining.substr(start, end);


### PR DESCRIPTION
## Motivation

If the string isn't terminated, `parseString()` returns a string of size `std::string::npos`, which then causes an out-of-bounds read later.

Fixes:

```
==47978== Invalid read of size 1
==47978==    at 0x4BEF70A: nix::expect(nix::(anonymous namespace)::StringViewStream&, char) (../src/libstore/derivations.cc:232)
==47978==    by 0x4BEE3CA: parseDerivationOutput (../src/libstore/derivations.cc:383)
==47978==    by 0x4BEE3CA: nix::parseDerivation(nix::StoreDirConfig const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::basic_string_view<char, std::char_traits<char> >, nix::ExperimentalFeatureSettings const&) (???:492)
==47978==    by 0x3F3803: nix::DerivationTest_UnterminatedString_Test::TestBody() (../src/libstore-tests/derivation/external-formats.cc:27)
==47978==    by 0x52AD3DD: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /nix/store/qyg0071v3bf8vgcnccd6zi0gvc5abs3f-gtest-1.17.0/lib/libgtest.so.1.17.0)
==47978==    by 0x5298E3D: testing::Test::Run() (in /nix/store/qyg0071v3bf8vgcnccd6zi0gvc5abs3f-gtest-1.17.0/lib/libgtest.so.1.17.0)
==47978==    by 0x5298FCC: testing::TestInfo::Run() (in /nix/store/qyg0071v3bf8vgcnccd6zi0gvc5abs3f-gtest-1.17.0/lib/libgtest.so.1.17.0)
==47978==    by 0x529920E: testing::TestSuite::Run() (in /nix/store/qyg0071v3bf8vgcnccd6zi0gvc5abs3f-gtest-1.17.0/lib/libgtest.so.1.17.0)
==47978==    by 0x52A3996: testing::internal::UnitTestImpl::RunAllTests() (in /nix/store/qyg0071v3bf8vgcnccd6zi0gvc5abs3f-gtest-1.17.0/lib/libgtest.so.1.17.0)
==47978==    by 0x52A3F74: testing::UnitTest::Run() (in /nix/store/qyg0071v3bf8vgcnccd6zi0gvc5abs3f-gtest-1.17.0/lib/libgtest.so.1.17.0)
==47978==    by 0x49DD52: RUN_ALL_TESTS (gtest.h:2334)
==47978==    by 0x49DD52: main (???:16)
```

Found by Claude Opus 4.7.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved error detection and reporting for unterminated strings during derivation parsing, enabling clearer error messages when encountering malformed input.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/454)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->