### PR TITLE
Re-enable TCP keep-alive and handle S3's XML errors

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -22,6 +22,7 @@
 
 #include <curl/curl.h>
 
+#include <array>
 #include <cmath>
 #include <cstring>
 #include <queue>
@@ -693,24 +694,32 @@ struct curlFileTransfer : public FileTransfer
                 // S3 returns certain retryable errors as HTTP 400/500/503 with XML error codes.
                 // These take precedence over the generic HTTP status handling below.
                 // Only parse the response body on status codes where S3 XML errors can appear.
-                static const std::set<std::string> s3RetryableErrors{
-                    "RequestTimeout",     // HTTP 400 - stale connection reuse
-                    "IncompleteBody",     // HTTP 400 - network issue
-                    "InternalError",      // HTTP 500 - S3 internal failure
-                    "SlowDown",           // HTTP 503 - throttling
-                    "ServiceUnavailable", // HTTP 503 - temporary unavailability
-                };
+                static constexpr std::array<std::string_view, 12> s3RetryableErrors{{
+                    "IncompleteBody",       // HTTP 400 - network issue
+                    "InternalError",        // HTTP 500 - S3 internal failure
+                    "InternalFailure",      // HTTP 500 - alias for InternalError
+                    "InternalServerError",  // HTTP 500 - alias for InternalError
+                    "RequestExpired",       // HTTP 400 - clock skew / slow upload
+                    "RequestTimeout",       // HTTP 400 - stale connection reuse
+                    "RequestTimeTooSkewed", // HTTP 403 - clock drift
+                    "RequestThrottled",     // HTTP 400 - throttling variant
+                    "SlowDown",             // HTTP 503 - throttling
+                    "ServiceUnavailable",   // HTTP 503 - temporary unavailability
+                    "Throttling",           // HTTP 400 - throttling variant
+                    "ThrottledException",   // HTTP 400 - throttling variant
+                }};
                 // S3 error responses have the form <Error><Code>...</Code>...</Error>.
                 // Require the <Error> root to avoid matching unrelated XML with a <Code> element.
                 static std::regex s3ErrorCodeRegex("<Error>[^]*<Code>([^<]+)</Code>");
                 std::smatch s3Match;
-                bool isS3XmlStatus = httpStatus == 400 || httpStatus == 500 || httpStatus == 503;
+                bool isS3XmlStatus = httpStatus == 400 || httpStatus == 403 || httpStatus == 500 || httpStatus == 503;
                 auto s3ErrorCode =
                     (isS3XmlStatus && errorSink && std::regex_search(errorSink->s, s3Match, s3ErrorCodeRegex))
                         ? s3Match[1].str()
                         : "";
 
-                if (s3RetryableErrors.count(s3ErrorCode)) {
+                if (std::find(s3RetryableErrors.begin(), s3RetryableErrors.end(), s3ErrorCode)
+                    != s3RetryableErrors.end()) {
                     debug("S3 error '%s', will retry", s3ErrorCode);
                 } else if (httpStatus == 404 || httpStatus == 410 || code == CURLE_FILE_COULDNT_READ_FILE) {
                     // The file is definitely not there

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -690,7 +690,29 @@ struct curlFileTransfer : public FileTransfer
                 // We treat most errors as transient, but won't retry when hopeless
                 Error err = Transient;
 
-                if (httpStatus == 404 || httpStatus == 410 || code == CURLE_FILE_COULDNT_READ_FILE) {
+                // S3 returns certain retryable errors as HTTP 400/500/503 with XML error codes.
+                // These take precedence over the generic HTTP status handling below.
+                // Only parse the response body on status codes where S3 XML errors can appear.
+                static const std::set<std::string> s3RetryableErrors{
+                    "RequestTimeout",     // HTTP 400 - stale connection reuse
+                    "IncompleteBody",     // HTTP 400 - network issue
+                    "InternalError",      // HTTP 500 - S3 internal failure
+                    "SlowDown",           // HTTP 503 - throttling
+                    "ServiceUnavailable", // HTTP 503 - temporary unavailability
+                };
+                // S3 error responses have the form <Error><Code>...</Code>...</Error>.
+                // Require the <Error> root to avoid matching unrelated XML with a <Code> element.
+                static std::regex s3ErrorCodeRegex("<Error>[^]*<Code>([^<]+)</Code>");
+                std::smatch s3Match;
+                bool isS3XmlStatus = httpStatus == 400 || httpStatus == 500 || httpStatus == 503;
+                auto s3ErrorCode =
+                    (isS3XmlStatus && errorSink && std::regex_search(errorSink->s, s3Match, s3ErrorCodeRegex))
+                        ? s3Match[1].str()
+                        : "";
+
+                if (s3RetryableErrors.count(s3ErrorCode)) {
+                    debug("S3 error '%s', will retry", s3ErrorCode);
+                } else if (httpStatus == 404 || httpStatus == 410 || code == CURLE_FILE_COULDNT_READ_FILE) {
                     // The file is definitely not there
                     err = NotFound;
                 } else if (httpStatus == 401 || httpStatus == 407) {

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -579,6 +579,14 @@ struct curlFileTransfer : public FileTransfer
 #endif
             curl_easy_setopt(req, CURLOPT_CONNECTTIMEOUT, fileTransfer.settings.connectTimeout.get());
 
+            /* Enable TCP keepalive to detect dead connections and server closures.
+               Probes every 30s to catch network failures and idle timeouts early. */
+            curl_easy_setopt(req, CURLOPT_TCP_KEEPALIVE, 1L);
+            curl_easy_setopt(req, CURLOPT_TCP_KEEPIDLE, 30L);
+            curl_easy_setopt(req, CURLOPT_TCP_KEEPINTVL, 30L);
+            /* Don't reuse idle connections older than 90s. */
+            curl_easy_setopt(req, CURLOPT_MAXAGE_CONN, 90L);
+
             curl_easy_setopt(req, CURLOPT_LOW_SPEED_LIMIT, 1L);
             curl_easy_setopt(req, CURLOPT_LOW_SPEED_TIME, fileTransfer.settings.stalledDownloadTimeout.get());
 


### PR DESCRIPTION
## Motivation

Upstream https://github.com/NixOS/nix/pull/15855.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP connection stability for long-running transfers with enhanced keepalive configuration.
  * Enhanced S3 error handling with smarter retry logic that accurately identifies retryable S3 errors, reducing unnecessary failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->