### PR TITLE
nario tweaks

### DIFF
--- a/src/libstore/export-import.cc
+++ b/src/libstore/export-import.cc
@@ -113,6 +113,8 @@ StorePaths importPaths(Store & store, Source & source, CheckSigsFlag checkSigs)
 
             auto path = store.parseStorePath(readString(source));
 
+            Activity act(*logger, lvlTalkative, actUnknown, fmt("importing path '%s'", store.printStorePath(path)));
+
             auto references = CommonProto::Serialise<StorePathSet>::read(store, CommonProto::ReadConn{.from = source});
             auto deriver = readString(source);
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1043,6 +1043,7 @@ void LocalStore::doAddToStore(const ValidPathInfo & info, Source & source, Repai
 
     auto realPath = toRealPath(info.path);
 
+    // TODO: make repair more safe: write to a temporary location first before renaming/deleting.
     deletePath(realPath);
 
     /* Maybe free up some disk space (before writing the NAR) so that

--- a/src/libutil/include/nix/util/serialise.hh
+++ b/src/libutil/include/nix/util/serialise.hh
@@ -762,6 +762,8 @@ struct EnsureRead : Source
     {
         try {
             finish();
+        } catch (EndOfFile &) {
+            // Ignore this, since an EOF will generally already have been encountered by the user of EnsureRead.
         } catch (...) {
             ignoreExceptionInDestructor();
         }


### PR DESCRIPTION
## Motivation

* Don't show duplicate "error: unexpected end-of-file" when reading a truncated NAR.
* Show "importing path..." progress for v1 narios, similar to v2.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception handling to properly manage end-of-file scenarios during serialization operations, increasing stability and reliability of import and export workflows.

* **Chores**
  * Enhanced activity logging for package import operations to improve diagnostic visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->