### PR TITLE
Build all the archs without DSP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,20 +65,25 @@ jobs:
   build_aarch64-linux:
     uses: ./.github/workflows/build.yml
     with:
-      if: ${{
-            github.event_name != 'pull_request'
-            || (
-              github.event.pull_request.head.repo.full_name == 'DeterminateSystems/nix-src'
-              && (
-                (github.event.action == 'labeled' && github.event.label.name == 'upload to s3')
-                || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'upload to s3'))
-              )
-            )
-          }}
       system: aarch64-linux
       runner: UbuntuLatest32Cores128GArm
       runner_for_virt: UbuntuLatest32Cores128GArm
       runner_small: UbuntuLatest32Cores128GArm
+    secrets:
+      sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      sentry_org: ${{ secrets.SENTRY_ORG }}
+      sentry_project: ${{ secrets.SENTRY_PROJECT }}
+
+  build_aarch64-linux_no_dsp:
+    uses: ./.github/workflows/build.yml
+    if: github.event_name == 'merge_group'
+    with:
+      flake: .
+      system: aarch64-linux
+      runner: UbuntuLatest32Cores128GArm
+      runner_for_virt: UbuntuLatest32Cores128GArm
+      runner_small: UbuntuLatest32Cores128GArm
+      upload_artifacts: false
     secrets:
       sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
       sentry_org: ${{ secrets.SENTRY_ORG }}
@@ -96,6 +101,21 @@ jobs:
       sentry_org: ${{ secrets.SENTRY_ORG }}
       sentry_project: ${{ secrets.SENTRY_PROJECT }}
 
+  build_aarch64-darwin_no_dsp:
+    uses: ./.github/workflows/build.yml
+    if: github.event_name == 'merge_group'
+    with:
+      flake: .
+      system: aarch64-darwin
+      runner: namespace-profile-mac-m2-12c28g
+      runner_for_virt: namespace-profile-mac-m2-12c28g
+      runner_small: macos-latest-xlarge
+      upload_artifacts: false
+    secrets:
+      sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      sentry_org: ${{ secrets.SENTRY_ORG }}
+      sentry_project: ${{ secrets.SENTRY_PROJECT }}
+
   success:
     runs-on: ubuntu-latest
     needs:
@@ -103,6 +123,9 @@ jobs:
       - build_x86_64-linux
       - build_aarch64-linux
       - build_aarch64-darwin
+      - build_x86_64-linux_no_dsp
+      - build_aarch64-linux_no_dsp
+      - build_aarch64-darwin_no_dsp
     if: ${{ always() }}
     steps:
       - run: "true"
@@ -146,6 +169,7 @@ jobs:
             }}
         run: |
           nix build ./packaging/secure-packages#fallbackPathsNix --out-link fallback
+          nix build .#fallbackPathsNix --out-link fallback.no-dsp
           cat fallback > ./artifacts/fallback-paths.nix
 
       - uses: DeterminateSystems/push-artifact-ids@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       runner_small: ubuntu-latest
       run_tests: true
       run_vm_tests: false
-      run_regression_tests: true
+      run_regression_tests: false
       upload_artifacts: false
 
   build_aarch64-linux:


### PR DESCRIPTION
Also builds aarch64 linux in CI because why not?

## Motivation

The determinate flake doesn't use DSP by default, causing users to have to build Determinate Nix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI/build pipeline to add additional “no DSP” build variants and ensure the overall success checks wait for these new jobs.
  * Adjusted test behavior for the x86_64 “no DSP” variant.
  * Updated the Nix build step to target the local flake attribute and adjust the output link naming for the fallback artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->