### PR TITLE
Mirror to nix-artifacts on release of tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,8 @@ jobs:
       - build_aarch64-linux_no_dsp
       - build_aarch64-darwin_no_dsp
     if: ${{ always() }}
+    outputs:
+      store-path: ${{ steps.buildfallback.outputs.store-path }}
     steps:
       - run: "true"
       - run: |
@@ -157,6 +159,7 @@ jobs:
           done
 
       - name: Build fallback-paths.nix
+        id: buildfallback
         if: ${{
               github.event_name != 'pull_request'
               || (
@@ -171,6 +174,14 @@ jobs:
           nix build ./packaging/secure-packages#fallbackPathsNix --out-link fallback
           nix build .#fallbackPathsNix --out-link fallback.no-dsp
           cat fallback > ./artifacts/fallback-paths.nix
+          nix path-info -r --json ./fallback > ./artifacts/closure.json
+          nix path-info -r ./fallback > ./artifacts/closure.txt
+          echo "store-path=$(readlink -f fallback)" >> "$GITHUB_OUTPUT"
+
+      - uses: DeterminateSystems/public-slice-mirror/.github/actions/upload-store-paths@381c2a441618b35b2bae85bddb257ede8f9aef0f
+        if: steps.buildfallback.outputs.store-path != ''
+        with:
+          store-paths: ${{ steps.buildfallback.outputs.store-path }}
 
       - uses: DeterminateSystems/push-artifact-ids@main
         with:
@@ -185,7 +196,7 @@ jobs:
   publish:
     needs:
       - success
-    if: (!github.repository.fork && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/')))
+    if: (!github.event.repository.fork && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/')))
     environment: ${{ github.event_name == 'release' && 'production' || '' }}
     runs-on: ubuntu-latest
     permissions:
@@ -207,3 +218,20 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
         run: |
           gh release edit "$TAG_NAME" --notes-file doc/manual/source/release-notes-determinate/"$TAG_NAME".md || true
+
+  mirror:
+    if: ${{
+          (
+            (needs.success.outputs.store-path != '')
+            && (!github.event.repository.fork && (startsWith(github.ref, 'refs/tags/')))
+          )
+        }}
+    needs: success
+    permissions:
+      id-token: write   # required so the workflow can auth to FlakeHub
+      contents: read
+    uses: DeterminateSystems/public-slice-mirror/.github/workflows/subset-mirror.yml@381c2a441618b35b2bae85bddb257ede8f9aef0f
+    with:
+      flake-name: DeterminateSystems/nix-artifacts
+      rolling: false
+      tag: ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,8 @@ jobs:
       - build_aarch64-darwin_no_dsp
     if: ${{ always() }}
     outputs:
-      store-path: ${{ steps.buildfallback.outputs.store-path }}
+      store-path-dsp: ${{ steps.buildfallback.outputs.store-path-dsp }}
+      store-path-root: ${{ steps.buildfallback.outputs.store-path-root }}
     steps:
       - run: "true"
       - run: |
@@ -171,17 +172,25 @@ jobs:
               )
             }}
         run: |
-          nix build ./packaging/secure-packages#fallbackPathsNix --out-link fallback
-          nix build .#fallbackPathsNix --out-link fallback.no-dsp
-          cat fallback > ./artifacts/fallback-paths.nix
-          nix path-info -r --json ./fallback > ./artifacts/closure.json
-          nix path-info -r ./fallback > ./artifacts/closure.txt
-          echo "store-path=$(readlink -f fallback)" >> "$GITHUB_OUTPUT"
+          nix build ./packaging/secure-packages#fallbackPathsNix --out-link fallback.dsp
+          cat fallback.dsp > ./artifacts/fallback-paths.nix
+
+          nix path-info -r --json ./fallback.dsp > ./artifacts/closure.dsp.json
+          nix path-info -r ./fallback.dsp > ./artifacts/closure.dsp.txt
+
+          nix build .#fallbackPathsNix --out-link fallback.root
+          nix path-info -r --json ./fallback.root > ./artifacts/closure.root.json
+          nix path-info -r ./fallback.root > ./artifacts/closure.root.txt
+
+          echo "store-path-dsp=$(readlink -f fallback.dsp)" >> "$GITHUB_OUTPUT"
+          echo "store-path-root=$(readlink -f fallback.root)" >> "$GITHUB_OUTPUT"
 
       - uses: DeterminateSystems/public-slice-mirror/.github/actions/upload-store-paths@381c2a441618b35b2bae85bddb257ede8f9aef0f
-        if: steps.buildfallback.outputs.store-path != ''
+        if: steps.buildfallback.outputs.store-path-dsp != ''
         with:
-          store-paths: ${{ steps.buildfallback.outputs.store-path }}
+          store-paths: |
+            ${{ steps.buildfallback.outputs.store-path-dsp }}
+            ${{ steps.buildfallback.outputs.store-path-root }}
 
       - uses: DeterminateSystems/push-artifact-ids@main
         with:
@@ -222,7 +231,7 @@ jobs:
   mirror:
     if: ${{
           (
-            (needs.success.outputs.store-path != '')
+            (needs.success.outputs.store-path-dsp != '')
             && (!github.event.repository.fork && (startsWith(github.ref, 'refs/tags/')))
           )
         }}


### PR DESCRIPTION
Mirror the closure of fallback-paths to `nix-artifacts` as part of release hardening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD artifact handling by generating additional fallback metadata and exposing resolved fallback store paths for downstream use.
  * Improved publish gating to more reliably detect fork vs non-fork events.
  * Added a conditional mirror publishing step that runs only for non-fork tagged builds when fallback artifacts are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->