### PR TITLE
Denote empty files in stack traces

### DIFF
--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -99,7 +99,8 @@ void printCodeLines(std::ostream & out, const std::string & prefix, const Pos & 
 
             out << std::endl << fmt("%1%      |%2%" ANSI_RED "%3%" ANSI_NORMAL, prefix, spaces, arrows);
         }
-    }
+    } else
+        out << std::endl << fmt("%1% %|2$5d|| " ANSI_ITALIC "(empty file)" ANSI_NORMAL, prefix, (errPos.line));
 
     // next line of code.
     if (loc.nextLineOfCode.has_value()) {
@@ -144,9 +145,10 @@ static bool printPosMaybe(std::ostream & oss, std::string_view indent, const std
 {
     bool hasPos = pos && *pos;
     if (hasPos) {
-        oss << indent << ANSI_BLUE << "at " ANSI_WARNING << *pos << ANSI_NORMAL << ":";
+        auto loc = pos->getCodeLines();
+        oss << indent << ANSI_BLUE << "at " ANSI_WARNING << *pos << ANSI_NORMAL << (loc ? ":" : "");
 
-        if (auto loc = pos->getCodeLines()) {
+        if (loc) {
             printCodeLines(oss, "", *pos, *loc);
             oss << "\n";
         }


### PR DESCRIPTION
## Motivation

Instead of
```
error: syntax error, unexpected end of file
 at «git+file:///.../nixos?rev=0defd19d32413f757d7273596cd9641cb91af25a&shallow=1&submodules=1»/configuration.nix:1:1:
```

(note the `:` followed by nothing at the end of the line),  Nix now shows

```
error: syntax error, unexpected end of file
at «git+file:///home/eelco/Dev/nix-master/nixos?rev=0defd19d32413f757d7273596cd9641cb91af25a&shallow=1&submodules=1»/configuration.nix:1:1:
    1| (empty file)
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error-message display when source code context is unavailable: shows a clear "(empty file)" placeholder instead of omitting the code line.
  * Refined error position formatting so the "at <position>:" header appears only when code lines are present, ensuring more consistent and readable error reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->