### PR TITLE
Remove non-atomically initialised variable vImportedDrvToDerivation

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -319,6 +319,10 @@ EvalState::EvalState(
           CanonPath("derivation-internal.nix"),
 #include "primops/derivation.nix.gen.hh"
           )}
+    , importedDrvToDerivation{internalFS->addFile(
+          CanonPath("imported-drv-to-derivation.nix"),
+#include "imported-drv-to-derivation.nix.gen.hh"
+          )}
     , store(store)
     , buildStore(buildStore ? buildStore : store)
     , inputCache(fetchers::InputCache::create())

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -399,6 +399,7 @@ public:
     const ref<MemorySourceAccessor> internalFS;
 
     const SourcePath derivationInternal;
+    const SourcePath importedDrvToDerivation;
 
     /**
      * Store used to materialise .drv files.
@@ -409,8 +410,6 @@ public:
      * Store used to build stuff.
      */
     const ref<Store> buildStore;
-
-    RootValue vImportedDrvToDerivation = nullptr;
 
     const ref<fetchers::InputCache> inputCache;
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -249,18 +249,10 @@ void derivationToValue(
     auto w = state.allocValue();
     w->mkAttrs(attrs);
 
-    if (!state.vImportedDrvToDerivation) {
-        state.vImportedDrvToDerivation = allocRootValue(state.allocValue());
-        state.eval(
-            state.parseExprFromString(
-#include "imported-drv-to-derivation.nix.gen.hh"
-                , state.rootPath(CanonPath::root)),
-            **state.vImportedDrvToDerivation);
-    }
+    auto vImportedDrvToDerivation = state.allocValue();
+    state.evalFile(state.importedDrvToDerivation, *vImportedDrvToDerivation); // has caching
 
-    state.forceFunction(
-        **state.vImportedDrvToDerivation, pos, "while evaluating imported-drv-to-derivation.nix.gen.hh");
-    v.mkApp(*state.vImportedDrvToDerivation, w);
+    v.mkApp(vImportedDrvToDerivation, w);
     state.forceAttrs(v, pos, "while calling imported-drv-to-derivation.nix.gen.hh");
 }
 


### PR DESCRIPTION


## Motivation

Fixes https://github.com/DeterminateSystems/nix-src/issues/447.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal evaluation of a derivation-related helper was changed from a cached in-memory value to a path-based evaluation with internal caching semantics.
  * No public APIs or exported symbols changed; visible behavior for end users remains functionally consistent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->