### PR TITLE
Input::isRelative(): Fix assertion failure

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -174,8 +174,7 @@ bool Input::isFinal() const
 
 std::optional<std::filesystem::path> Input::isRelative() const
 {
-    assert(scheme);
-    return scheme->isRelative(*this);
+    return scheme ? scheme->isRelative(*this) : std::nullopt;
 }
 
 Attrs Input::toAttrs() const

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -402,19 +402,20 @@ Input Input::applyOverrides(std::optional<std::string> ref, std::optional<Hash> 
 
 void Input::clone(const Settings & settings, Store & store, const std::filesystem::path & destDir) const
 {
-    assert(scheme);
+    if (!scheme)
+        throw Error("cannot clone unsupported input '%s'", attrsToJSON(attrs));
     scheme->clone(settings, store, *this, destDir);
 }
 
 std::optional<std::filesystem::path> Input::getSourcePath() const
 {
-    assert(scheme);
-    return scheme->getSourcePath(*this);
+    return scheme ? scheme->getSourcePath(*this) : std::nullopt;
 }
 
 void Input::putFile(const CanonPath & path, std::string_view contents, std::optional<std::string> commitMsg) const
 {
-    assert(scheme);
+    if (!scheme)
+        throw Error("unsupported input '%s' does not support modifying file '%s'", attrsToJSON(attrs), path);
     return scheme->putFile(*this, path, contents, commitMsg);
 }
 


### PR DESCRIPTION

## Motivation

This happens if a lockfile contains an input with an unknown `type` field.

Spotted in a Sentry crash report.
```
SIGABRT / SI_TKILL / 0x0: Fatal Error: SIGABRT / SI_TKILL / 0x0
  libc.so.6           0x7dd077c9caac __pthread_kill_implementation (pthread_kill.c:44)
  libc.so.6           0x7dd077c4190d __GI_raise (raise.c:26)
  libc.so.6           0x7dd077c28941 __GI_abort (abort.c:79)
  libstdc++.so.6      0x7dd0780adc3d null
  libnixfetchers.so.2.34.60x7dd07856ebf3 __wrap___assert_fail (wrap-assert-fail.cc:16)
  libnixfetchers.so.2.34.60x7dd07852c4db nix::fetchers::Input::isRelative[abi:cxx11] (fetchers.cc:177)
  libnixfetchers.so.2.34.60x7dd07852c4db nix::fetchers::Input::isRelative[abi:cxx11] (fetchers.cc:175)
  libnixflake.so.2.34.60x7dd078f1be19 nix::flake::LockedNode::LockedNode (lockfile.cc:78)
  libnixflake.so.2.34.60x7dd078f1e41c std::_Construct<T> (stl_construct.h:119)
  libnixflake.so.2.34.60x7dd078f1e41c std::allocator_traits<T>::construct<T> (alloc_traits.h:706)
  libnixflake.so.2.34.60x7dd078f1e41c std::_Sp_counted_ptr_inplace<T>::_Sp_counted_ptr_inplace<T> (shared_ptr_base.h:607)
  libnixflake.so.2.34.60x7dd078f1e41c std::__shared_count<T>::__shared_count<T> (shared_ptr_base.h:969)
  libnixflake.so.2.34.60x7dd078f1e41c std::__shared_ptr<T>::__shared_ptr<T> (shared_ptr_base.h:1713)
  libnixflake.so.2.34.60x7dd078f1e41c std::shared_ptr<T>::shared_ptr<T> (shared_ptr.h:463)
  libnixflake.so.2.34.60x7dd078f1e41c std::make_shared<T> (shared_ptr.h:1008)
  libnixflake.so.2.34.60x7dd078f1e41c nix::make_ref<T> (ref.hh:164)
  libnixflake.so.2.34.60x7dd078f1e41c _ZZN3nix5flake8LockFileC4ERKNS_8fetchers8SettingsESt17basic_string_viewIcSt11char_traitsIcEES9_ENHUlRKT_RNS0_4NodeERKN8nlohmann16json_abi_v3_12_010basic_jsonISt3mapSt6vectorNSt7__cxx1112basic_stringIcS8_SaIcEEEblmdSaNSG_14adl_serializerESJ_IhSaIhEEvEEE_... (lockfile.cc:171)
  libnixflake.so.2.34.60x7dd078f1f983 nix::flake::LockFile::LockFile (lockfile.cc:182)
  libnixflake.so.2.34.60x7dd078ef7775 nix::flake::readLockFile (flake.cc:428)
  libnixflake.so.2.34.60x7dd078f001c6 nix::flake::lockFlake (flake.cc:449)
  libnixflake.so.2.34.60x7dd078f0350c nix::flake::lockFlake (flake.cc:956)
  nix                 0x5fabcc9dd358 nix::FlakeCommand::lockFlake (flake.cc:61)
  nix                 0x5fabcc9ddd99 .LTHUNK42.lto_priv.0 (flake.cc:176)
  libnixcmd.so.2.34.6 0x7dd07897c2fe nix::StoreCommand::run (command.cc:110)
  libnixcmd.so.2.34.6 0x7dd07897c457 {virtual override thunk}
  nix                 0x5fabcca145f5 nix::mainWrapped (main.cc:638)
  libnixutil.so.2.34.60x7dd079041635 std::function<T>::operator() (std_function.h:591)
  libnixutil.so.2.34.60x7dd079041635 nix::fun<T>::operator()<T> (fun.hh:78)
  libnixutil.so.2.34.60x7dd079041635 nix::handleExceptions (error.cc:489)
  nix                 0x5fabcc974d22 main (main.cc:661)
  libc.so.6           0x7dd077c2a4d7 __libc_start_call_main (libc_start_call_main.h:58)
  libc.so.6           0x7dd077c2a59a __libc_start_main_alias_2 (libc-start.c:360)
  nix                 0x5fabcc97a1f4 _start
```
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for inputs without schemes, providing clearer error messages instead of unexpected failures
  * Enhanced robustness when processing unsupported input types, ensuring more graceful degradation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->