### PR TITLE
Make optimiseStore() multi-threaded

### DIFF
--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -9,10 +9,11 @@
 #include "nix/store/active-builds.hh"
 #include "nix/util/sync.hh"
 
+#include <atomic>
 #include <chrono>
 #include <future>
 #include <string>
-#include <boost/unordered/unordered_flat_set.hpp>
+#include <boost/unordered/concurrent_flat_set_fwd.hpp>
 
 namespace nix {
 
@@ -28,8 +29,8 @@ const int nixSchemaVersion = 10;
 
 struct OptimiseStats
 {
-    unsigned long filesLinked = 0;
-    uint64_t bytesFreed = 0;
+    std::atomic<unsigned long> filesLinked = 0;
+    std::atomic<uint64_t> bytesFreed = 0;
 };
 
 struct LocalSettings;
@@ -519,7 +520,7 @@ private:
 
     std::pair<std::filesystem::path, AutoCloseFD> createTempDirInStore();
 
-    typedef boost::unordered_flat_set<ino_t> InodeHash;
+    typedef boost::concurrent_flat_set<ino_t> InodeHash;
 
     InodeHash loadInodeHash();
     Strings readDirectoryIgnoringInodes(const std::filesystem::path & path, const InodeHash & inodeHash);

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -291,8 +291,15 @@ void LocalStore::optimiseStore(OptimiseStats & stats)
 {
     Activity act(*logger, actOptimiseStore);
 
-    auto paths = queryAllValidPaths();
-    InodeHash inodeHash = loadInodeHash();
+    auto paths = [&]() {
+        Activity act(*logger, lvlTalkative, actUnknown, "querying valid paths");
+        return queryAllValidPaths();
+    }();
+
+    InodeHash inodeHash = [&]() {
+        Activity act(*logger, lvlTalkative, actUnknown, "reading .links directory");
+        return loadInodeHash();
+    }();
 
     act.progress(0, paths.size());
 

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -1,9 +1,12 @@
 #include "nix/store/local-store.hh"
 #include "nix/store/globals.hh"
 #include "nix/util/signals.hh"
+#include "nix/util/thread-pool.hh"
 #include "nix/store/posix-fs-canonicalise.hh"
 #include "nix/util/posix-source-accessor.hh"
 #include "nix/util/file-system.hh"
+
+#include <boost/unordered/concurrent_flat_set.hpp>
 
 #include <cstdlib>
 #include <cstring>
@@ -303,19 +306,24 @@ void LocalStore::optimiseStore(OptimiseStats & stats)
 
     act.progress(0, paths.size());
 
-    uint64_t done = 0;
+    std::atomic<uint64_t> done = 0;
+
+    ThreadPool pool;
 
     for (auto & i : paths) {
-        addTempRoot(i);
-        if (!isValidPath(i))
-            continue; /* path was GC'ed, probably */
-        {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("optimising path '%s'", printStorePath(i)));
-            optimisePath_(&act, stats, config->realStoreDir.get() / i.to_string(), inodeHash, NoRepair);
-        }
-        done++;
-        act.progress(done, paths.size());
+        pool.enqueue([&, i]() {
+            addTempRoot(i);
+            if (!isValidPath(i))
+                return; /* path was GC'ed, probably */
+            {
+                Activity act2(*logger, lvlTalkative, actUnknown, fmt("optimising path '%s'", printStorePath(i)));
+                optimisePath_(&act2, stats, config->realStoreDir.get() / i.to_string(), inodeHash, NoRepair);
+            }
+            act.progress(++done, paths.size());
+        });
     }
+
+    pool.process();
 }
 
 void LocalStore::optimiseStore()
@@ -324,7 +332,7 @@ void LocalStore::optimiseStore()
 
     optimiseStore(stats);
 
-    printInfo("%s freed by hard-linking %d files", renderSize(stats.bytesFreed), stats.filesLinked);
+    printInfo("%s freed by hard-linking %d files", renderSize(stats.bytesFreed.load()), stats.filesLinked.load());
 }
 
 void LocalStore::optimisePath(const std::filesystem::path & path, RepairFlag repair)


### PR DESCRIPTION
## Motivation

Since `nix store optimise` does a lot of hashing, it benefits a lot from multi-threading. On a store with 920K store paths, I got a speedup  from 301s to 111s.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored store optimization process to improve thread safety and statistics tracking.
  * Updated internal data structures to use atomic counters for concurrent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->