### PR TITLE
LocalStore: Implement addMultipleToStore()

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -563,11 +563,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
            so if we were interrupted partway through, a marker left next
            to a partially-deleted path would make `addMultipleToStore()`
            reuse that corrupt path. */
-        {
-            auto marker = realPath;
-            marker += ".unpacked";
-            deletePath(marker);
-        }
+        deletePath(unpackedMarkerFor(realPath));
 
         uint64_t bytesFreed;
         deleteStorePath(realPath, bytesFreed, isKnownPath);

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -557,6 +557,18 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
 
         results.paths.insert(path);
 
+        /* If this path has a leftover `.unpacked` marker (from an
+           interrupted `addMultipleToStore()`), delete the marker
+           *before* the path itself. Deleting a directory is not atomic,
+           so if we were interrupted partway through, a marker left next
+           to a partially-deleted path would make `addMultipleToStore()`
+           reuse that corrupt path. */
+        {
+            auto marker = realPath;
+            marker += ".unpacked";
+            deletePath(marker);
+        }
+
         uint64_t bytesFreed;
         deleteStorePath(realPath, bytesFreed, isKnownPath);
 

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -285,6 +285,9 @@ public:
 
     void addToStore(const ValidPathInfo & info, Source & source, RepairFlag repair, CheckSigsFlag checkSigs) override;
 
+    void
+    addMultipleToStore(PathsSource && pathsToCopy, Activity & act, RepairFlag repair, CheckSigsFlag checkSigs) override;
+
     StorePath addToStoreFromDump(
         Source & dump,
         std::string_view name,

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -315,6 +315,18 @@ private:
      */
     void doAddToStore(const ValidPathInfo & info, Source & source, RepairFlag repair);
 
+    /**
+     * The path of the marker file (`<realPath>.unpacked`) used to record
+     * that the NAR for the store path at `realPath` has been unpacked
+     * completely and successfully. See `addMultipleToStore()`.
+     */
+    static std::filesystem::path unpackedMarkerFor(const std::filesystem::path & realPath)
+    {
+        auto marker = realPath;
+        marker += ".unpacked";
+        return marker;
+    }
+
     void createTempRootsFile();
 
     /**

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -302,6 +302,19 @@ public:
 
 private:
 
+    /**
+     * Restore the contents of `info` from `source` (a NAR) into the
+     * store, verifying the NAR hash/size and (if applicable) the
+     * content address, then canonicalise, optimise and optionally fsync
+     * the path.
+     *
+     * This does *not* acquire a lock on the path or register it as
+     * valid: the caller must already hold the path lock and is
+     * responsible for registering the path afterwards. Shared by
+     * `addToStore()` and `addMultipleToStore()`.
+     */
+    void doAddToStore(const ValidPathInfo & info, Source & source, RepairFlag repair);
+
     void createTempRootsFile();
 
     /**

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1036,6 +1036,10 @@ void LocalStore::doAddToStore(const ValidPathInfo & info, Source & source, Repai
 
     deletePath(realPath);
 
+    /* Maybe free up some disk space (before writing the NAR) so that
+       restorePath() below doesn't fail with ENOSPC. */
+    autoGC();
+
     /* While restoring the path from the NAR, compute the hash
        of the NAR. */
     HashSink hashSink(HashAlgorithm::SHA256);
@@ -1095,8 +1099,6 @@ void LocalStore::doAddToStore(const ValidPathInfo & info, Source & source, Repai
                 actualHash.hash.to_string(HashFormat::Nix32, true));
         }
     }
-
-    autoGC();
 
     canonicalisePathMetaData(realPath, {NIX_WHEN_SUPPORT_ACLS(localSettings.ignoredAcls)});
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1247,7 +1247,11 @@ void LocalStore::addMultipleToStore(
                Require both the marker and the unpacked path to be owned
                by us, so that (when sandboxing is disabled) a build user
                can't plant a fake marker to trick us into registering an
-               arbitrary path as valid. */
+               arbitrary path as valid.
+
+               Note that GC will delete the marker before the path itself,
+               so if the marker and the path both exists, the contents of
+               the path are correct. */
             auto realPath = toRealPath(info.path);
             auto unpackedMarker = realPath;
             unpackedMarker += ".unpacked";

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1011,6 +1011,23 @@ bool LocalStore::realisationIsUntrusted(const Realisation & realisation)
     return config->requireSigs && !realisation.checkSignatures(realisation.id, getPublicKeys());
 }
 
+/* Check whether `path` exists and is owned by the current user. This is
+   used to decide whether to trust a previously-unpacked store path and
+   its `.unpacked` marker. Otherwise, if sandboxing is disabled, a build
+   user could plant files to trick us into registering an arbitrary
+   store path as valid. */
+static bool existsAndIsOwnedBySelf(const std::filesystem::path & path)
+{
+    auto st = maybeLstat(path);
+    if (!st)
+        return false;
+#ifndef _WIN32
+    if (st->st_uid != geteuid() || st->st_gid != getegid())
+        return false;
+#endif
+    return true;
+}
+
 void LocalStore::doAddToStore(const ValidPathInfo & info, Source & source, RepairFlag repair)
 {
     const LocalSettings & localSettings = config->getLocalSettings();
@@ -1129,7 +1146,9 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
 void LocalStore::addMultipleToStore(
     PathsSource && pathsToCopy, Activity & act, RepairFlag repair, CheckSigsFlag checkSigs)
 {
-    uint64_t bytesExpected = 0;
+    /* Atomic because it's decremented from the worker threads below
+       (when a download is skipped). */
+    std::atomic<uint64_t> bytesExpected{0};
     for (auto & [info, _] : pathsToCopy)
         bytesExpected += info.narSize;
     act.setExpected(actCopyPath, bytesExpected);
@@ -1215,10 +1234,32 @@ void LocalStore::addMultipleToStore(
         pool.enqueue([&, item]() {
             checkInterrupt();
 
+            auto & info = item->first;
+
             MaintainCount<decltype(nrRunning)> mc(nrRunning);
             showProgress();
 
-            doAddToStore(item->first, *item->second, repair);
+            /* The existence of `<realPath>.unpacked` marks that the NAR
+               for this path was previously unpacked (see below). This allows
+               an interrupted `addMultipleToStore()` to reuse already-extracted
+               paths instead of re-fetching them.
+
+               Require both the marker and the unpacked path to be owned
+               by us, so that (when sandboxing is disabled) a build user
+               can't plant a fake marker to trick us into registering an
+               arbitrary path as valid. */
+            auto realPath = toRealPath(info.path);
+            auto unpackedMarker = realPath;
+            unpackedMarker += ".unpacked";
+
+            if (!repair && existsAndIsOwnedBySelf(unpackedMarker) && existsAndIsOwnedBySelf(realPath)) {
+                notice("reusing previously unpacked path at '%s'", printStorePath(info.path));
+                act.setExpected(actCopyPath, bytesExpected -= info.narSize);
+            } else {
+                doAddToStore(info, *item->second, repair);
+                /* The path has been unpacked, so mark it as such. */
+                writeFile(unpackedMarker, "");
+            }
 
             nrDone++;
             showProgress();
@@ -1234,6 +1275,13 @@ void LocalStore::addMultipleToStore(
         infos.insert_or_assign(item->first.path, item->first);
 
     registerValidPaths(infos);
+
+    /* Now that the paths are registered as valid, the .unpacked markers are no longer needed. */
+    for (auto * item : toWrite) {
+        auto unpackedMarker = toRealPath(item->first.path);
+        unpackedMarker += ".unpacked";
+        deletePath(unpackedMarker);
+    }
 
     outputLocks.setDeletion(true);
 }

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1283,7 +1283,7 @@ void LocalStore::addMultipleToStore(
 
     /* Now that the paths are registered as valid, the .unpacked markers are no longer needed. */
     for (auto * item : toWrite)
-        deletePath(unpackedMarkerFor(toRealPath(item->first.path)));
+        tryUnlink(unpackedMarkerFor(toRealPath(item->first.path)));
 
     outputLocks.setDeletion(true);
 }

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -17,6 +17,7 @@
 #include "nix/store/posix-fs-canonicalise.hh"
 #include "nix/util/posix-source-accessor.hh"
 #include "nix/store/keys.hh"
+#include "nix/store/filetransfer.hh"
 #include "nix/util/users.hh"
 #include "nix/store/store-registration.hh"
 #include "nix/util/provenance.hh"
@@ -1205,7 +1206,10 @@ void LocalStore::addMultipleToStore(
        the paths as valid, which is deferred to stage C. */
     std::sort(toWrite.begin(), toWrite.end(), [](auto * a, auto * b) { return a->first.narSize > b->first.narSize; });
 
-    ThreadPool pool;
+    /* Use enough threads to saturate both the local CPUs (for
+       decompression/hashing/optimising) and the incoming connections to
+       the source store (e.g. a binary cache). */
+    ThreadPool pool(std::max((size_t) std::thread::hardware_concurrency(), fileTransferSettings.httpConnections.get()));
 
     for (auto * item : toWrite) {
         pool.enqueue([&, item]() {

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1112,9 +1112,6 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
             outputLock.setDeletion(true);
         }
     }
-
-    // In case `cleanup` ignored an `Interrupted` exception
-    checkInterrupt();
 }
 
 StorePath LocalStore::addToStoreFromDump(

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1253,8 +1253,7 @@ void LocalStore::addMultipleToStore(
                so if the marker and the path both exists, the contents of
                the path are correct. */
             auto realPath = toRealPath(info.path);
-            auto unpackedMarker = realPath;
-            unpackedMarker += ".unpacked";
+            auto unpackedMarker = unpackedMarkerFor(realPath);
 
             if (!repair && existsAndIsOwnedBySelf(unpackedMarker) && existsAndIsOwnedBySelf(realPath)) {
                 notice("reusing previously unpacked path at '%s'", printStorePath(info.path));
@@ -1281,11 +1280,8 @@ void LocalStore::addMultipleToStore(
     registerValidPaths(infos);
 
     /* Now that the paths are registered as valid, the .unpacked markers are no longer needed. */
-    for (auto * item : toWrite) {
-        auto unpackedMarker = toRealPath(item->first.path);
-        unpackedMarker += ".unpacked";
-        deletePath(unpackedMarker);
-    }
+    for (auto * item : toWrite)
+        deletePath(unpackedMarkerFor(toRealPath(item->first.path)));
 
     outputLocks.setDeletion(true);
 }

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -9,6 +9,8 @@
 #include "nix/store/references.hh"
 #include "nix/util/callback.hh"
 #include "nix/util/topo-sort.hh"
+#include "nix/util/thread-pool.hh"
+#include "nix/util/util.hh"
 #include "nix/util/finally.hh"
 #include "nix/util/compression.hh"
 #include "nix/util/signals.hh"
@@ -1112,6 +1114,194 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
             outputLock.setDeletion(true);
         }
     }
+}
+
+void LocalStore::addMultipleToStore(
+    PathsSource && pathsToCopy, Activity & act, RepairFlag repair, CheckSigsFlag checkSigs)
+{
+    uint64_t bytesExpected = 0;
+    for (auto & [info, _] : pathsToCopy)
+        bytesExpected += info.narSize;
+    act.setExpected(actCopyPath, bytesExpected);
+
+    std::atomic<size_t> nrDone{0};
+    std::atomic<uint64_t> nrRunning{0};
+    auto showProgress = [&, nrTotal = pathsToCopy.size()]() { act.progress(nrDone, nrTotal, nrRunning); };
+
+    using PathWithSource = std::pair<ValidPathInfo, std::unique_ptr<Source>>;
+
+    const LocalSettings & localSettings = config->getLocalSettings();
+
+    /* Stage A: figure out which paths are not already valid, lock them,
+       and re-check their validity under the lock.
+
+       `PathLocks::lockPaths()` acquires the locks in sorted order, so
+       all processes lock store paths in the same order and we cannot
+       deadlock against another process writing to the same store. All
+       locks are held until we've registered the paths as valid
+       (stage C). */
+    std::set<std::filesystem::path> pathsToLock;
+    std::vector<PathWithSource *> maybeToWrite;
+
+    for (auto & item : pathsToCopy) {
+        auto & info = item.first;
+
+        if (checkSigs && pathInfoIsUntrusted(info))
+            throw Error(
+                "cannot add path '%s' because it lacks a signature by a trusted key", printStorePath(info.path));
+
+        addTempRoot(info.path);
+
+        if (!repair && isValidPath(info.path)) {
+            nrDone++;
+            showProgress();
+            continue;
+        }
+
+        maybeToWrite.push_back(&item);
+
+        /* Lock the output path. But don't lock if we're being called
+           from a build hook (whose parent process already acquired a
+           lock on this path). */
+        if (!locksHeld.count(printStorePath(info.path)))
+            pathsToLock.insert(toRealPath(info.path));
+    }
+
+    if (maybeToWrite.empty())
+        return;
+
+    PathLocks outputLocks;
+    if (!pathsToLock.empty())
+        outputLocks.lockPaths(pathsToLock);
+
+    std::vector<PathWithSource *> toWrite;
+
+    for (auto * item : maybeToWrite) {
+        auto & info = item->first;
+
+        /* The path may have been created by another process in the meantime. */
+        if (!repair && isValidPathUncached(info.path)) {
+            // We may have a negative cache entry for this path, so get rid of it.
+            invalidatePathInfoCacheFor(info.path);
+            nrDone++;
+            showProgress();
+            continue;
+        }
+
+        info.ultimate = false;
+        toWrite.push_back(item);
+    }
+
+    /* Stage B: extract the NARs in parallel, in order of descending NAR
+       size so that the largest (and typically slowest) NARs are started
+       first. This does everything `addToStore` does except registering
+       the path as valid, which is deferred to stage C.
+
+       FIXME: this duplicates the body of `addToStore`. */
+    std::sort(toWrite.begin(), toWrite.end(), [](auto * a, auto * b) { return a->first.narSize > b->first.narSize; });
+
+    ThreadPool pool;
+
+    for (auto * item : toWrite) {
+        pool.enqueue([&, item]() {
+            checkInterrupt();
+
+            MaintainCount<decltype(nrRunning)> mc(nrRunning);
+            showProgress();
+
+            auto & info = item->first;
+            auto & source = *item->second;
+            auto realPath = toRealPath(info.path);
+
+            deletePath(realPath);
+
+            /* While restoring the path from the NAR, compute the hash
+               of the NAR. */
+            HashSink hashSink(HashAlgorithm::SHA256);
+
+            TeeSource wrapperSource{source, hashSink};
+
+            restorePath(realPath, wrapperSource, localSettings.fsyncStorePaths);
+
+            auto hashResult = hashSink.finish();
+
+            if (hashResult.hash != info.narHash)
+                throw Error(
+                    "hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",
+                    printStorePath(info.path),
+                    info.narHash.to_string(HashFormat::SRI, true),
+                    hashResult.hash.to_string(HashFormat::SRI, true));
+
+            if (hashResult.numBytesDigested != info.narSize)
+                throw Error(
+                    "size mismatch importing path '%s';\n  specified: %s\n  got:       %s",
+                    printStorePath(info.path),
+                    info.narSize,
+                    hashResult.numBytesDigested);
+
+            if (info.ca) {
+                auto & specified = *info.ca;
+                auto actualHash = ({
+                    auto accessor = getFSAccessor(false);
+                    CanonPath path{info.path.to_string()};
+                    Hash h{HashAlgorithm::SHA256}; // throwaway def to appease C++
+                    auto fim = specified.method.getFileIngestionMethod();
+                    switch (fim) {
+                    case FileIngestionMethod::Flat:
+                    case FileIngestionMethod::NixArchive: {
+                        HashModuloSink caSink{
+                            specified.hash.algo,
+                            std::string{info.path.hashPart()},
+                        };
+                        dumpPath({accessor, path}, caSink, (FileSerialisationMethod) fim);
+                        h = caSink.finish().hash;
+                        break;
+                    }
+                    case FileIngestionMethod::Git:
+                        h = git::dumpHash(specified.hash.algo, {accessor, path}).hash;
+                        break;
+                    }
+                    ContentAddress{
+                        .method = specified.method,
+                        .hash = std::move(h),
+                    };
+                });
+                if (specified.hash != actualHash.hash) {
+                    throw Error(
+                        "ca hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",
+                        printStorePath(info.path),
+                        specified.hash.to_string(HashFormat::Nix32, true),
+                        actualHash.hash.to_string(HashFormat::Nix32, true));
+                }
+            }
+
+            autoGC();
+
+            canonicalisePathMetaData(realPath, {NIX_WHEN_SUPPORT_ACLS(localSettings.ignoredAcls)});
+
+            optimisePath(realPath, repair); // FIXME: combine with hashPath()
+
+            if (localSettings.fsyncStorePaths) {
+                recursiveSync(realPath);
+                syncParent(realPath);
+            }
+
+            nrDone++;
+            showProgress();
+        });
+    }
+
+    pool.process();
+
+    /* Stage C: register all the newly added paths as valid in a single
+       transaction. */
+    ValidPathInfos infos;
+    for (auto * item : toWrite)
+        infos.insert_or_assign(item->first.path, item->first);
+
+    registerValidPaths(infos);
+
+    outputLocks.setDeletion(true);
 }
 
 StorePath LocalStore::addToStoreFromDump(

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1022,7 +1022,7 @@ static bool existsAndIsOwnedBySelf(const std::filesystem::path & path)
     if (!st)
         return false;
 #ifndef _WIN32
-    if (st->st_uid != geteuid() || st->st_gid != getegid())
+    if (st->st_uid != geteuid())
         return false;
 #endif
     return true;

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1010,6 +1010,86 @@ bool LocalStore::realisationIsUntrusted(const Realisation & realisation)
     return config->requireSigs && !realisation.checkSignatures(realisation.id, getPublicKeys());
 }
 
+void LocalStore::doAddToStore(const ValidPathInfo & info, Source & source, RepairFlag repair)
+{
+    const LocalSettings & localSettings = config->getLocalSettings();
+
+    auto realPath = toRealPath(info.path);
+
+    deletePath(realPath);
+
+    /* While restoring the path from the NAR, compute the hash
+       of the NAR. */
+    HashSink hashSink(HashAlgorithm::SHA256);
+
+    TeeSource wrapperSource{source, hashSink};
+
+    restorePath(realPath, wrapperSource, localSettings.fsyncStorePaths);
+
+    auto hashResult = hashSink.finish();
+
+    if (hashResult.hash != info.narHash)
+        throw Error(
+            "hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",
+            printStorePath(info.path),
+            info.narHash.to_string(HashFormat::SRI, true),
+            hashResult.hash.to_string(HashFormat::SRI, true));
+
+    if (hashResult.numBytesDigested != info.narSize)
+        throw Error(
+            "size mismatch importing path '%s';\n  specified: %s\n  got:       %s",
+            printStorePath(info.path),
+            info.narSize,
+            hashResult.numBytesDigested);
+
+    if (info.ca) {
+        auto & specified = *info.ca;
+        auto actualHash = ({
+            auto accessor = getFSAccessor(false);
+            CanonPath path{info.path.to_string()};
+            Hash h{HashAlgorithm::SHA256}; // throwaway def to appease C++
+            auto fim = specified.method.getFileIngestionMethod();
+            switch (fim) {
+            case FileIngestionMethod::Flat:
+            case FileIngestionMethod::NixArchive: {
+                HashModuloSink caSink{
+                    specified.hash.algo,
+                    std::string{info.path.hashPart()},
+                };
+                dumpPath({accessor, path}, caSink, (FileSerialisationMethod) fim);
+                h = caSink.finish().hash;
+                break;
+            }
+            case FileIngestionMethod::Git:
+                h = git::dumpHash(specified.hash.algo, {accessor, path}).hash;
+                break;
+            }
+            ContentAddress{
+                .method = specified.method,
+                .hash = std::move(h),
+            };
+        });
+        if (specified.hash != actualHash.hash) {
+            throw Error(
+                "ca hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",
+                printStorePath(info.path),
+                specified.hash.to_string(HashFormat::Nix32, true),
+                actualHash.hash.to_string(HashFormat::Nix32, true));
+        }
+    }
+
+    autoGC();
+
+    canonicalisePathMetaData(realPath, {NIX_WHEN_SUPPORT_ACLS(localSettings.ignoredAcls)});
+
+    optimisePath(realPath, repair); // FIXME: combine with hashPath()
+
+    if (localSettings.fsyncStorePaths) {
+        recursiveSync(realPath);
+        syncParent(realPath);
+    }
+}
+
 void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairFlag repair, CheckSigsFlag checkSigs)
 {
     if (checkSigs && pathInfoIsUntrusted(info))
@@ -1033,78 +1113,7 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
             /* The path may have been created by another process in the meantime, so check again. */
             if (repair || !isValidPathUncached(info.path)) {
 
-                deletePath(realPath);
-
-                /* While restoring the path from the NAR, compute the hash
-                   of the NAR. */
-                HashSink hashSink(HashAlgorithm::SHA256);
-
-                TeeSource wrapperSource{source, hashSink};
-
-                restorePath(realPath, wrapperSource, config->getLocalSettings().fsyncStorePaths);
-
-                auto hashResult = hashSink.finish();
-
-                if (hashResult.hash != info.narHash)
-                    throw Error(
-                        "hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",
-                        printStorePath(info.path),
-                        info.narHash.to_string(HashFormat::SRI, true),
-                        hashResult.hash.to_string(HashFormat::SRI, true));
-
-                if (hashResult.numBytesDigested != info.narSize)
-                    throw Error(
-                        "size mismatch importing path '%s';\n  specified: %s\n  got:       %s",
-                        printStorePath(info.path),
-                        info.narSize,
-                        hashResult.numBytesDigested);
-
-                if (info.ca) {
-                    auto & specified = *info.ca;
-                    auto actualHash = ({
-                        auto accessor = getFSAccessor(false);
-                        CanonPath path{info.path.to_string()};
-                        Hash h{HashAlgorithm::SHA256}; // throwaway def to appease C++
-                        auto fim = specified.method.getFileIngestionMethod();
-                        switch (fim) {
-                        case FileIngestionMethod::Flat:
-                        case FileIngestionMethod::NixArchive: {
-                            HashModuloSink caSink{
-                                specified.hash.algo,
-                                std::string{info.path.hashPart()},
-                            };
-                            dumpPath({accessor, path}, caSink, (FileSerialisationMethod) fim);
-                            h = caSink.finish().hash;
-                            break;
-                        }
-                        case FileIngestionMethod::Git:
-                            h = git::dumpHash(specified.hash.algo, {accessor, path}).hash;
-                            break;
-                        }
-                        ContentAddress{
-                            .method = specified.method,
-                            .hash = std::move(h),
-                        };
-                    });
-                    if (specified.hash != actualHash.hash) {
-                        throw Error(
-                            "ca hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",
-                            printStorePath(info.path),
-                            specified.hash.to_string(HashFormat::Nix32, true),
-                            actualHash.hash.to_string(HashFormat::Nix32, true));
-                    }
-                }
-
-                autoGC();
-
-                canonicalisePathMetaData(realPath, {NIX_WHEN_SUPPORT_ACLS(config->getLocalSettings().ignoredAcls)});
-
-                optimisePath(realPath, repair); // FIXME: combine with hashPath()
-
-                if (config->getLocalSettings().fsyncStorePaths) {
-                    recursiveSync(realPath);
-                    syncParent(realPath);
-                }
+                doAddToStore(info, source, repair);
 
                 registerValidPath(info);
             } else
@@ -1129,8 +1138,6 @@ void LocalStore::addMultipleToStore(
     auto showProgress = [&, nrTotal = pathsToCopy.size()]() { act.progress(nrDone, nrTotal, nrRunning); };
 
     using PathWithSource = std::pair<ValidPathInfo, std::unique_ptr<Source>>;
-
-    const LocalSettings & localSettings = config->getLocalSettings();
 
     /* Stage A: figure out which paths are not already valid, lock them,
        and re-check their validity under the lock.
@@ -1195,9 +1202,7 @@ void LocalStore::addMultipleToStore(
     /* Stage B: extract the NARs in parallel, in order of descending NAR
        size so that the largest (and typically slowest) NARs are started
        first. This does everything `addToStore` does except registering
-       the path as valid, which is deferred to stage C.
-
-       FIXME: this duplicates the body of `addToStore`. */
+       the paths as valid, which is deferred to stage C. */
     std::sort(toWrite.begin(), toWrite.end(), [](auto * a, auto * b) { return a->first.narSize > b->first.narSize; });
 
     ThreadPool pool;
@@ -1209,82 +1214,7 @@ void LocalStore::addMultipleToStore(
             MaintainCount<decltype(nrRunning)> mc(nrRunning);
             showProgress();
 
-            auto & info = item->first;
-            auto & source = *item->second;
-            auto realPath = toRealPath(info.path);
-
-            deletePath(realPath);
-
-            /* While restoring the path from the NAR, compute the hash
-               of the NAR. */
-            HashSink hashSink(HashAlgorithm::SHA256);
-
-            TeeSource wrapperSource{source, hashSink};
-
-            restorePath(realPath, wrapperSource, localSettings.fsyncStorePaths);
-
-            auto hashResult = hashSink.finish();
-
-            if (hashResult.hash != info.narHash)
-                throw Error(
-                    "hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",
-                    printStorePath(info.path),
-                    info.narHash.to_string(HashFormat::SRI, true),
-                    hashResult.hash.to_string(HashFormat::SRI, true));
-
-            if (hashResult.numBytesDigested != info.narSize)
-                throw Error(
-                    "size mismatch importing path '%s';\n  specified: %s\n  got:       %s",
-                    printStorePath(info.path),
-                    info.narSize,
-                    hashResult.numBytesDigested);
-
-            if (info.ca) {
-                auto & specified = *info.ca;
-                auto actualHash = ({
-                    auto accessor = getFSAccessor(false);
-                    CanonPath path{info.path.to_string()};
-                    Hash h{HashAlgorithm::SHA256}; // throwaway def to appease C++
-                    auto fim = specified.method.getFileIngestionMethod();
-                    switch (fim) {
-                    case FileIngestionMethod::Flat:
-                    case FileIngestionMethod::NixArchive: {
-                        HashModuloSink caSink{
-                            specified.hash.algo,
-                            std::string{info.path.hashPart()},
-                        };
-                        dumpPath({accessor, path}, caSink, (FileSerialisationMethod) fim);
-                        h = caSink.finish().hash;
-                        break;
-                    }
-                    case FileIngestionMethod::Git:
-                        h = git::dumpHash(specified.hash.algo, {accessor, path}).hash;
-                        break;
-                    }
-                    ContentAddress{
-                        .method = specified.method,
-                        .hash = std::move(h),
-                    };
-                });
-                if (specified.hash != actualHash.hash) {
-                    throw Error(
-                        "ca hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",
-                        printStorePath(info.path),
-                        specified.hash.to_string(HashFormat::Nix32, true),
-                        actualHash.hash.to_string(HashFormat::Nix32, true));
-                }
-            }
-
-            autoGC();
-
-            canonicalisePathMetaData(realPath, {NIX_WHEN_SUPPORT_ACLS(localSettings.ignoredAcls)});
-
-            optimisePath(realPath, repair); // FIXME: combine with hashPath()
-
-            if (localSettings.fsyncStorePaths) {
-                recursiveSync(realPath);
-                syncParent(realPath);
-            }
+            doAddToStore(item->first, *item->second, repair);
 
             nrDone++;
             showProgress();


### PR DESCRIPTION
## Motivation

This speeds up `nix copy` into a local store.
    
Previously copyPaths() relied on the default `addMultipleToStore()`, which walks the closure in topological order calling `addToStore()` per path. This means that we can't start copying a NAR into the store until all its dependencies have been added, in order to preserve the closure variant. This may waste available network/CPU capacity.
    
So now we extract the NARs into the store first before registering the store paths as valid. Specifically:
    
1. We acquire locks on all store paths in sorted order (to avoid deadlocks).
    
2. We extract the NARs in order of descending NAR size (to minimize the makespan).
    
3. We register all new paths as valid in a single transaction.

This speeds up
```
# nix copy --from https://cache.nixos.org --to /tmp/nix --no-check-sigs /nix/store/8xyk1qxxjfb8cm62g61yc59phwha92w7-kdenlive-25.08.3
```
from ~8.8s to ~5.4s. (Of course this depends a lot on network speed, I/O, CPU etc.)
    
Note: currently this doesn't benefit copying into a local store via the Nix daemon. (See `RemoteStore::addMultipleToStore()` which sends NARs in topological order.) It also doesn't yet benefit substitution, since it currently substitutes one path at a time. (It should just rely on `copyPaths()` to fetch entire missing closures.)

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Add bulk parallel installs for faster multi-path additions.
  * Consolidated restore and validation flow for more reliable installs and reuse of already-unpacked content when safe.
* **Bug Fixes**
  * Cleanup of stale temporary unpack markers to prevent reuse of corrupted content.
  * Stronger ownership, locking and signature checks to reduce invalid installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->