### PR TITLE
Improve error message when user isn't allowed access to the daemon

### DIFF
--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -11,6 +11,7 @@ namespace nix {
 
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
+#define WORKER_MAGIC_ACCESS_DENIED 0xab9a9ff0 // = 🚫
 
 #define STDERR_NEXT 0x6f6c6d67
 #define STDERR_READ 0x64617461  // data needed from source

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -110,7 +110,8 @@ void RemoteStore::initConnection(Connection & conn)
         if (ex)
             std::rethrow_exception(ex);
     } catch (Error & e) {
-        throw Error("cannot open connection to remote store '%s': %s", config.getHumanReadableURI(), e.what());
+        throw Error(
+            "cannot open connection to remote store '%s': %s", config.getHumanReadableURI(), Uncolored(e.message()));
     }
 
     setOptions(conn);

--- a/src/libstore/worker-protocol-connection.cc
+++ b/src/libstore/worker-protocol-connection.cc
@@ -161,8 +161,11 @@ WorkerProto::Version WorkerProto::BasicClientConnection::handshake(
     to.flush();
 
     unsigned int magic = readInt(from);
-    if (magic != WORKER_MAGIC_2)
-        throw Error("nix-daemon protocol mismatch from");
+    if (magic != WORKER_MAGIC_2) {
+        if (magic == WORKER_MAGIC_ACCESS_DENIED)
+            throw Error("access denied by the Nix daemon (check the `allowed-users` setting in the daemon)");
+        throw Error("Nix daemon protocol mismatch");
+    }
     auto daemonVersion = WorkerProto::Version::Number::fromWire(readInt(from));
 
     if (daemonVersion.major != WorkerProto::latest.number.major)

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -315,9 +315,16 @@ static void daemonLoop(ref<const StoreConfig> storeConfig, std::optional<Trusted
                     trusted = *forceTrustClientOpt;
                 else {
                     peer = unix::getPeerInfo(remote.get());
-                    auto [_trusted, _userName] = authPeer(peer);
-                    trusted = _trusted;
-                    userName = _userName;
+                    try {
+                        auto [_trusted, _userName] = authPeer(peer);
+                        trusted = _trusted;
+                        userName = _userName;
+                    } catch (const Error & e) {
+                        // Don't just hang up on the user.
+                        FdSink sink(remote.get());
+                        sink << WORKER_MAGIC_ACCESS_DENIED;
+                        throw;
+                    }
                 };
 
                 printInfo(


### PR DESCRIPTION
## Motivation

Previously it said:
```
error: cannot open connection to remote store 'daemon': error: read of 32768 bytes: Connection reset by peer
```

Now it says:
```
error: cannot open connection to remote store 'daemon': access denied by the Nix daemon (check the `allowed-users` setting in the daemon)
```

Note: using an older client, you now get:
```
error: cannot open connection to remote store 'daemon': error: nix-daemon protocol mismatch from
```
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The daemon now sends an explicit access-denied marker when it rejects a client, and clients display clearer, distinct error messages for access denial vs protocol mismatch—making daemon access issues easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->