### PR TITLE
Add test for resuming downloads

### DIFF
--- a/src/nix/serve.cc
+++ b/src/nix/serve.cc
@@ -6,6 +6,7 @@
 #include "nix/store/nar-info.hh"
 #include "nix/store/binary-cache-store.hh"
 #include "nix/store/log-store.hh"
+#include "nix/util/environment-variables.hh"
 
 #include <future>
 #include <regex>
@@ -174,6 +175,14 @@ struct CmdServe : StoreCommand
                     read++;
                     state.firstByte.reset();
                 }
+
+                static bool truncate = getEnv("_NIX_TEST_NIX_SERVE_TRUNCATE_NAR").value_or("") == "1";
+                static std::atomic<uint64_t> truncatePoint{200000};
+                if (truncate && pos > truncatePoint) {
+                    truncatePoint += 200000;
+                    return MHD_CONTENT_READER_END_WITH_ERROR;
+                }
+
                 try {
                     read += state.source->read(buf, max);
                     return read;

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -129,7 +129,18 @@ basicDownloadTests "file://$cacheDir"
 restartNixServe
 basicDownloadTests "$httpBinaryCacheUrl"
 
+
+# Test whether resuming from a binary cache that doesn't support ranged requests works.
+export _NIX_TEST_NIX_SERVE_TRUNCATE_NAR=1
+restartNixServe
+clearStore
+nix-store -r "$bigFile" --substituters "$httpBinaryCacheUrl" 2>&1 | tee "$TEST_ROOT/log"
+[[ $(grep -c "curl error: Transferred a partial file" "$TEST_ROOT/log") -eq 2 ]]
+unset _NIX_TEST_NIX_SERVE_TRUNCATE_NAR
+
+
 # Regression test: queryMissing() should cache narinfos.
+restartNixServe
 nix path-info -vvvv --store "$httpBinaryCacheUrl" "$bigFile" 2> "$TEST_ROOT/log"
 [[ $(grep -c "downloading.*narinfo'" "$TEST_ROOT/log") -eq 1 ]]
 


### PR DESCRIPTION


## Motivation

For some reason this wasn't included in #445.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resilience for resuming partial downloads from HTTP binary caches that lack range request support, improving reliability when network interruptions occur during package downloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->