### PR TITLE
BinaryCacheStore::addMultipleToStore(): Don't hold lock while calling uploadNarInfo()

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -440,7 +440,8 @@ void BinaryCacheStore::addMultipleToStore(
                         auto & info = infosMap.at(n.path)->first;
                         if (!repair && isValidPath(info.path))
                             return;
-                        uploadNarInfo(narInfos_.lock()->at(n.path));
+                        auto narInfo = narInfos_.lock()->at(n.path);
+                        uploadNarInfo(narInfo);
                     },
                 },
                 node);


### PR DESCRIPTION
## Motivation

Pointed out in https://github.com/NixOS/nix/pull/15957#discussion_r3343702835 by @xokdvium.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization with no user-visible changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/nix-src/pull/481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->