### PR TITLE
HttpBinaryCacheStore: Don't ignore 401/407 errors

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -685,8 +685,12 @@ struct curlFileTransfer : public FileTransfer
                 if (httpStatus == 404 || httpStatus == 410 || code == CURLE_FILE_COULDNT_READ_FILE) {
                     // The file is definitely not there
                     err = NotFound;
-                } else if (httpStatus == 401 || httpStatus == 403 || httpStatus == 407) {
-                    // Don't retry on authentication/authorization failures
+                } else if (httpStatus == 401 || httpStatus == 407) {
+                    err = Unauthorized;
+                } else if (httpStatus == 403) {
+                    // Don't retry on authentication/authorization failures.
+                    // Note: the only reason we treat this differently from 401/407 is S3 returns 403 if a file doesn't
+                    // exist and the bucket is unlistable.
                     err = Forbidden;
                 } else if (httpStatus == 429) {
                     // 429 means too many requests, so we retry (with a substantially longer delay)

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -385,7 +385,7 @@ public:
     void
     download(FileTransferRequest && request, Sink & sink, std::function<void(FileTransferResult)> resultCallback = {});
 
-    enum Error { NotFound, Forbidden, Misc, Transient, Interrupted };
+    enum Error { NotFound, Unauthorized, Forbidden, Misc, Transient, Interrupted };
 };
 
 /**


### PR DESCRIPTION
The only reason it treats 403 errors as 404s is that S3 returns 403 for files that don't exist if the bucket is unlistable. But we don't want to ignore (and definitely shouldn't cache) 401/407 errors as "file not found".

This fixes "token expired" errors from cache.flakehub.com being silently ignored and cached. Now you get:

```
# nix build --dry-run /nix/store/qnfhg5anpfpr4il3jlp9bnkf6vhyzbnj-determinate-nix-3.20.0
error: unable to download 'https://cache.flakehub.com/qnfhg5anpfpr4il3jlp9bnkf6vhyzbnj.narinfo': HTTP error 401

       response body:
         {"code":401,"error":"Unauthorized","message":"Unauthorized.","request_id":"019e3a82-2474-7f80-8564-6e1bc2234654"}
don't know how to build these paths:
      /nix/store/qnfhg5anpfpr4il3jlp9bnkf6vhyzbnj-determinate-nix-3.20.0
```
i.e. it's a fatal error now unless you use `--fallback`.

Note: this can "break" systems that have expired/unauthenticated binary caches, but that *is* the intended behaviour without `--fallback` (we don't want fallback to building from source by default).

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for file transfer operations with improved distinction between authentication failures and permission errors. HTTP `401` and `407` responses now properly report as authentication errors, while `403` responses are reported as permission errors, providing clearer error messages when file transfer operations encounter access issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->