### PR TITLE
Daemon: Ignore interrupts between accept() and child start

### DIFF
--- a/src/libcmd/unix/unix-socket-server.cc
+++ b/src/libcmd/unix/unix-socket-server.cc
@@ -104,7 +104,6 @@ PeerInfo getPeerInfo(Descriptor remote)
                 socklen_t remoteAddrLen = sizeof(remoteAddr);
 
                 AutoCloseFD remote = accept(fd.fd, (struct sockaddr *) &remoteAddr, &remoteAddrLen);
-                checkInterrupt();
                 if (!remote) {
                     if (errno == EINTR)
                         continue;

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -340,6 +340,8 @@ static void daemonLoop(ref<const StoreConfig> storeConfig, std::optional<Trusted
                 options.allowVfork = false;
                 startProcess(
                     [&, storeConfig, closeListeners = std::move(closeListeners)]() {
+                        setInterrupted(false);
+
                         closeListeners();
 
                         // Background the daemon.


### PR DESCRIPTION

## Motivation

Sending SIGINT to the nix-daemon parent process is supposed to stop the parent, not the children. So any connection that has been `accept()`ed should continue normally. However, there is a time window between the call to `accept()` and the `fork()` of the child where we could receive SIGINT, which would cause the child to throw an `Interrupted` exception. This shows up in the client as

```
error: cannot open connection to remote store 'daemon': read of 32768 bytes: Connection reset by peer
```

Solution: don't call `checkInterrupts()` after `accept()`, and clear the interrupt flag in the child process.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed interrupted state handling in daemon worker processes to prevent improper inheritance from parent context.

* **Chores**
  * Removed redundant interrupt check in socket acceptance loop, streamlining interrupt handling flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->