### PR TITLE
Improve path display

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -299,8 +299,9 @@ EvalState::EvalState(
            instance if we're evaluating a file from the physical
            /nix/store while using a chroot store, and also for lazy
            mounted fetchTree. */
-        auto accessor = settings.pureEval ? storeFS.cast<SourceAccessor>()
-                                          : makeUnionSourceAccessor({getFSSourceAccessor(), storeFS});
+        auto accessor = settings.pureEval
+                            ? storeFS.cast<SourceAccessor>()
+                            : makeUnionSourceAccessor({getFSSourceAccessor(), storeFS}, storeFS.cast<SourceAccessor>());
 
         /* Apply access control if needed. */
         if (settings.restrictEval || settings.pureEval)

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -427,38 +427,17 @@ static void fetch(
             .atPos(pos)
             .debugThrow();
 
-    // early exit if pinned and already in the store
-    if (expectedHash && expectedHash->algo == HashAlgorithm::SHA256) {
-        auto expectedPath = state.store->makeFixedOutputPath(
-            name,
-            FixedOutputInfo{
-                .method = unpack ? FileIngestionMethod::NixArchive : FileIngestionMethod::Flat,
-                .hash = *expectedHash,
-                .references = {}});
-
-        // Try to get the path from the local store or substituters
-        try {
-            state.store->ensurePath(expectedPath);
-            debug("using substituted/cached path '%s' for '%s'", state.store->printStorePath(expectedPath), *url);
-            state.allowAndSetStorePathString(expectedPath, v);
-            return;
-        } catch (Error & e) {
-            debug(
-                "substitution of '%s' failed, will try to download: %s",
-                state.store->printStorePath(expectedPath),
-                e.message());
-            // Fall through to download
-        }
-    }
-
     if (unpack) {
         auto attrs = fetchers::Attrs{
             {"type", "tarball"},
             {"url", *url},
             {"name", name},
         };
-        if (expectedHash)
+        if (expectedHash) {
             attrs.emplace("narHash", expectedHash->to_string(HashFormat::SRI, true));
+            // Mark as final to allow the tree to be substituted.
+            attrs.emplace("__final", Explicit<bool>{true});
+        }
         auto input = fetchers::Input::fromAttrs(state.fetchSettings, std::move(attrs));
         auto cachedInput =
             state.inputCache->getAccessor(state.fetchSettings, *state.store, input, fetchers::UseRegistries::No);

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -446,7 +446,7 @@ static void fetch(
             debug(
                 "substitution of '%s' failed, will try to download: %s",
                 state.store->printStorePath(expectedPath),
-                e.what());
+                e.message());
             // Fall through to download
         }
     }

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -299,21 +299,6 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessor(const Settings & settin
     }
 }
 
-/**
- * Helper class that ensures that paths in substituted source trees
- * are rendered as `«input»/path` rather than
- * `«input»/nix/store/<hash>-source/path`.
- */
-struct SubstitutedSourceAccessor : ForwardingSourceAccessor
-{
-    using ForwardingSourceAccessor::ForwardingSourceAccessor;
-
-    std::string showPath(const CanonPath & path) override
-    {
-        return displayPrefix + path.abs() + displaySuffix;
-    }
-};
-
 std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(const Settings & settings, Store & store) const
 {
     // FIXME: cache the accessor
@@ -326,7 +311,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(const Settings
         storePath = computeStorePath(store);
 
     auto makeStoreAccessor = [&]() -> std::pair<ref<SourceAccessor>, Input> {
-        auto accessor = make_ref<SubstitutedSourceAccessor>(store.requireStoreObjectAccessor(*storePath));
+        auto accessor = store.requireStoreObjectAccessor(*storePath);
 
         // FIXME: use the NAR hash for fingerprinting Git trees since it may have a .gitattributes file and we don't
         // know if we used `git archive` or libgit2 to fetch it.

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1016,7 +1016,7 @@ struct GitSourceAccessor : SourceAccessor
     {
         auto entry = lookup(state, path);
         if (!entry)
-            throw Error("'%s' does not exist", showPath(path));
+            throw FileNotFound("path '%s' does not exist", showPath(path));
         return entry;
     }
 

--- a/src/libutil-tests/source-accessor.cc
+++ b/src/libutil-tests/source-accessor.cc
@@ -129,7 +129,7 @@ TEST_F(FSSourceAccessorTest, works)
     {
         auto accessor = makeFSSourceAccessor(tmpDir / "nonexistent");
         EXPECT_FALSE(accessor->maybeLstat(CanonPath::root));
-        EXPECT_THROW(accessor->readFile(CanonPath::root), SystemError);
+        EXPECT_THROW(accessor->readFile(CanonPath::root), FileNotFound);
     }
 
     {

--- a/src/libutil-tests/util.cc
+++ b/src/libutil-tests/util.cc
@@ -383,4 +383,44 @@ TEST(getOr, getFromContainer)
     ASSERT_EQ(getOr(s, "one", "nope"), expected);
 }
 
+/* ----------------------------------------------------------------------------
+ * markLast
+ * --------------------------------------------------------------------------*/
+
+TEST(markLast, empty)
+{
+    std::vector<int> v;
+    std::vector<std::pair<bool, int>> result;
+    for (auto [last, x] : markLast(v))
+        result.emplace_back(last, x);
+    ASSERT_TRUE(result.empty());
+}
+
+TEST(markLast, singleElement)
+{
+    std::vector<int> v{42};
+    std::vector<std::pair<bool, int>> result;
+    for (auto [last, x] : markLast(v))
+        result.emplace_back(last, x);
+    ASSERT_EQ(result, (std::vector<std::pair<bool, int>>{{true, 42}}));
+}
+
+TEST(markLast, multipleElements)
+{
+    std::vector<int> v{10, 20, 30};
+    std::vector<std::pair<bool, int>> result;
+    for (auto [last, x] : markLast(v))
+        result.emplace_back(last, x);
+    ASSERT_EQ(result, (std::vector<std::pair<bool, int>>{{false, 10}, {false, 20}, {true, 30}}));
+}
+
+TEST(markLast, mutateThroughReference)
+{
+    std::vector<int> v{1, 2, 3};
+    for (auto && [last, x] : markLast(v))
+        if (last)
+            x = 99;
+    ASSERT_EQ(v, (std::vector<int>{1, 2, 99}));
+}
+
 } // namespace nix

--- a/src/libutil/include/nix/util/source-accessor.hh
+++ b/src/libutil/include/nix/util/source-accessor.hh
@@ -274,6 +274,7 @@ ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root, bool trackL
  * Construct an accessor that presents a "union" view of a vector of
  * underlying accessors. Earlier accessors take precedence over later.
  */
-ref<SourceAccessor> makeUnionSourceAccessor(std::vector<ref<SourceAccessor>> && accessors);
+ref<SourceAccessor>
+makeUnionSourceAccessor(std::vector<ref<SourceAccessor>> && accessors, std::shared_ptr<SourceAccessor> displayAccessor);
 
 } // namespace nix

--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -435,6 +435,20 @@ constexpr auto enumerate(R && range)
 }
 
 /**
+ * An iterator adapter that enumerates the elements of a range,
+ * pairing each element with a boolean indicating whether it is the
+ * last element.
+ */
+template<std::ranges::viewable_range R>
+    requires std::ranges::sized_range<R>
+constexpr auto markLast(R && range)
+{
+    auto n = std::ranges::size(range);
+    return std::views::zip(
+        std::views::iota(size_t{1}) | std::views::transform([n](size_t i) { return i == n; }), std::forward<R>(range));
+}
+
+/**
  * C++17 std::visit boilerplate
  */
 template<class... Ts>

--- a/src/libutil/memory-source-accessor.cc
+++ b/src/libutil/memory-source-accessor.cc
@@ -57,7 +57,7 @@ void MemorySourceAccessor::readFile(const CanonPath & path, Sink & sink, fun<voi
 {
     auto * f = open(path, std::nullopt);
     if (!f)
-        throw FileNotFound("file '%s' does not exist", showPath(path));
+        throw FileNotFound("path '%s' does not exist", showPath(path));
     if (auto * r = std::get_if<File::Regular>(&f->raw)) {
         sizeCallback(r->contents.size());
         StringSource source{r->contents};
@@ -107,7 +107,7 @@ MemorySourceAccessor::DirEntries MemorySourceAccessor::readDirectory(const Canon
 {
     auto * f = open(path, std::nullopt);
     if (!f)
-        throw FileNotFound("file '%s' does not exist", showPath(path));
+        throw FileNotFound("path '%s' does not exist", showPath(path));
     if (auto * d = std::get_if<File::Directory>(&f->raw)) {
         DirEntries res;
         for (auto & [name, file] : d->entries)
@@ -122,7 +122,7 @@ std::string MemorySourceAccessor::readLink(const CanonPath & path)
 {
     auto * f = open(path, std::nullopt);
     if (!f)
-        throw FileNotFound("file '%s' does not exist", showPath(path));
+        throw FileNotFound("path '%s' does not exist", showPath(path));
     if (auto * s = std::get_if<File::Symlink>(&f->raw))
         return s->target;
     else

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -52,8 +52,12 @@ void PosixSourceAccessor::readFile(const CanonPath & path, Sink & sink, fun<void
             | O_NOFOLLOW | O_CLOEXEC
 #endif
         ));
-    if (!fd)
-        throw SysError("opening file '%1%'", ap.string());
+    if (!fd) {
+        if (errno == ENOENT)
+            throw FileNotFound("path '%1%' does not exist", showPath(path));
+        else
+            throw SysError("opening file '%1%'", showPath(path));
+    }
 
     auto size = getFileSize(fd.get());
 

--- a/src/libutil/union-source-accessor.cc
+++ b/src/libutil/union-source-accessor.cc
@@ -5,9 +5,11 @@ namespace nix {
 struct UnionSourceAccessor : SourceAccessor
 {
     std::vector<ref<SourceAccessor>> accessors;
+    std::shared_ptr<SourceAccessor> displayAccessor;
 
-    UnionSourceAccessor(std::vector<ref<SourceAccessor>> _accessors)
+    UnionSourceAccessor(std::vector<ref<SourceAccessor>> _accessors, std::shared_ptr<SourceAccessor> _displayAccessor)
         : accessors(std::move(_accessors))
+        , displayAccessor(std::move(_displayAccessor))
     {
         displayPrefix.clear();
     }
@@ -64,6 +66,8 @@ struct UnionSourceAccessor : SourceAccessor
 
     std::string showPath(const CanonPath & path) override
     {
+        if (displayAccessor)
+            return displayAccessor->showPath(path);
         for (auto & accessor : accessors)
             return accessor->showPath(path);
         return SourceAccessor::showPath(path);
@@ -108,9 +112,10 @@ struct UnionSourceAccessor : SourceAccessor
     }
 };
 
-ref<SourceAccessor> makeUnionSourceAccessor(std::vector<ref<SourceAccessor>> && accessors)
+ref<SourceAccessor>
+makeUnionSourceAccessor(std::vector<ref<SourceAccessor>> && accessors, std::shared_ptr<SourceAccessor> displayAccessor)
 {
-    return make_ref<UnionSourceAccessor>(std::move(accessors));
+    return make_ref<UnionSourceAccessor>(std::move(accessors), displayAccessor);
 }
 
 } // namespace nix

--- a/src/libutil/union-source-accessor.cc
+++ b/src/libutil/union-source-accessor.cc
@@ -16,13 +16,11 @@ struct UnionSourceAccessor : SourceAccessor
 
     void readFile(const CanonPath & path, Sink & sink, fun<void(uint64_t)> sizeCallback) override
     {
-        for (auto & accessor : accessors) {
-            auto st = accessor->maybeLstat(path);
-            if (st) {
+        for (const auto & [last, accessor] : markLast(accessors))
+            if (last || accessor->maybeLstat(path)) {
                 accessor->readFile(path, sink, sizeCallback);
                 return;
             }
-        }
         throw FileNotFound("path '%s' does not exist", showPath(path));
     }
 
@@ -56,11 +54,9 @@ struct UnionSourceAccessor : SourceAccessor
 
     std::string readLink(const CanonPath & path) override
     {
-        for (auto & accessor : accessors) {
-            auto st = accessor->maybeLstat(path);
-            if (st)
+        for (const auto & [last, accessor] : markLast(accessors))
+            if (last || accessor->maybeLstat(path))
                 return accessor->readLink(path);
-        }
         throw FileNotFound("path '%s' does not exist", showPath(path));
     }
 

--- a/tests/functional/flakes/source-paths.sh
+++ b/tests/functional/flakes/source-paths.sh
@@ -61,5 +61,5 @@ expectStderr 1 nix eval --expr "builtins.readFile ((builtins.fetchTree { type = 
 
 # This should still be the case if the input is in the store.
 narHash=$(nix flake prefetch --json "$repo" | jq -r .locked.narHash)
-expectStderr 1 nix eval --expr "builtins.readFile ((builtins.fetchTree { type = \"git\"; url = \"file://$repo\"; narHash = \"$narHash\"; }) + \"/README.md\")" --impure | grepQuiet "path '«git+file://$repo»/README.md' does not exist"
-expectStderr 1 nix eval --expr "builtins.readFile ((builtins.fetchTree { type = \"git\"; url = \"file://$repo\"; narHash = \"$narHash\"; }) + \"/README.md\")" | grepQuiet "path '«git+file://$repo»/README.md' does not exist"
+expectStderr 1 nix eval --expr "builtins.readFile ((builtins.fetchTree { type = \"git\"; url = \"file://$repo\"; narHash = \"$narHash\"; }) + \"/README.md\")" --impure | grepQuiet "path '.*git+file://$repo.*/README.md' does not exist"
+expectStderr 1 nix eval --expr "builtins.readFile ((builtins.fetchTree { type = \"git\"; url = \"file://$repo\"; narHash = \"$narHash\"; }) + \"/README.md\")" | grepQuiet "path '.*git+file://$repo.*/README.md' does not exist"

--- a/tests/functional/flakes/source-paths.sh
+++ b/tests/functional/flakes/source-paths.sh
@@ -55,3 +55,5 @@ expectStderr 1 nix eval "$repo#b" | grepQuiet "error: Path 'dir' in the reposito
 git -C "$repo" add "$repo/dir/default.nix"
 
 [[ $(nix eval "$repo#b") = 456 ]]
+
+expectStderr 1 nix eval --expr "builtins.readFile ((builtins.fetchTree { type = \"git\"; url = \"file://$repo\"; }) + \"/README.md\")" --impure | grepQuiet "path '$repo/README.md' does not exist"

--- a/tests/functional/flakes/source-paths.sh
+++ b/tests/functional/flakes/source-paths.sh
@@ -33,7 +33,7 @@ git -C "$repo" commit -a -m foo
 expectStderr 1 nix eval "git+file://$repo?ref=master#y" | grepQuiet "at «git+file://$repo?rev=.*»/flake.nix:"
 
 expectStderr 1 nix eval "$repo#z" | grepQuiet "error: Path 'foo' does not exist in Git repository \"$repo\"."
-expectStderr 1 nix eval "git+file://$repo?ref=master#z" | grepQuiet "error: '«git+file://$repo?rev=.*»/foo' does not exist"
+expectStderr 1 nix eval "git+file://$repo?ref=master#z" | grepQuiet "error: path '«git+file://$repo?rev=.*»/foo' does not exist"
 expectStderr 1 nix eval "$repo#a" | grepQuiet "error: Path 'foo' does not exist in Git repository \"$repo\"."
 
 echo 123 > "$repo/foo"
@@ -56,4 +56,5 @@ git -C "$repo" add "$repo/dir/default.nix"
 
 [[ $(nix eval "$repo#b") = 456 ]]
 
-expectStderr 1 nix eval --expr "builtins.readFile ((builtins.fetchTree { type = \"git\"; url = \"file://$repo\"; }) + \"/README.md\")" --impure | grepQuiet "path '$repo/README.md' does not exist"
+# Check that error messages in impure mode correctly refer to the original path, not a store path.
+expectStderr 1 nix eval --expr "builtins.readFile ((builtins.fetchTree { type = \"git\"; url = \"file://$repo\"; }) + \"/README.md\")" --impure | grepQuiet "Path 'README.md' does not exist in Git repository \"$repo\"."

--- a/tests/functional/flakes/source-paths.sh
+++ b/tests/functional/flakes/source-paths.sh
@@ -58,3 +58,8 @@ git -C "$repo" add "$repo/dir/default.nix"
 
 # Check that error messages in impure mode correctly refer to the original path, not a store path.
 expectStderr 1 nix eval --expr "builtins.readFile ((builtins.fetchTree { type = \"git\"; url = \"file://$repo\"; }) + \"/README.md\")" --impure | grepQuiet "Path 'README.md' does not exist in Git repository \"$repo\"."
+
+# This should still be the case if the input is in the store.
+narHash=$(nix flake prefetch --json "$repo" | jq -r .locked.narHash)
+expectStderr 1 nix eval --expr "builtins.readFile ((builtins.fetchTree { type = \"git\"; url = \"file://$repo\"; narHash = \"$narHash\"; }) + \"/README.md\")" --impure | grepQuiet "path '«git+file://$repo»/README.md' does not exist"
+expectStderr 1 nix eval --expr "builtins.readFile ((builtins.fetchTree { type = \"git\"; url = \"file://$repo\"; narHash = \"$narHash\"; }) + \"/README.md\")" | grepQuiet "path '«git+file://$repo»/README.md' does not exist"


### PR DESCRIPTION
## Motivation

This fixes various cases where Nix would show store paths instead of source trees in error messages, e.g.
```
error: path '/nix/store/v57qvdsi3n14hlzdrxkbv3dxj8781818-source/READMEE.md' does not exist
```
instead of    
```
error: path '«file:///home/eelco/Dev/nix/nixpkgs.tar.gz»/READMEE.md' does not exist
```

It also removes now unnecessary substitution code in `fetchTarball` as a followup to #468.    


<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better distinction of missing-file errors (throws FileNotFound vs other system errors) and clearer "path … does not exist" messages.
  * Improved path display for substituted/impure sources so missing-file errors reference original source paths.

* **New Features**
  * Tarball inputs now set explicit type/name and mark content-addressed inputs as final to enable later substitution.

* **Tests**
  * Added/updated unit and functional tests covering impure vs pure fetch/read behavior and new utility helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->