### PR TITLE
cxa-throw: Don't auto-detect

### DIFF
--- a/nix-meson-build-support/common/cxa-throw/meson.build
+++ b/nix-meson-build-support/common/cxa-throw/meson.build
@@ -1,67 +1,11 @@
 have_cxa_throw = false
 
-can_interpose_cxa_throw_test_code = '''
-#include <string>
-#include <unistd.h>
-
-#define CXA_THROW_ON_LOGIC_ERROR() _exit(0)
-#include "interpose-cxa-throw.cc"
-
-int main()
-{
-    const char * volatile p = nullptr;
-    std::string s(p);
-    return 1;
-}
-'''
-
-can_interpose_cxa_throw_result = cxx.run(
-  can_interpose_cxa_throw_test_code,
-  args : [ '-ldl' ],
-  include_directories : include_directories('.'),
-  name : 'can interpose __cxa_throw (catches libstdc++ throws)',
-)
-can_interpose_cxa_throw = can_interpose_cxa_throw_result.compiled() and can_interpose_cxa_throw_result.returncode() == 0
-
-if can_interpose_cxa_throw
-  interpose_cxa_throw_lib = static_library(
-    'interpose-cxa-throw',
-    'interpose-cxa-throw.cc',
-    dependencies : cxx.find_library('dl', required : false),
-  )
-
-  cxa_throw_dep = declare_dependency(
-    link_whole : interpose_cxa_throw_lib,
-  )
-
+if host_machine.system() == 'linux'
   have_cxa_throw = true
-else
-  can_wrap_cxa_throw_test_code = '''
-  #include <string>
-  #include <unistd.h>
 
-  #define CXA_THROW_ON_LOGIC_ERROR() _exit(0)
-  #include "wrap-cxa-throw.cc"
+  if get_option('default_library') == 'static'
+    wrap_cxa_throw_args = [ '-Wl,--wrap=__cxa_throw' ]
 
-  int main()
-  {
-      const char * volatile p = nullptr;
-      std::string s(p);
-      return 1;
-  }
-  '''
-
-  wrap_cxa_throw_args = [ '-Wl,--wrap=__cxa_throw' ]
-
-  can_wrap_cxa_throw_result = cxx.run(
-    can_wrap_cxa_throw_test_code,
-    args : wrap_cxa_throw_args,
-    include_directories : include_directories('.'),
-    name : 'can wrap __cxa_throw (catches libstdc++ throws)',
-  )
-  can_wrap_cxa_throw = can_wrap_cxa_throw_result.compiled() and can_wrap_cxa_throw_result.returncode() == 0
-
-  if can_wrap_cxa_throw
     wrap_cxa_throw_lib = static_library(
       'wrap-cxa-throw',
       'wrap-cxa-throw.cc',
@@ -72,6 +16,15 @@ else
       link_args : wrap_cxa_throw_args + [ '-Wl,-u,__wrap___cxa_throw' ],
     )
 
-    have_cxa_throw = true
+  else
+    interpose_cxa_throw_lib = static_library(
+      'interpose-cxa-throw',
+      'interpose-cxa-throw.cc',
+      dependencies : cxx.find_library('dl', required : false),
+    )
+
+    cxa_throw_dep = declare_dependency(
+      link_whole : interpose_cxa_throw_lib,
+    )
   endif
 endif


### PR DESCRIPTION

## Motivation

This speeds up running meson (re)configuration from 16.6s to 2.9s.

More importantly though, it's better to just specify that we expect this to work rather than try to compile something, since that can silently mask errors and disable this feature.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified build configuration by removing runtime capability probes and replacing them with deterministic platform-based wiring.
  * On Linux, exception handling support is enabled unconditionally; static-library builds configure wrap-based support, while non-static builds always include the interpose variant.
  * Reduced conditional checks and removed probe-related build variables, lowering maintenance complexity with no change to end-user behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/458)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->