### PR TITLE
Replace select() by poll()

### DIFF
--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -211,6 +211,9 @@ bool FdSource::hasData()
         return true;
 
     while (true) {
+#ifdef _WIN32
+        /* Windows' fd_set is a bounded handle array, so FD_SET can't
+           overflow; on Unix use poll() since fd may exceed FD_SETSIZE. */
         fd_set fds;
         FD_ZERO(&fds);
         Socket sock = toSocket(fd);
@@ -227,6 +230,20 @@ bool FdSource::hasData()
             throw SysError("polling file descriptor");
         }
         return FD_ISSET(sock, &fds);
+#else
+        struct pollfd pfd;
+        pfd.fd = fd;
+        pfd.events = POLLIN;
+        pfd.revents = 0;
+
+        auto n = poll(&pfd, 1, 0);
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            throw SysError("polling file descriptor");
+        }
+        return n > 0 && (pfd.revents & (POLLIN | POLLHUP | POLLERR)) != 0;
+#endif
     }
 }
 

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -28,7 +28,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
-#include <sys/select.h>
+#include <poll.h>
 #include <errno.h>
 #include <pwd.h>
 #include <grp.h>
@@ -385,23 +385,27 @@ static void forwardStdioConnection(RemoteStore & store)
     int from = conn->from.fd;
     int to = conn->to.fd;
 
-    Socket fromSock = toSocket(from), stdinSock = toSocket(getStandardInput());
-    auto nfds = std::max(fromSock, stdinSock) + 1;
     while (true) {
-        fd_set fds;
-        FD_ZERO(&fds);
-        FD_SET(fromSock, &fds);
-        FD_SET(stdinSock, &fds);
-        if (select(nfds, &fds, nullptr, nullptr, nullptr) == -1)
+        struct pollfd pfds[2];
+        pfds[0].fd = from;
+        pfds[0].events = POLLIN;
+        pfds[0].revents = 0;
+        pfds[1].fd = getStandardInput();
+        pfds[1].events = POLLIN;
+        pfds[1].revents = 0;
+        if (poll(pfds, 2, -1) == -1) {
+            if (errno == EINTR)
+                continue;
             throw SysError("waiting for data from client or server");
-        if (FD_ISSET(fromSock, &fds)) {
+        }
+        if (pfds[0].revents) {
             auto res = splice(from, nullptr, STDOUT_FILENO, nullptr, SSIZE_MAX, SPLICE_F_MOVE);
             if (res == -1)
                 throw SysError("splicing data from daemon socket to stdout");
             else if (res == 0)
                 throw EndOfFile("unexpected EOF from daemon socket");
         }
-        if (FD_ISSET(stdinSock, &fds)) {
+        if (pfds[1].revents) {
             auto res = splice(STDIN_FILENO, nullptr, to, nullptr, SSIZE_MAX, SPLICE_F_MOVE);
             if (res == -1)
                 throw SysError("splicing data from stdin to daemon socket");


### PR DESCRIPTION
## Motivation

This may fix some random "polling file descriptor: Invalid argument" errors seen on macOS. 

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated file descriptor polling implementation in utility and daemon components for improved system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->