### PR TITLE
Include panic() and std::terminate() info in Sentry crash reports

### DIFF
--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -453,7 +453,7 @@ void panic(std::string_view msg)
     writeErr("\n\n" ANSI_RED "terminating due to unexpected unrecoverable internal error: " ANSI_NORMAL);
     writeErr(msg);
     writeErr("\n");
-    setSentryTag("panic_msg", msg.data());
+    setSentryTag("panic_msg", std::string(msg).c_str());
     std::terminate();
 }
 

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -6,6 +6,7 @@
 #include "nix/util/signals.hh"
 #include "nix/util/terminal.hh"
 #include "nix/util/position.hh"
+#include "nix/util/sentry.hh"
 
 #include <cinttypes>
 #include <iostream>
@@ -452,6 +453,7 @@ void panic(std::string_view msg)
     writeErr("\n\n" ANSI_RED "terminating due to unexpected unrecoverable internal error: " ANSI_NORMAL);
     writeErr(msg);
     writeErr("\n");
+    setSentryTag("panic_msg", msg.data());
     std::terminate();
 }
 

--- a/src/nix/crash.cc
+++ b/src/nix/crash.cc
@@ -41,6 +41,11 @@ struct CmdCrash : Command
             std::bitset<4>{"012"};
         }
 
+        else if (type == "panic") {
+            printError("Triggering a panic...");
+            panic("test panic");
+        }
+
         else {
             throw Error("unknown crash type '%s'", type);
         }

--- a/src/nix/crash.cc
+++ b/src/nix/crash.cc
@@ -4,6 +4,11 @@
 
 using namespace nix;
 
+static void doThrow()
+{
+    throw Error("exception in destructor");
+}
+
 struct CmdCrash : Command
 {
     std::string type;
@@ -44,6 +49,20 @@ struct CmdCrash : Command
         else if (type == "panic") {
             printError("Triggering a panic...");
             panic("test panic");
+        }
+
+        else if (type == "terminate") {
+            printError("Triggering an std::terminate...");
+
+            struct Foo
+            {
+                ~Foo()
+                {
+                    doThrow();
+                }
+            };
+
+            Foo foo;
         }
 
         else {

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -384,6 +384,33 @@ struct CmdHelpStores : Command
 
 static auto rCmdHelpStores = registerCommand<CmdHelpStores>("help-stores");
 
+static void terminateHandler()
+{
+    // Add the exception type and message to the Sentry crash report.
+    auto ex = std::current_exception();
+    if (ex) {
+        try {
+            std::rethrow_exception(ex);
+        } catch (BaseError & e) {
+            try {
+                nix::setSentryTag("terminate_exception_type", typeid(e).name());
+                nix::setSentryTag("terminate_exception_msg", e.message().c_str());
+            } catch (...) {
+            }
+        } catch (const std::exception & e) {
+            try {
+                nix::setSentryTag("terminate_exception_type", typeid(e).name());
+                nix::setSentryTag("terminate_exception_msg", e.what());
+            } catch (...) {
+            }
+        }
+    }
+
+    // Call the original terminate handler.
+    std::set_terminate(nullptr);
+    std::terminate();
+}
+
 void mainWrapped(int argc, char ** argv)
 {
     savedArgv = argv;
@@ -423,6 +450,7 @@ void mainWrapped(int argc, char ** argv)
         sentry_init(options);
         setSentryTag = [](const char * key, const char * value) { sentry_set_tag(key, value); };
         setSentryTag("nix_command", argc > 0 ? std::string(baseNameOf(argv[0])).c_str() : "");
+        std::set_terminate(terminateHandler);
         sentryEnabled = true;
     }
 

--- a/tests/functional/sentry.sh
+++ b/tests/functional/sentry.sh
@@ -27,7 +27,7 @@ waitForCrashDump() {
     return 1
 }
 
-for type in segfault assert logic-error; do
+for type in segfault assert logic-error panic terminate; do
     if [[ $type = logic-error && $(uname) = Darwin ]]; then continue; fi
 
     rm -rf "$sentryDir"


### PR DESCRIPTION
## Motivation

This includes panic messages and uncaught exception type/message in crash reports.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Crash diagnostics now capture panic messages and additional exception details, and annotate unexpected process terminations for richer crash reports.
* **Tests**
  * Expanded functional tests to cover the new crash scenarios and validate enhanced error-reporting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/459)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->