### PR TITLE
Flake schema docs

### DIFF
--- a/doc/manual/source/protocols/flake-schemas.md
+++ b/doc/manual/source/protocols/flake-schemas.md
@@ -8,12 +8,15 @@ every output type that you want to be supported. If a flake does not have a `sch
 
 A schema is an attribute set with the following attributes:
 
-| Attribute   | Description                                                                                     | Default |
-| :---------- | :---------------------------------------------------------------------------------------------- | :------ |
-| `version`   | Should be set to 1                                                                              |         |
-| `doc`       | A string containing documentation about the flake output type in Markdown format.               |         |
-| `allowIFD`  | Whether the evaluation of the output attributes of this flake can read from derivation outputs. | `true`  |
-| `inventory` | A function that returns the contents of the flake output (described [below](#inventory)).       |         |
+| Attribute         | Description                                                                                                                  | Default |
+| :---------------- | :----------------------------------------------------------------------------------------------------------------------------| :------ |
+| `version`         | Should be set to 1                                                                                                           |         |
+| `doc`             | A string containing documentation about the flake output type in Markdown format.                                            |         |
+| `allowIFD`        | Whether the evaluation of the output attributes of this flake can read from derivation outputs.                              | `true`  |
+| `inventory`       | A function that returns the contents of the flake output (described [below](#inventory)).                                    |         |
+| `roles`           | The roles supported by this flake output type (see [below](#roles)).                                                         |         |
+| `appendSystem`    | Whether the current system type is appended to the flake output attribute path, as in outputs like `packages`.               |         |
+| `defaultAttrPath` | A default flake output attribute path suffix. For example, `packages` will look for `default` if no attribute path is given. |         |
 
 # Inventory
 
@@ -41,6 +44,25 @@ Both leaf and non-leaf nodes can have the following attributes:
 | :----------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `forSystems` | A list of Nix system types (e.g. `["x86_64-linux"]`) supported by this node. This is used by tools to skip nodes that cannot be built on the user's system. Setting this on a non-leaf node allows all the children to be skipped, regardless of the `forSystems` attributes of the children. If this attribute is not set, the node is never skipped. |
 | `isLegacy`   | If set to true, this node is skipped unless the `--legacy` CLI flag is set. |
+
+# Roles
+
+Roles allow schemas to declare what commands operate on them. For instance, to have the `nix build` command build a flake output, the schema should declare:
+```nix
+roles.nix-build = { };
+```
+
+The following roles are used by various Nix commands:
+
+* `nix-build`: Used by `nix build`, `nix shell`, and `nix develop`.
+* `nix-bundler`: Denotes bundler functions used by `nix bundle`.
+* `nix-develop`: Used by `nix develop`.
+* `nix-fmt`: Used by `nix formatter`.
+* `nix-run`: Used by `nix run` and `nix bundle`.
+* `nix-search`: Denotes an output that will be searched by `nix search`.
+* `nix-template`: Used by `nix flake init` and `nix flake new`.
+
+Tools are free to define new roles. For instance, instead of hard-coding a flake output type like `nixosConfigurations`, `nixos-rebuild --flake` could use any flake output that implements a `nixos-configuration` role.
 
 # Example
 

--- a/src/libcmd/installable-flake.cc
+++ b/src/libcmd/installable-flake.cc
@@ -9,6 +9,7 @@
 #include "nix/store/derivations.hh"
 #include "nix/expr/eval-inline.hh"
 #include "nix/expr/eval.hh"
+#include "nix/expr/eval-error.hh"
 #include "nix/expr/get-drvs.hh"
 #include "nix/store/store-api.hh"
 #include "nix/main/shared.hh"
@@ -248,11 +249,16 @@ std::vector<ref<eval_cache::AttrCursor>> InstallableFlake::getCursors(EvalState 
         }
 #endif
 
-        auto attr = outputs->findAlongAttrPath(attrPath);
-        if (attr)
-            res.push_back(ref(*attr));
-        else
-            suggestions += attr.getSuggestions();
+        try {
+            auto attr = outputs->findAlongAttrPath(attrPath);
+            if (attr)
+                res.push_back(ref(*attr));
+            else
+                suggestions += attr.getSuggestions();
+        } catch (TypeError & e) {
+            debug("error resolving attribute '%s': %s", attrPath.to_string(state), e.msg());
+            // Continue to next attribute path
+        }
     }
 
     if (res.size() == 0)

--- a/src/libexpr/include/nix/expr/eval-cache.hh
+++ b/src/libexpr/include/nix/expr/eval-cache.hh
@@ -106,11 +106,11 @@ class AttrCursor : public std::enable_shared_from_this<AttrCursor>
     friend struct CachedEvalError;
 
 public:
-    ref<EvalCache> root;
+    const ref<EvalCache> root;
 
 private:
     using Parent = std::optional<std::pair<ref<AttrCursor>, Symbol>>;
-    Parent parent;
+    const Parent parent;
     RootValue _value;
     std::optional<std::pair<AttrId, AttrValue>> cachedValue;
 

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -38,6 +38,7 @@ suites += {
     'substitution.sh',
     'shallow.sh',
     'get-flake.sh',
+    'type-error-fallback.sh',
     'provenance.sh',
     'search.sh',
   ],

--- a/tests/functional/flakes/type-error-fallback.sh
+++ b/tests/functional/flakes/type-error-fallback.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+source ./common.sh
+
+# Test that attribute path resolution correctly handles TypeError fallback
+# when packages.*.foo is a string but legacyPackages.*.foo is an attrset
+
+flakeDir=$TEST_ROOT/type-error-fallback
+
+mkdir -p "$flakeDir"
+cat > "$flakeDir"/flake.nix <<EOF
+{
+    outputs = { self }: {
+        # packages.*.hello is a string (not a path, just a string value)
+        packages.$system.hello = "packages-hello";
+
+        # legacyPackages.*.hello is an attrset with .out
+        legacyPackages.$system.hello = {
+            type = "derivation";
+            out = "legacyPackages-hello-out";
+            outputName = "out";
+        };
+    };
+}
+EOF
+
+# Test 1: #hello should pick packages (the string)
+result=$(nix eval --impure --raw "$flakeDir#hello")
+[[ "$result" == "packages-hello" ]]
+
+# Test 2: #hello.out should fallback to legacyPackages after TypeError
+# (because packages.hello is a string, not an attrset with .out)
+result=$(nix eval --impure --raw "$flakeDir#hello.out")
+[[ "$result" == "legacyPackages-hello-out" ]]
+
+# Test 3: Explicitly accessing packages.*.hello.out should fail
+# (when directly specified, no fallback happens)
+expect 1 nix eval --impure "$flakeDir#packages.$system.hello.out" 2>&1 | \
+    grepQuiet "does not provide attribute"
+
+# Test 4: Explicitly accessing legacyPackages.*.hello.out should succeed
+result=$(nix eval --impure --raw "$flakeDir#legacyPackages.$system.hello.out")
+[[ "$result" == "legacyPackages-hello-out" ]]


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Update flake schema docs plus a few other improvements from https://github.com/NixOS/nix/pull/8892.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded flake schema docs with a complete attribute table, defaults, and a new “Roles” section describing standard role names.

* **Bug Fixes**
  * Improved flake attribute resolution to tolerate type errors and continue resolution with fallback suggestions.

* **Tests**
  * Added functional test covering type-error fallback behavior during flake attribute resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->