### PR TITLE
upload-debug-info-to-sentry.py: Upload binaries in addition to debug files

### DIFF
--- a/maintainers/upload-debug-info-to-sentry.py
+++ b/maintainers/upload-debug-info-to-sentry.py
@@ -133,7 +133,6 @@ def main():
             build_id = get_build_id(lib)
             if build_id is None:
                 print(f"  {lib} (no build ID, uploading binary)", file=sys.stderr)
-                debug_files.append(lib)
                 continue
 
             local = find_debug_file_in_dirs(build_id, args.debug_dir)

--- a/maintainers/upload-debug-info-to-sentry.py
+++ b/maintainers/upload-debug-info-to-sentry.py
@@ -128,6 +128,8 @@ def main():
         debug_files = []
         print("ELF files to process:", file=sys.stderr)
         for lib in libs:
+            debug_files.append(lib)
+
             build_id = get_build_id(lib)
             if build_id is None:
                 print(f"  {lib} (no build ID, uploading binary)", file=sys.stderr)
@@ -142,9 +144,9 @@ def main():
 
             debuginfo = fetch_debuginfo(build_id)
             if debuginfo is None:
-                print(f"  {lib} ({build_id}): no separate debug info, uploading binary", file=sys.stderr)
-                debug_files.append(lib)
+                print(f"  {lib} ({build_id}): no separate debug info", file=sys.stderr)
                 continue
+
             print(f"  {lib} ({build_id}): member={debuginfo['member']}", file=sys.stderr)
             nar_path = download_nar(build_id, debuginfo["archive"])
             debug_file = extract_debug_symbols(nar_path, debuginfo["member"], build_id)


### PR DESCRIPTION

## Motivation

This should provide better stack unwinding in Sentry.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Discovered binaries and libraries are now added to the upload list as they are found during processing.
  * Messaging clarified when no separate debug information is available, and processing continues without duplicating entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->