### PR TITLE
Make fetchTarball lazy

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -451,35 +451,38 @@ static void fetch(
         }
     }
 
-    // Download the file/tarball if substitution failed or no hash was provided
-    auto storePath = unpack ? fetchToStore(
-                                  state.fetchSettings,
-                                  *state.store,
-                                  fetchers::downloadTarball(*state.store, state.fetchSettings, *url),
-                                  FetchMode::Copy,
-                                  name)
-                            : fetchers::downloadFile(*state.store, state.fetchSettings, *url, name).storePath;
-
-    if (expectedHash) {
-        auto hash = unpack ? state.store->queryPathInfo(storePath)->narHash
-                           : hashPath(
-                                 {state.store->requireStoreObjectAccessor(storePath)},
-                                 FileSerialisationMethod::Flat,
-                                 HashAlgorithm::SHA256)
-                                 .hash;
-        if (hash != *expectedHash) {
-            state
-                .error<EvalError>(
-                    "hash mismatch in file downloaded from '%s':\n  specified: %s\n  got:       %s",
-                    *url,
-                    expectedHash->to_string(HashFormat::Nix32, true),
-                    hash.to_string(HashFormat::Nix32, true))
-                .withExitStatus(102)
-                .debugThrow();
+    if (unpack) {
+        auto attrs = fetchers::Attrs{
+            {"type", "tarball"},
+            {"url", *url},
+        };
+        if (expectedHash)
+            attrs.emplace("narHash", expectedHash->to_string(HashFormat::SRI, true));
+        auto input = fetchers::Input::fromAttrs(state.fetchSettings, std::move(attrs));
+        auto cachedInput =
+            state.inputCache->getAccessor(state.fetchSettings, *state.store, input, fetchers::UseRegistries::No);
+        auto storePath = state.mountInput(cachedInput.lockedInput, input, cachedInput.accessor, false);
+        state.mkStorePathString(storePath, v);
+    } else {
+        auto storePath = fetchers::downloadFile(*state.store, state.fetchSettings, *url, name).storePath;
+        if (expectedHash) {
+            auto hash = hashPath(
+                            {state.store->requireStoreObjectAccessor(storePath)},
+                            FileSerialisationMethod::Flat,
+                            HashAlgorithm::SHA256)
+                            .hash;
+            if (hash != *expectedHash)
+                state
+                    .error<EvalError>(
+                        "hash mismatch in file downloaded from '%s':\n  specified: %s\n  got:       %s",
+                        *url,
+                        expectedHash->to_string(HashFormat::Nix32, true),
+                        hash.to_string(HashFormat::Nix32, true))
+                    .withExitStatus(102)
+                    .debugThrow();
         }
+        state.allowAndSetStorePathString(storePath, v);
     }
-
-    state.allowAndSetStorePathString(storePath, v);
 }
 
 static void prim_fetchurl(EvalState & state, const PosIdx pos, Value ** args, Value & v)

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -455,6 +455,7 @@ static void fetch(
         auto attrs = fetchers::Attrs{
             {"type", "tarball"},
             {"url", *url},
+            {"name", name},
         };
         if (expectedHash)
             attrs.emplace("narHash", expectedHash->to_string(HashFormat::SRI, true));


### PR DESCRIPTION
## Motivation

This makes `fetchTarball` faster by (possibly) avoiding an unnecessary copy to the Nix store.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger SHA256 validation for downloaded files with clearer error behavior on mismatch.

* **Refactor**
  * Streamlined tarball and single-file download flow with improved input caching and more reliable storage path handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->