### PR TITLE
Binary cache info

### DIFF
--- a/src/libstore-tests/nar-info-disk-cache.cc
+++ b/src/libstore-tests/nar-info-disk-cache.cc
@@ -30,15 +30,16 @@ TEST(NarInfoDiskCacheImpl, create_and_read)
 
         // Set up "background noise" and check that different caches receive different ids
         {
-            auto bc1 = cache->createCache("https://bar", "/nix/storedir", wantMassQuery, prio);
-            auto bc2 = cache->createCache("https://xyz", "/nix/storedir", false, 12);
+            auto bc1 =
+                cache->createCache("https://bar", "/nix/storedir", {.wantMassQuery = wantMassQuery, .priority = prio});
+            auto bc2 = cache->createCache("https://xyz", "/nix/storedir", {.priority = 12});
             ASSERT_NE(bc1, bc2);
             barId = bc1;
         }
 
         // Check that the fields are saved and returned correctly. This does not test
         // the select statement yet, because of in-memory caching.
-        savedId = cache->createCache("http://foo", "/nix/storedir", wantMassQuery, prio);
+        savedId = cache->createCache("http://foo", "/nix/storedir", {.wantMassQuery = wantMassQuery, .priority = prio});
         ;
         {
             auto r = cache->upToDateCacheExists("http://foo");
@@ -84,7 +85,7 @@ TEST(NarInfoDiskCacheImpl, create_and_read)
         }
 
         // "Update", same data, check that the id number is reused
-        cache2->createCache("http://foo", "/nix/storedir", wantMassQuery, prio);
+        cache2->createCache("http://foo", "/nix/storedir", {.wantMassQuery = wantMassQuery, .priority = prio});
 
         {
             auto r = cache2->upToDateCacheExists("http://foo");
@@ -107,7 +108,8 @@ TEST(NarInfoDiskCacheImpl, create_and_read)
             auto r0 = cache2->upToDateCacheExists("https://bar");
             ASSERT_FALSE(r0);
 
-            cache2->createCache("https://bar", "/nix/storedir", !wantMassQuery, prio + 10);
+            cache2->createCache(
+                "https://bar", "/nix/storedir", {.wantMassQuery = !wantMassQuery, .priority = prio + 10});
             auto r = cache2->upToDateCacheExists("https://bar");
             ASSERT_EQ(r->wantMassQuery, !wantMassQuery);
             ASSERT_EQ(r->priority, prio + 10);

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -75,7 +75,8 @@ void HttpBinaryCacheStore::init()
         } catch (UploadToHTTP &) {
             throw Error("'%s' does not appear to be a binary cache", config->cacheUri.to_string());
         }
-        diskCache->createCache(cacheKey, config->storeDir, config->wantMassQuery, config->priority);
+        diskCache->createCache(
+            cacheKey, config->storeDir, {.wantMassQuery = config->wantMassQuery, .priority = config->priority});
     }
 }
 

--- a/src/libstore/include/nix/store/nar-info-disk-cache.hh
+++ b/src/libstore/include/nix/store/nar-info-disk-cache.hh
@@ -25,15 +25,18 @@ struct NarInfoDiskCache
 
     virtual ~NarInfoDiskCache() {}
 
-    virtual int
-    createCache(const std::string & uri, const std::string & storeDir, bool wantMassQuery, int priority) = 0;
-
     struct CacheInfo
     {
-        int id;
-        bool wantMassQuery;
-        int priority;
+        int id = 0;
+        bool wantMassQuery = false;
+        int priority = 0;
     };
+
+    /**
+     * Create or update the cached nix-cache-info for the binary cache at `uri`.
+     * Note that `info.id` is ignored. This function returns the id of the cache entry.
+     */
+    virtual int createCache(const std::string & uri, const std::string & storeDir, const CacheInfo & info) = 0;
 
     virtual std::optional<CacheInfo> upToDateCacheExists(const std::string & uri) = 0;
 

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -67,10 +67,8 @@ struct NarInfoDiskCacheImpl : NarInfoDiskCache
 
     struct Cache
     {
-        int id;
         std::string storeDir;
-        bool wantMassQuery;
-        int priority;
+        CacheInfo info;
     };
 
     struct State
@@ -192,11 +190,12 @@ private:
             if (!queryCache.next())
                 return std::nullopt;
             auto cache = Cache{
-                .id = (int) queryCache.getInt(0),
                 .storeDir = queryCache.getStr(1),
-                .wantMassQuery = queryCache.getInt(2) != 0,
-                .priority = (int) queryCache.getInt(3),
-            };
+                .info = {
+                    .id = (int) queryCache.getInt(0),
+                    .wantMassQuery = queryCache.getInt(2) != 0,
+                    .priority = (int) queryCache.getInt(3),
+                }};
             state.caches.emplace(uri, cache);
         }
         return getCache(state, uri);
@@ -214,14 +213,9 @@ public:
             auto cache(queryCacheRaw(*state, uri));
 
             if (cache)
-                return cache->id;
+                return cache->info.id;
 
-            Cache ret{
-                .id = -1, // set below
-                .storeDir = storeDir,
-                .wantMassQuery = info.wantMassQuery,
-                .priority = info.priority,
-            };
+            Cache ret{.storeDir = storeDir, .info = info};
 
             {
                 auto r(state->insertCache.use()
@@ -233,13 +227,13 @@ public:
                 if (!r.next()) {
                     unreachable();
                 }
-                ret.id = (int) r.getInt(0);
+                ret.info.id = (int) r.getInt(0);
             }
 
             state->caches[uri] = ret;
 
             txn.commit();
-            return ret.id;
+            return ret.info.id;
         });
     }
 
@@ -250,7 +244,7 @@ public:
             auto cache(queryCacheRaw(*state, uri));
             if (!cache)
                 return std::nullopt;
-            return CacheInfo{.id = cache->id, .wantMassQuery = cache->wantMassQuery, .priority = cache->priority};
+            return cache->info;
         });
     }
 
@@ -266,7 +260,7 @@ public:
                 auto now = time(nullptr);
 
                 auto queryNAR(state->queryNAR.use()
-                                  .apply(cache.id)
+                                  .apply(cache.info.id)
                                   .apply(hashPart)
                                   .apply(now - settings.ttlNegative)
                                   .apply(now - settings.ttlPositive));
@@ -312,7 +306,7 @@ public:
                 auto now = time(nullptr);
 
                 auto queryRealisation(state->queryRealisation.use()
-                                          .apply(cache.id)
+                                          .apply(cache.info.id)
                                           .apply(id.to_string())
                                           .apply(now - settings.ttlNegative)
                                           .apply(now - settings.ttlPositive));
@@ -350,7 +344,7 @@ public:
                 // assert(hashPart == storePathToHash(info->path));
 
                 state->insertNAR.use()
-                    .apply(cache.id)
+                    .apply(cache.info.id)
                     .apply(hashPart)
                     .apply(std::string(info->path.name()))
                     .apply(narInfo ? narInfo->url : "", narInfo != 0)
@@ -372,7 +366,7 @@ public:
                     .exec();
 
             } else {
-                state->insertMissingNAR.use().apply(cache.id).apply(hashPart).apply(time(nullptr)).exec();
+                state->insertMissingNAR.use().apply(cache.info.id).apply(hashPart).apply(time(nullptr)).exec();
             }
         });
     }
@@ -385,7 +379,7 @@ public:
             auto & cache(getCache(*state, uri));
 
             state->insertRealisation.use()
-                .apply(cache.id)
+                .apply(cache.info.id)
                 .apply(realisation.id.to_string())
                 .apply(static_cast<nlohmann::json>(realisation).dump())
                 .apply(time(nullptr))
@@ -399,7 +393,11 @@ public:
             auto state(_state.lock());
 
             auto & cache(getCache(*state, uri));
-            state->insertMissingRealisation.use().apply(cache.id).apply(id.to_string()).apply(time(nullptr)).exec();
+            state->insertMissingRealisation.use()
+                .apply(cache.info.id)
+                .apply(id.to_string())
+                .apply(time(nullptr))
+                .exec();
         });
     }
 };

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -203,7 +203,7 @@ private:
     }
 
 public:
-    int createCache(const std::string & uri, const std::string & storeDir, bool wantMassQuery, int priority) override
+    int createCache(const std::string & uri, const std::string & storeDir, const CacheInfo & info) override
     {
         return retrySQLite<int>([&]() {
             auto state(_state.lock());
@@ -219,8 +219,8 @@ public:
             Cache ret{
                 .id = -1, // set below
                 .storeDir = storeDir,
-                .wantMassQuery = wantMassQuery,
-                .priority = priority,
+                .wantMassQuery = info.wantMassQuery,
+                .priority = info.priority,
             };
 
             {
@@ -228,8 +228,8 @@ public:
                            .apply(uri)
                            .apply(time(nullptr))
                            .apply(storeDir)
-                           .apply(wantMassQuery)
-                           .apply(priority));
+                           .apply(info.wantMassQuery)
+                           .apply(info.priority));
                 if (!r.next()) {
                     unreachable();
                 }


### PR DESCRIPTION
## Motivation

This deduplicates the `Cache` and `CacheInfo` types, and makes `NarInfoDiskCache::createCache()` take a `CacheInfo` instead of a bunch of separate arguments. This makes it easier to add new `nix-cache-info` fields in the future. 

Upstream https://github.com/NixOS/nix/pull/16006.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored cache creation API to use structured parameter passing with named fields for improved code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->