### PR TITLE
Mark thread-local variables as initial-exec

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -255,7 +255,7 @@ EvalMemory::EvalMemory()
     assertGCInitialized();
 }
 
-thread_local EvalState::EvalContext EvalState::evalContext;
+[[gnu::tls_model("initial-exec")]] thread_local EvalState::EvalContext EvalState::evalContext;
 
 EvalState::EvalState(
     const LookupPath & lookupPathFromArguments,
@@ -1547,7 +1547,7 @@ void ExprLambda::eval(EvalState & state, Env & env, Value & v)
     v.mkLambda(&env, this);
 }
 
-thread_local size_t EvalState::callDepth = 0;
+[[gnu::tls_model("initial-exec")]] thread_local size_t EvalState::callDepth = 0;
 
 void EvalState::callFunction(Value & fun, std::span<Value *> args, Value & vRes, const PosIdx pos)
 {

--- a/src/libexpr/include/nix/expr/eval-inline.hh
+++ b/src/libexpr/include/nix/expr/eval-inline.hh
@@ -32,7 +32,7 @@ Value * EvalMemory::allocValue()
 #if NIX_USE_BOEHMGC
     /* Allocation cache for GC'd Value objects. Boehm GC is already a global resource, so thread_local is
        a natural solution. Multiple EvalState instances on the same thread will reuse the same cache. */
-    static thread_local std::shared_ptr<void *> valueAllocCache{
+    [[gnu::tls_model("initial-exec")]] static thread_local std::shared_ptr<void *> valueAllocCache{
         std::allocate_shared<void *>(traceable_allocator<void *>(), nullptr)};
 
     /* We use the boehm batch allocator to speed up allocations of Values (of which there are many).
@@ -70,7 +70,7 @@ Env & EvalMemory::allocEnv(size_t size)
     if (size == 1) {
         /* Allocation cache for size-1 Env objects. Boehm GC is already a global resource, so thread_local is
            a natural solution. Multiple EvalState instances on the same thread will reuse the same cache. */
-        static thread_local std::shared_ptr<void *> env1AllocCache{
+        [[gnu::tls_model("initial-exec")]] static thread_local std::shared_ptr<void *> env1AllocCache{
             std::allocate_shared<void *>(traceable_allocator<void *>(), nullptr)};
         /* see allocValue for explanations. */
         if (!*env1AllocCache) {
@@ -97,7 +97,7 @@ Env & EvalMemory::allocEnv(size_t size)
  * in p0 of pending/awaited thunks. We're not using std::thread::id
  * because it's not guaranteed to fit.
  */
-extern thread_local uint32_t myEvalThreadId;
+[[gnu::tls_model("initial-exec")]] extern thread_local uint32_t myEvalThreadId;
 
 template<std::size_t ptrSize>
 void ValueStorage<ptrSize, std::enable_if_t<detail::useBitPackedValueStorage<ptrSize>>>::force(

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -912,7 +912,7 @@ private:
      * setting to throw stack overflow hopefully before we run out of
      * system stack.
      */
-    thread_local static size_t callDepth;
+    [[gnu::tls_model("initial-exec")]] thread_local static size_t callDepth;
 
 public:
 
@@ -1147,7 +1147,7 @@ public:
         std::shared_ptr<const Provenance> provenance;
     };
 
-    thread_local static EvalContext evalContext;
+    [[gnu::tls_model("initial-exec")]] thread_local static EvalContext evalContext;
 
     /**
      * Create a work item that propagates the current evaluation context.

--- a/src/libexpr/include/nix/expr/parallel-eval.hh
+++ b/src/libexpr/include/nix/expr/parallel-eval.hh
@@ -61,7 +61,7 @@ struct Executor
 
     std::vector<std::future<void>> spawn(WorkItems && items);
 
-    static thread_local bool amWorkerThread;
+    [[gnu::tls_model("initial-exec")]] static thread_local bool amWorkerThread;
 };
 
 struct FutureVector

--- a/src/libexpr/parallel-eval.cc
+++ b/src/libexpr/parallel-eval.cc
@@ -13,7 +13,7 @@ struct alignas(64) WaiterDomain
 
 static std::array<Sync<WaiterDomain>, 128> waiterDomains;
 
-thread_local bool Executor::amWorkerThread{false};
+[[gnu::tls_model("initial-exec")]] thread_local bool Executor::amWorkerThread{false};
 
 unsigned int Executor::getEvalCores(const EvalSettings & evalSettings)
 {
@@ -134,8 +134,9 @@ std::vector<std::future<void>> Executor::spawn(WorkItems && items)
         for (auto & item : items) {
             std::promise<void> promise;
             futures.push_back(promise.get_future());
-            thread_local std::random_device rd;
-            thread_local std::uniform_int_distribution<uint64_t> dist(0, 1ULL << 48);
+            [[gnu::tls_model("initial-exec")]] static thread_local std::random_device rd;
+            [[gnu::tls_model("initial-exec")]] static thread_local std::uniform_int_distribution<uint64_t> dist(
+                0, 1ULL << 48);
             auto key = (uint64_t(item.second) << 48) | dist(rd);
             state->queue.emplace(key, Item{.promise = std::move(promise), .work = std::move(item.first)});
         }
@@ -200,7 +201,7 @@ static Sync<WaiterDomain> & getWaiterDomain(detail::ValueBase & v)
 }
 
 static std::atomic<uint32_t> nextEvalThreadId{1};
-thread_local uint32_t myEvalThreadId(nextEvalThreadId++);
+[[gnu::tls_model("initial-exec")]] thread_local uint32_t myEvalThreadId(nextEvalThreadId++);
 
 template<>
 ValueStorage<sizeof(void *)>::PackedPointer

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -24,7 +24,7 @@ LoggerSettings loggerSettings;
 
 static GlobalConfig::Register rLoggerSettings(&loggerSettings);
 
-static thread_local ActivityId curActivity = 0;
+[[gnu::tls_model("initial-exec")]] static thread_local ActivityId curActivity = 0;
 
 ActivityId getCurActivity()
 {

--- a/src/libutil/unix/include/nix/util/signals-impl.hh
+++ b/src/libutil/unix/include/nix/util/signals-impl.hh
@@ -37,7 +37,7 @@ namespace unix {
 
 extern std::atomic<bool> _isInterrupted;
 
-extern thread_local std::function<bool()> interruptCheck;
+[[gnu::tls_model("initial-exec")]] extern thread_local std::function<bool()> interruptCheck;
 
 void _interrupted();
 

--- a/src/libutil/unix/signals.cc
+++ b/src/libutil/unix/signals.cc
@@ -13,7 +13,7 @@ using namespace unix;
 
 std::atomic<bool> unix::_isInterrupted = false;
 
-thread_local std::function<bool()> unix::interruptCheck;
+[[gnu::tls_model("initial-exec")]] thread_local std::function<bool()> unix::interruptCheck;
 
 void unix::_interrupted()
 {


### PR DESCRIPTION
## Motivation

As suggested by @xokdvium, use the `initial-exec` model for thread-local storage. This should be faster, at least until https://github.com/NixOS/nixpkgs/pull/518519 lands. It didn't show a clear performance improvement in my testing, e.g. on a `nix search nixpkgs`:
```
maximum RSS:        median = 5037324.0000  mean = 5040103.2000  stddev =  19835.2237  min = 5005472.0000  max = 5080404.0000  [not rejected, p=0.10552, Δ=-6886.93333±12125.09181]
soft page faults:   median = 1264925.0000  mean = 1265636.1333  stddev =   5001.5549  min = 1258135.0000  max = 1275674.0000  [not rejected, p=0.10466, Δ=-1707.91111±2999.43676]
system CPU time:    median =     40.9134  mean =     40.8374  stddev =      0.6536  min =     39.3454  max =     41.9917  [not rejected, p=0.49896, Δ=-0.09703±0.41150]
user CPU time:      median =     40.0625  mean =     39.7700  stddev =      0.8387  min =     38.0676  max =     40.8150  [rejected, p=0.00000, Δ=-1.03734±0.54708]
elapsed time:       median =     13.2556  mean =     12.7748  stddev =      0.7929  min =     11.4628  max =     13.5534  [not rejected, p=0.83082, Δ=-0.03600±0.48379]
```
however it shouldn't hurt either.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Adjusted thread-local storage model across evaluation, parallel execution, logging, and signal handling to improve multi-threaded evaluation and responsiveness with no change to user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->