### PR TITLE
Add an exact flake registry override for `nixpkgs`

### DIFF
--- a/src/libfetchers/builtin-flake-registry.json
+++ b/src/libfetchers/builtin-flake-registry.json
@@ -332,6 +332,17 @@
       }
     },
     {
+      "exact": true,
+      "from": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      },
+      "to": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0"
+      }
+    },
+    {
       "from": {
         "id": "nixpkgs",
         "type": "indirect"

--- a/src/libfetchers/builtin-flake-registry.json
+++ b/src/libfetchers/builtin-flake-registry.json
@@ -339,7 +339,7 @@
       },
       "to": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0"
+        "url": "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1"
       }
     },
     {

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -284,7 +284,7 @@ nix registry remove flake1
 [[ $(nix registry resolve flake1) = "git+file://$flake1Dir" ]]
 
 # Test the builtin fallback registry.
-[[ $(nix registry resolve nixpkgs --flake-registry http://fail.invalid.org/sdklsdklsd --download-attempts 1) = github:NixOS/nixpkgs/nixpkgs-unstable ]]
+[[ $(nix registry resolve nixpkgs --flake-registry http://fail.invalid.org/sdklsdklsd --download-attempts 1) = https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1 ]]
 
 # Test 'nix registry list' with a disabled global registry.
 nix registry add user-flake1 git+file://"$flake1Dir"


### PR DESCRIPTION
Never see this again:

<img width="1311" height="729" alt="image" src="https://github.com/user-attachments/assets/99c4d3b7-07ef-4aaa-93b5-c75c40143e2e" />


Users of CI platforms that aren't GitHub Actions frequently see rate-limiting errors while fetching Nixpkgs.

This is because GitHub aggressively rate-limits tarball downloads for requests without a GitHub Token. In GitHub Actions, this is largely solved by providing a token in the nix.conf.

This change causes nixpkgs and therefore `nix run nixpkgs#...` commands to fetch Nixpkgs from FlakeHub, making this work out of the box across the board.

Note that users are encouraged to avoid using the flake registry for flake inputs: https://github.com/DeterminateSystems/nix-src/issues/37

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the nixpkgs flake registry to an exact tarball source on FlakeHub (https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1) instead of the previous GitHub-based reference, providing a fixed retrieval endpoint.

* **Tests**
  * Updated regression expectations to reflect the new tarball-based fallback resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->