### PR TITLE
libfetchers: verify git-lfs returns the same objects as git

### DIFF
--- a/src/libfetchers/git-lfs-fetch.cc
+++ b/src/libfetchers/git-lfs-fetch.cc
@@ -7,6 +7,7 @@
 #include "nix/util/users.hh"
 #include "nix/util/util.hh"
 #include "nix/util/hash.hh"
+#include "nix/util/json-utils.hh"
 #include "nix/store/ssh.hh"
 #include "nix/util/deleter.hh"
 
@@ -291,7 +292,8 @@ void Fetch::fetch(
 
     const auto obj = objUrls[0];
     try {
-        std::string sha256 = obj.at("oid"); // oid is also the sha256
+        // Use the committed pointer's oid/size for integrity, not server's claim
+        std::string sha256 = pointer->oid;
         std::string ourl = obj.at("actions").at("download").at("href");
         auto authHeader = [&]() -> std::optional<std::string> {
             const auto & download = obj.at("actions").at("download");
@@ -303,7 +305,20 @@ void Fetch::fetch(
                 return std::nullopt;
             return std::string(*authIt);
         }();
-        const uint64_t size = obj.at("size");
+        const uint64_t size = pointer->size;
+
+        auto objOid = getString(valueAt(getObject(obj), "oid"));
+        auto objSize = getUnsigned(valueAt(getObject(obj), "size"));
+        if (objOid != pointer->oid || objSize != pointer->size) {
+            throw Error(
+                "LFS server returned mismatched oid/size for '%s' (got oid=%s size=%d, expected oid=%s size=%d)",
+                pointerFilePath,
+                objOid,
+                objSize,
+                pointer->oid,
+                pointer->size);
+        }
+
         sizeCallback(size);
         downloadToSink(ourl, authHeader, sink, sha256, size);
 


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Git LFS objects should return the same OID as regular Git.

## Context

Prevents servers from returning the wrong objects, or objects with different sizes.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git LFS download integrity checks: the client now validates downloads against the pointer file’s checksum and size and rejects mismatches reported by the server before processing, preventing corrupted or tampered LFS content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/456)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->