### PR TITLE
Send assertion messages to Sentry

### DIFF
--- a/nix-meson-build-support/common/assert-fail/wrap-assert-fail.cc
+++ b/nix-meson-build-support/common/assert-fail/wrap-assert-fail.cc
@@ -1,4 +1,5 @@
 #include "nix/util/error.hh"
+#include "nix/util/sentry.hh"
 
 #include <cstdio>
 #include <cstdlib>
@@ -13,5 +14,6 @@ __wrap___assert_fail(const char * assertion, const char * file, unsigned int lin
         snprintf(buf, sizeof(buf), "Assertion '%s' failed in %s at %s:%" PRIuLEAST32, assertion, function, file, line);
     if (n < 0)
         nix::panic("Assertion failed and could not format error message");
-    nix::panic(std::string_view(buf, std::min(static_cast<int>(sizeof(buf)), n)));
+    nix::setSentryTag("assertion", buf);
+    nix::panic(buf);
 }

--- a/src/libutil/include/nix/util/meson.build
+++ b/src/libutil/include/nix/util/meson.build
@@ -77,6 +77,7 @@ headers = [ config_pub_h ] + files(
   'ref.hh',
   'regex-combinators.hh',
   'repair-flag.hh',
+  'sentry.hh',
   'serialise.hh',
   'signals.hh',
   'signature/local-keys.hh',

--- a/src/libutil/include/nix/util/sentry.hh
+++ b/src/libutil/include/nix/util/sentry.hh
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "nix/util/fun.hh"
+
+namespace nix {
+
+extern fun<void(const char *, const char *)> setSentryTag;
+
+}

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -307,4 +307,6 @@ std::pair<std::string_view, std::string_view> getLine(std::string_view s)
     }
 }
 
+fun<void(const char *, const char *)> setSentryTag = [](const char *, const char *) {};
+
 } // namespace nix

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -23,6 +23,7 @@
 #include "nix/flake/flake.hh"
 #include "nix/flake/settings.hh"
 #include "nix/util/json-utils.hh"
+#include "nix/util/sentry.hh"
 
 #include "self-exe.hh"
 #include "crash-handler.hh"
@@ -420,7 +421,8 @@ void mainWrapped(int argc, char ** argv)
         sentry_options_set_auto_session_tracking(options, false);
         sentry_options_set_handler_path(options, CRASHPAD_HANDLER_PATH);
         sentry_init(options);
-        sentry_set_tag("nix_command", argc > 0 ? std::string(baseNameOf(argv[0])).c_str() : "");
+        setSentryTag = [](const char * key, const char * value) { sentry_set_tag(key, value); };
+        setSentryTag("nix_command", argc > 0 ? std::string(baseNameOf(argv[0])).c_str() : "");
         sentryEnabled = true;
     }
 
@@ -629,10 +631,7 @@ void mainWrapped(int argc, char ** argv)
         evalSettings.pureEval = false;
     }
 
-#if HAVE_SENTRY
-    if (sentryEnabled)
-        sentry_set_tag("nix_subcommand", concatStringsSep(" ", subcommand).c_str());
-#endif
+    setSentryTag("nix_subcommand", concatStringsSep(" ", subcommand).c_str());
 
     try {
         args.command->second->run();


### PR DESCRIPTION
## Motivation

This includes a tag like

> Assertion 'false && "This is an assertion failure"' failed in virtual void CmdCrash::run() at ../src/nix/crash.cc:36

in the sentry crash report.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error tracking and diagnostic capabilities. The system now captures additional context information when errors and assertion failures occur, with improved event categorization and tagging for better organization. This enables more efficient troubleshooting, improved issue tracking, and better support workflows for faster resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/457)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->