### PR TITLE
SQLiteStmt::Use: Rename operator() -> apply()

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -124,13 +124,23 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::FullAttrs) (0, false).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::FullAttrs)
+                .apply(0, false)
+                .exec();
 
             AttrId rowId = state->db.getLastInsertedRowId();
             assert(rowId);
 
             for (auto & attr : attrs)
-                state->insertAttribute.use()(rowId)(symbols[attr])(AttrType::Placeholder) (0, false).exec();
+                state->insertAttribute.use()
+                    .apply(rowId)
+                    .apply(symbols[attr])
+                    .apply(AttrType::Placeholder)
+                    .apply(0, false)
+                    .exec();
 
             return rowId;
         });
@@ -150,10 +160,20 @@ struct AttrDb
                     ctx.append(elem->view());
                     first = false;
                 }
-                state->insertAttributeWithContext.use()(key.first)(symbols[key.second])(AttrType::String) (s) (ctx)
+                state->insertAttributeWithContext.use()
+                    .apply(key.first)
+                    .apply(symbols[key.second])
+                    .apply(AttrType::String)
+                    .apply(s)
+                    .apply(ctx)
                     .exec();
             } else {
-                state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::String) (s).exec();
+                state->insertAttribute.use()
+                    .apply(key.first)
+                    .apply(symbols[key.second])
+                    .apply(AttrType::String)
+                    .apply(s)
+                    .exec();
             }
 
             return state->db.getLastInsertedRowId();
@@ -165,7 +185,12 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::Bool) (b ? 1 : 0).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::Bool)
+                .apply(b ? 1 : 0)
+                .exec();
 
             return state->db.getLastInsertedRowId();
         });
@@ -176,7 +201,12 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::Int) (n).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::Int)
+                .apply(n)
+                .exec();
 
             return state->db.getLastInsertedRowId();
         });
@@ -187,9 +217,11 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute
-                .use()(key.first)(symbols[key.second])(
-                    AttrType::ListOfStrings) (dropEmptyInitThenConcatStringsSep("\t", l))
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::ListOfStrings)
+                .apply(dropEmptyInitThenConcatStringsSep("\t", l))
                 .exec();
 
             return state->db.getLastInsertedRowId();
@@ -201,7 +233,12 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::Placeholder) (0, false).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::Placeholder)
+                .apply(0, false)
+                .exec();
 
             return state->db.getLastInsertedRowId();
         });
@@ -212,7 +249,12 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::Missing) (0, false).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::Missing)
+                .apply(0, false)
+                .exec();
 
             return state->db.getLastInsertedRowId();
         });
@@ -223,7 +265,12 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::Misc) (0, false).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::Misc)
+                .apply(0, false)
+                .exec();
 
             return state->db.getLastInsertedRowId();
         });
@@ -234,7 +281,12 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()(key.first)(symbols[key.second])(AttrType::Failed) (0, false).exec();
+            state->insertAttribute.use()
+                .apply(key.first)
+                .apply(symbols[key.second])
+                .apply(AttrType::Failed)
+                .apply(0, false)
+                .exec();
 
             return state->db.getLastInsertedRowId();
         });
@@ -244,7 +296,7 @@ struct AttrDb
     {
         auto state(_state->lock());
 
-        auto queryAttribute(state->queryAttribute.use()(key.first)(symbols[key.second]));
+        auto queryAttribute(state->queryAttribute.use().apply(key.first).apply(symbols[key.second]));
         if (!queryAttribute.next())
             return {};
 
@@ -257,7 +309,7 @@ struct AttrDb
         case AttrType::FullAttrs: {
             // FIXME: expensive, should separate this out.
             std::vector<Symbol> attrs;
-            auto queryAttributes(state->queryAttributes.use()(rowId));
+            auto queryAttributes(state->queryAttributes.use().apply(rowId));
             while (queryAttributes.next())
                 attrs.emplace_back(symbols.create(queryAttributes.getStr(0)));
             return {{rowId, attrs}};

--- a/src/libfetchers/cache.cc
+++ b/src/libfetchers/cache.cc
@@ -60,7 +60,11 @@ struct CacheImpl : Cache
     void upsert(const Key & key, const Attrs & value) override
     {
         _state.lock()
-            ->upsert.use()(key.first)(attrsToJSON(key.second).dump())(attrsToJSON(value).dump())(time(nullptr))
+            ->upsert.use()
+            .apply(key.first)
+            .apply(attrsToJSON(key.second).dump())
+            .apply(attrsToJSON(value).dump())
+            .apply(time(nullptr))
             .exec();
     }
 
@@ -87,7 +91,7 @@ struct CacheImpl : Cache
 
         auto keyJSON = attrsToJSON(key.second).dump();
 
-        auto stmt(state->lookup.use()(key.first)(keyJSON));
+        auto stmt(state->lookup.use().apply(key.first).apply(keyJSON));
         if (!stmt.next()) {
             debug("did not find cache entry for '%s:%s'", key.first, keyJSON);
             return {};

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -121,9 +121,9 @@ struct SQLiteStmt
         /**
          * Bind the next parameter.
          */
-        Use & operator()(std::string_view value, bool notNull = true);
-        Use & operator()(const unsigned char * data, size_t len, bool notNull = true);
-        Use & operator()(int64_t value, bool notNull = true);
+        Use & apply(std::string_view value, bool notNull = true);
+        Use & apply(const unsigned char * data, size_t len, bool notNull = true);
+        Use & apply(int64_t value, bool notNull = true);
         Use & bind(); // null
 
         int step();

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -658,9 +658,10 @@ void LocalStore::registerDrvOutput(const Realisation & info)
             if (info.isCompatibleWith(*oldR)) {
                 auto combinedSignatures = oldR->signatures;
                 combinedSignatures.insert(info.signatures.begin(), info.signatures.end());
-                state->stmts->UpdateRealisedOutput
-                    .use()(concatStringsSep(" ", Signature::toStrings(combinedSignatures)))(info.id.strHash())(
-                        info.id.outputName)
+                state->stmts->UpdateRealisedOutput.use()
+                    .apply(concatStringsSep(" ", Signature::toStrings(combinedSignatures)))
+                    .apply(info.id.strHash())
+                    .apply(info.id.outputName)
                     .exec();
             } else {
                 throw Error(
@@ -673,9 +674,11 @@ void LocalStore::registerDrvOutput(const Realisation & info)
                     printStorePath(info.outPath));
             }
         } else {
-            state->stmts->RegisterRealisedOutput
-                .use()(info.id.strHash())(info.id.outputName)(printStorePath(info.outPath))(
-                    concatStringsSep(" ", Signature::toStrings(info.signatures)))
+            state->stmts->RegisterRealisedOutput.use()
+                .apply(info.id.strHash())
+                .apply(info.id.outputName)
+                .apply(printStorePath(info.outPath))
+                .apply(concatStringsSep(" ", Signature::toStrings(info.signatures)))
                 .exec();
         }
     });
@@ -684,8 +687,9 @@ void LocalStore::registerDrvOutput(const Realisation & info)
 void LocalStore::cacheDrvOutputMapping(
     State & state, const uint64_t deriver, const std::string & outputName, const StorePath & output)
 {
-    retrySQLite<void>(
-        [&]() { state.stmts->AddDerivationOutput.use()(deriver)(outputName) (printStorePath(output)).exec(); });
+    retrySQLite<void>([&]() {
+        state.stmts->AddDerivationOutput.use().apply(deriver).apply(outputName).apply(printStorePath(output)).exec();
+    });
 }
 
 uint64_t LocalStore::addValidPath(State & state, const ValidPathInfo & info)
@@ -695,14 +699,17 @@ uint64_t LocalStore::addValidPath(State & state, const ValidPathInfo & info)
             "cannot add path '%s' to the Nix store because it claims to be content-addressed but isn't",
             printStorePath(info.path));
 
-    auto query = state.stmts->RegisterValidPath.use()(printStorePath(info.path))(info.narHash.to_string(
-        HashFormat::Base16, true))(info.registrationTime == 0 ? time(nullptr) : info.registrationTime)(
-        info.deriver ? printStorePath(*info.deriver) : "",
-        (bool) info.deriver)(info.narSize, info.narSize != 0)(info.ultimate ? 1 : 0, info.ultimate)(
-        concatStringsSep(" ", Signature::toStrings(info.sigs)),
-        !info.sigs.empty())(renderContentAddress(info.ca), (bool) info.ca);
+    auto query = state.stmts->RegisterValidPath.use()
+                     .apply(printStorePath(info.path))
+                     .apply(info.narHash.to_string(HashFormat::Base16, true))
+                     .apply(info.registrationTime == 0 ? time(nullptr) : info.registrationTime)
+                     .apply(info.deriver ? printStorePath(*info.deriver) : "", (bool) info.deriver)
+                     .apply(info.narSize, info.narSize != 0)
+                     .apply(info.ultimate ? 1 : 0, info.ultimate)
+                     .apply(concatStringsSep(" ", Signature::toStrings(info.sigs)), !info.sigs.empty())
+                     .apply(renderContentAddress(info.ca), (bool) info.ca);
     if (experimentalFeatureSettings.isEnabled(Xp::Provenance))
-        query(info.provenance ? info.provenance->to_json_str() : "", (bool) info.provenance);
+        query.apply(info.provenance ? info.provenance->to_json_str() : "", (bool) info.provenance);
     query.exec();
     uint64_t id = state.db.getLastInsertedRowId();
 
@@ -749,7 +756,7 @@ void LocalStore::queryPathInfoUncached(
 std::shared_ptr<const ValidPathInfo> LocalStore::queryPathInfoInternal(State & state, const StorePath & path)
 {
     /* Get the path info. */
-    auto useQueryPathInfo(state.stmts->QueryPathInfo.use()(printStorePath(path)));
+    auto useQueryPathInfo(state.stmts->QueryPathInfo.use().apply(printStorePath(path)));
 
     if (!useQueryPathInfo.next())
         return std::shared_ptr<ValidPathInfo>();
@@ -787,7 +794,7 @@ std::shared_ptr<const ValidPathInfo> LocalStore::queryPathInfoInternal(State & s
         info->ca = ContentAddress::parseOpt(s);
 
     /* Get the references. */
-    auto useQueryReferences(state.stmts->QueryReferences.use()(info->id));
+    auto useQueryReferences(state.stmts->QueryReferences.use().apply(info->id));
 
     while (useQueryReferences.next())
         info->references.insert(parseStorePath(useQueryReferences.getStr(0)));
@@ -804,17 +811,19 @@ std::shared_ptr<const ValidPathInfo> LocalStore::queryPathInfoInternal(State & s
 /* Update path info in the database. */
 void LocalStore::updatePathInfo(State & state, const ValidPathInfo & info)
 {
-    state.stmts->UpdatePathInfo
-        .use()(info.narSize, info.narSize != 0)(info.narHash.to_string(HashFormat::Base16, true))(
-            info.ultimate ? 1 : 0,
-            info.ultimate)(concatStringsSep(" ", Signature::toStrings(info.sigs)), !info.sigs.empty())(
-            renderContentAddress(info.ca), (bool) info.ca)(printStorePath(info.path))
+    state.stmts->UpdatePathInfo.use()
+        .apply(info.narSize, info.narSize != 0)
+        .apply(info.narHash.to_string(HashFormat::Base16, true))
+        .apply(info.ultimate ? 1 : 0, info.ultimate)
+        .apply(concatStringsSep(" ", Signature::toStrings(info.sigs)), !info.sigs.empty())
+        .apply(renderContentAddress(info.ca), (bool) info.ca)
+        .apply(printStorePath(info.path))
         .exec();
 }
 
 uint64_t LocalStore::queryValidPathId(State & state, const StorePath & path)
 {
-    auto use(state.stmts->QueryPathInfo.use()(printStorePath(path)));
+    auto use(state.stmts->QueryPathInfo.use().apply(printStorePath(path)));
     if (!use.next())
         throw InvalidPath("path '%s' is not valid", printStorePath(path));
     return use.getInt(0);
@@ -822,7 +831,7 @@ uint64_t LocalStore::queryValidPathId(State & state, const StorePath & path)
 
 bool LocalStore::isValidPath_(State & state, const StorePath & path)
 {
-    return state.stmts->QueryPathInfo.use()(printStorePath(path)).next();
+    return state.stmts->QueryPathInfo.use().apply(printStorePath(path)).next();
 }
 
 bool LocalStore::isValidPathUncached(const StorePath & path)
@@ -853,7 +862,7 @@ StorePathSet LocalStore::queryAllValidPaths()
 
 void LocalStore::queryReferrers(State & state, const StorePath & path, StorePathSet & referrers)
 {
-    auto useQueryReferrers(state.stmts->QueryReferrers.use()(printStorePath(path)));
+    auto useQueryReferrers(state.stmts->QueryReferrers.use().apply(printStorePath(path)));
 
     while (useQueryReferrers.next())
         referrers.insert(parseStorePath(useQueryReferrers.getStr(0)));
@@ -869,7 +878,7 @@ StorePathSet LocalStore::queryValidDerivers(const StorePath & path)
     return retrySQLite<StorePathSet>([&]() {
         auto state(_state->lock());
 
-        auto useQueryValidDerivers(state->stmts->QueryValidDerivers.use()(printStorePath(path)));
+        auto useQueryValidDerivers(state->stmts->QueryValidDerivers.use().apply(printStorePath(path)));
 
         StorePathSet derivers;
         while (useQueryValidDerivers.next())
@@ -887,7 +896,7 @@ LocalStore::queryStaticPartialDerivationOutputMap(const StorePath & path)
         std::map<std::string, std::optional<StorePath>> outputs;
         uint64_t drvId;
         drvId = queryValidPathId(*state, path);
-        auto use(state->stmts->QueryDerivationOutputs.use()(drvId));
+        auto use(state->stmts->QueryDerivationOutputs.use().apply(drvId));
         while (use.next())
             outputs.insert_or_assign(use.getStr(0), parseStorePath(use.getStr(1)));
 
@@ -905,7 +914,7 @@ std::optional<StorePath> LocalStore::queryPathFromHashPart(const std::string & h
     return retrySQLite<std::optional<StorePath>>([&]() -> std::optional<StorePath> {
         auto state(_state->lock());
 
-        auto useQueryPathFromHashPart(state->stmts->QueryPathFromHashPart.use()(prefix));
+        auto useQueryPathFromHashPart(state->stmts->QueryPathFromHashPart.use().apply(prefix));
 
         if (!useQueryPathFromHashPart.next())
             return {};
@@ -951,7 +960,7 @@ void LocalStore::registerValidPaths(const ValidPathInfos & infos)
         for (auto & [_, i] : infos) {
             auto referrer = queryValidPathId(*state, i.path);
             for (auto & j : i.references)
-                state->stmts->AddReference.use()(referrer)(queryValidPathId(*state, j)).exec();
+                state->stmts->AddReference.use().apply(referrer).apply(queryValidPathId(*state, j)).exec();
         }
 
         /* Do a topological sort of the paths.  This will throw an
@@ -985,7 +994,7 @@ void LocalStore::invalidatePath(State & state, const StorePath & path)
 {
     debug("invalidating path '%s'", printStorePath(path));
 
-    state.stmts->InvalidatePath.use()(printStorePath(path)).exec();
+    state.stmts->InvalidatePath.use().apply(printStorePath(path)).exec();
 
     /* Note that the foreign key constraints on the Refs table take
        care of deleting the references entries for `path'. */
@@ -1723,7 +1732,7 @@ void LocalStore::addSignatures(const StorePath & storePath, const std::set<Signa
 std::optional<std::pair<int64_t, UnkeyedRealisation>>
 LocalStore::queryRealisationCore_(LocalStore::State & state, const DrvOutput & id)
 {
-    auto useQueryRealisedOutput(state.stmts->QueryRealisedOutput.use()(id.strHash())(id.outputName));
+    auto useQueryRealisedOutput(state.stmts->QueryRealisedOutput.use().apply(id.strHash()).apply(id.outputName));
     if (!useQueryRealisedOutput.next())
         return std::nullopt;
     auto realisationDbId = useQueryRealisedOutput.getInt(0);

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -156,14 +156,15 @@ struct NarInfoDiskCacheImpl : NarInfoDiskCache
                     .use()
                     // Use a minimum TTL to prevent --refresh from
                     // nuking the entire disk cache.
-                    (now - std::max(settings.ttlNegative.get(), 3600U))(
-                        now - std::max(settings.ttlPositive.get(), 30 * 24 * 3600U))
+                    .apply(now - std::max(settings.ttlNegative.get(), 3600U))
+                    .apply(now - std::max(settings.ttlPositive.get(), 30 * 24 * 3600U))
                     .exec();
 
                 debug("deleted %d entries from the NAR info disk cache", sqlite3_changes(state->db));
 
                 SQLiteStmt(state->db, "insert or replace into LastPurge(dummy, value) values ('', ?)")
-                    .use()(now)
+                    .use()
+                    .apply(now)
                     .exec();
             }
         });
@@ -187,7 +188,7 @@ private:
                the the subtraction would promote time_t to unsigned if time_t is
                32 bit. */
             auto timestamp = static_cast<int64_t>(time(nullptr)) - static_cast<int64_t>(settings.ttlMeta.get());
-            auto queryCache(state.queryCache.use()(uri)(timestamp));
+            auto queryCache(state.queryCache.use().apply(uri).apply(timestamp));
             if (!queryCache.next())
                 return std::nullopt;
             auto cache = Cache{
@@ -223,7 +224,12 @@ public:
             };
 
             {
-                auto r(state->insertCache.use()(uri)(time(nullptr))(storeDir) (wantMassQuery) (priority));
+                auto r(state->insertCache.use()
+                           .apply(uri)
+                           .apply(time(nullptr))
+                           .apply(storeDir)
+                           .apply(wantMassQuery)
+                           .apply(priority));
                 if (!r.next()) {
                     unreachable();
                 }
@@ -259,8 +265,11 @@ public:
 
                 auto now = time(nullptr);
 
-                auto queryNAR(
-                    state->queryNAR.use()(cache.id)(hashPart) (now - settings.ttlNegative)(now - settings.ttlPositive));
+                auto queryNAR(state->queryNAR.use()
+                                  .apply(cache.id)
+                                  .apply(hashPart)
+                                  .apply(now - settings.ttlNegative)
+                                  .apply(now - settings.ttlPositive));
 
                 if (!queryNAR.next())
                     return {oUnknown, 0};
@@ -302,8 +311,11 @@ public:
 
                 auto now = time(nullptr);
 
-                auto queryRealisation(state->queryRealisation.use()(cache.id)(id.to_string())(
-                    now - settings.ttlNegative)(now - settings.ttlPositive));
+                auto queryRealisation(state->queryRealisation.use()
+                                          .apply(cache.id)
+                                          .apply(id.to_string())
+                                          .apply(now - settings.ttlNegative)
+                                          .apply(now - settings.ttlPositive));
 
                 if (!queryRealisation.next())
                     return {oUnknown, 0};
@@ -337,21 +349,30 @@ public:
 
                 // assert(hashPart == storePathToHash(info->path));
 
-                state->insertNAR
-                    .use()(cache.id)(hashPart) (std::string(info->path.name()))(
-                        narInfo ? narInfo->url : "", narInfo != 0)(narInfo ? narInfo->compression : "", narInfo != 0)(
+                state->insertNAR.use()
+                    .apply(cache.id)
+                    .apply(hashPart)
+                    .apply(std::string(info->path.name()))
+                    .apply(narInfo ? narInfo->url : "", narInfo != 0)
+                    .apply(narInfo ? narInfo->compression : "", narInfo != 0)
+                    .apply(
                         narInfo && narInfo->fileHash ? narInfo->fileHash->to_string(HashFormat::Nix32, true) : "",
-                        narInfo && narInfo->fileHash)(
-                        narInfo ? narInfo->fileSize : 0, narInfo != 0 && narInfo->fileSize)(info->narHash.to_string(
-                        HashFormat::Nix32, true))(info->narSize)(concatStringsSep(" ", info->shortRefs()))(
-                        info->deriver ? std::string(info->deriver->to_string()) : "", (bool) info->deriver)(
-                        concatStringsSep(" ", Signature::toStrings(info->sigs)))(renderContentAddress(info->ca))(
+                        narInfo && narInfo->fileHash)
+                    .apply(narInfo ? narInfo->fileSize : 0, narInfo != 0 && narInfo->fileSize)
+                    .apply(info->narHash.to_string(HashFormat::Nix32, true))
+                    .apply(info->narSize)
+                    .apply(concatStringsSep(" ", info->shortRefs()))
+                    .apply(info->deriver ? std::string(info->deriver->to_string()) : "", (bool) info->deriver)
+                    .apply(concatStringsSep(" ", Signature::toStrings(info->sigs)))
+                    .apply(renderContentAddress(info->ca))
+                    .apply(
                         info->provenance ? info->provenance->to_json_str() : "",
-                        experimentalFeatureSettings.isEnabled(Xp::Provenance) && info->provenance)(time(nullptr))
+                        experimentalFeatureSettings.isEnabled(Xp::Provenance) && info->provenance)
+                    .apply(time(nullptr))
                     .exec();
 
             } else {
-                state->insertMissingNAR.use()(cache.id)(hashPart) (time(nullptr)).exec();
+                state->insertMissingNAR.use().apply(cache.id).apply(hashPart).apply(time(nullptr)).exec();
             }
         });
     }
@@ -363,9 +384,11 @@ public:
 
             auto & cache(getCache(*state, uri));
 
-            state->insertRealisation
-                .use()(cache.id)(realisation.id.to_string())(static_cast<nlohmann::json>(realisation).dump())(
-                    time(nullptr))
+            state->insertRealisation.use()
+                .apply(cache.id)
+                .apply(realisation.id.to_string())
+                .apply(static_cast<nlohmann::json>(realisation).dump())
+                .apply(time(nullptr))
                 .exec();
         });
     }
@@ -376,7 +399,7 @@ public:
             auto state(_state.lock());
 
             auto & cache(getCache(*state, uri));
-            state->insertMissingRealisation.use()(cache.id)(id.to_string())(time(nullptr)).exec();
+            state->insertMissingRealisation.use().apply(cache.id).apply(id.to_string()).apply(time(nullptr)).exec();
         });
     }
 };

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -175,7 +175,7 @@ SQLiteStmt::Use::~Use()
     sqlite3_reset(stmt);
 }
 
-SQLiteStmt::Use & SQLiteStmt::Use::operator()(std::string_view value, bool notNull)
+SQLiteStmt::Use & SQLiteStmt::Use::apply(std::string_view value, bool notNull)
 {
     if (notNull) {
         if (sqlite3_bind_text(stmt, curArg++, value.data(), -1, SQLITE_TRANSIENT) != SQLITE_OK)
@@ -185,7 +185,7 @@ SQLiteStmt::Use & SQLiteStmt::Use::operator()(std::string_view value, bool notNu
     return *this;
 }
 
-SQLiteStmt::Use & SQLiteStmt::Use::operator()(const unsigned char * data, size_t len, bool notNull)
+SQLiteStmt::Use & SQLiteStmt::Use::apply(const unsigned char * data, size_t len, bool notNull)
 {
     if (notNull) {
         if (sqlite3_bind_blob(stmt, curArg++, data, len, SQLITE_TRANSIENT) != SQLITE_OK)
@@ -195,7 +195,7 @@ SQLiteStmt::Use & SQLiteStmt::Use::operator()(const unsigned char * data, size_t
     return *this;
 }
 
-SQLiteStmt::Use & SQLiteStmt::Use::operator()(int64_t value, bool notNull)
+SQLiteStmt::Use & SQLiteStmt::Use::apply(int64_t value, bool notNull)
 {
     if (notNull) {
         if (sqlite3_bind_int64(stmt, curArg++, value) != SQLITE_OK)


### PR DESCRIPTION
## Motivation

Upstream https://github.com/NixOS/nix/pull/15989.

Using `operator()` causes very ugly clang formatting, e.g.

```c++
    state.stmts->RegisterValidPath
        .use()(printStorePath(info.path))(info.narHash.to_string(HashFormat::Base16, true))(
            info.registrationTime == 0 ? time(nullptr) : info.registrationTime)(
            info.deriver ? printStorePath(*info.deriver) : "",
            (bool) info.deriver)(info.narSize, info.narSize != 0)(info.ultimate ? 1 : 0, info.ultimate)(
            concatStringsSep(" ", Signature::toStrings(info.sigs)),
            !info.sigs.empty())(renderContentAddress(info.ca), (bool) info.ca)
```
This was especially painful when there was a merge conflict involving this type of code.

Now it looks like this:
```c++
    state.stmts->RegisterValidPath.use()
        .apply(printStorePath(info.path))
        .apply(info.narHash.to_string(HashFormat::Base16, true))
        .apply(info.registrationTime == 0 ? time(nullptr) : info.registrationTime)
        .apply(info.deriver ? printStorePath(*info.deriver) : "", (bool) info.deriver)
        .apply(info.narSize, info.narSize != 0)
        .apply(info.ultimate ? 1 : 0, info.ultimate)
        .apply(concatStringsSep(" ", Signature::toStrings(info.sigs)), !info.sigs.empty())
        .apply(renderContentAddress(info.ca), (bool) info.ca)
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized database statement parameter binding patterns across the codebase for improved code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->