### PR TITLE
BinaryCacheStore: Drop draining of input source

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -305,11 +305,8 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
 void BinaryCacheStore::addToStore(
     const ValidPathInfo & info, Source & narSource, RepairFlag repair, CheckSigsFlag checkSigs)
 {
-    if (!repair && isValidPath(info.path)) {
-        // FIXME: copyNAR -> null sink
-        narSource.drain();
+    if (!repair && isValidPath(info.path))
         return;
-    }
 
     addToStoreCommon(narSource, repair, checkSigs, {[&](HashResult nar) {
                          /* FIXME reinstate these, once we can correctly do hash modulo sink as
@@ -425,10 +422,7 @@ void BinaryCacheStore::addMultipleToStore(
                            lock held by LegacySSHStore::narFromPath(). */
                         auto source = std::move(source_);
 
-                        if (!repair && isValidPath(info.path)) {
-                            // FIXME: copyNAR -> null sink
-                            source->drain();
-                        } else {
+                        if (repair || !isValidPath(info.path)) {
                             MaintainCount<decltype(nrRunning)> mc(nrRunning);
                             showProgress();
                             auto narInfo = uploadData(*source, repair, [&](HashResult nar) {


### PR DESCRIPTION

## Motivation

In 602a1f86bc392e915bb927d3e22ae9e8c7109968 we decided it's now the responsibility of the caller to drain the source (using `EnsureRead`) if that's important. Usually it isn't, so we don't want to read a NAR we don't need.

Small cleanup taken from https://github.com/NixOS/nix/pull/15957.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized binary cache store operations to skip unnecessary validation steps when paths are already verified and repair is not required, improving performance and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->