### PR TITLE
nix develop: Restore hiding the "dirty" notice

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -495,6 +495,11 @@ struct Common : InstallableCommand, MixProfile
             shellOutPath,
         };
     }
+
+    void preRun(ref<Store> store) override
+    {
+        fetchSettings.warnDirty = false;
+    }
 };
 
 struct CmdDevelop : Common, MixEnvironment


### PR DESCRIPTION

## Motivation

Restores #33. This was accidentally lost in
823b1195b309e8814a13009efef725f2ce2ed178.

As a slight improvement over #33, put this in `Common` so `nix print-dev-env` is affected as well.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed dirty-fetch warnings during command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->