### PR TITLE
Fix SSH connection sharing

### DIFF
--- a/src/libstore/include/nix/store/ssh.hh
+++ b/src/libstore/include/nix/store/ssh.hh
@@ -40,10 +40,10 @@ private:
     Sync<State> state_;
 
     void addCommonSSHOpts(OsStrings & args);
-    bool isMasterRunning();
+    bool isMasterRunning(std::filesystem::path socketPath);
 
 #ifndef _WIN32 // TODO re-enable on Windows, once we can start processes.
-    std::filesystem::path startMaster();
+    std::optional<std::filesystem::path> startMaster();
 #endif
 
 public:

--- a/src/libstore/include/nix/store/ssh.hh
+++ b/src/libstore/include/nix/store/ssh.hh
@@ -39,7 +39,7 @@ private:
 
     Sync<State> state_;
 
-    void addCommonSSHOpts(OsStrings & args);
+    void addCommonSSHOpts(OsStrings & args, std::optional<std::filesystem::path> socketPath);
     bool isMasterRunning(std::filesystem::path socketPath);
 
 #ifndef _WIN32 // TODO re-enable on Windows, once we can start processes.

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -262,7 +262,7 @@ std::optional<std::filesystem::path> SSHMaster::startMaster()
             if (dup2(out.writeSide.get(), STDOUT_FILENO) == -1)
                 throw SysError("duping over stdout");
 
-            OsStrings args = {"ssh", hostnameAndUser.c_str(), "-M", "-N"};
+            OsStrings args = {"ssh", hostnameAndUser.c_str(), "-M", "-N", "-oControlPersist=no"};
             if (verbosity >= lvlChatty)
                 args.push_back("-v");
             addCommonSSHOpts(args, state->socketPath);

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -90,7 +90,7 @@ SSHMaster::SSHMaster(
     checkValidAuthority(authority);
 }
 
-void SSHMaster::addCommonSSHOpts(OsStrings & args)
+void SSHMaster::addCommonSSHOpts(OsStrings & args, std::optional<std::filesystem::path> socketPath)
 {
     auto sshArgs = getNixSshOpts();
     args.insert(args.end(), sshArgs.begin(), sshArgs.end());
@@ -114,15 +114,15 @@ void SSHMaster::addCommonSSHOpts(OsStrings & args)
     // the remote session won't be garbled if the local command is slow.
     args.push_back(OS_STR("-oPermitLocalCommand=yes"));
     args.push_back(OS_STR("-oLocalCommand=echo started"));
+    args.insert(args.end(), {OS_STR("-S"), socketPath ? socketPath->native() : OS_STR("none")});
 }
 
 bool SSHMaster::isMasterRunning(std::filesystem::path socketPath)
 {
     assert(useMaster);
 
-    OsStrings args = {
-        OS_STR("-O"), OS_STR("check"), string_to_os_string(hostnameAndUser), OS_STR("-S"), socketPath.string()};
-    addCommonSSHOpts(args);
+    OsStrings args = {OS_STR("-O"), OS_STR("check"), string_to_os_string(hostnameAndUser)};
+    addCommonSSHOpts(args, socketPath);
 
     auto res = runProgram(RunOptions{.program = "ssh", .args = std::move(args), .mergeStderrToStdout = true});
     return res.first == 0;
@@ -187,8 +187,7 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(OsStrings && comm
 
             if (!fakeSSH) {
                 args = {"ssh", hostnameAndUser.c_str(), "-x"};
-                addCommonSSHOpts(args);
-                args.insert(args.end(), {"-S", socketPath ? socketPath->string() : "none"});
+                addCommonSSHOpts(args, socketPath);
                 if (verbosity >= lvlChatty)
                     args.push_back("-v");
                 args.splice(args.end(), std::move(extraSshArgs));
@@ -263,10 +262,10 @@ std::optional<std::filesystem::path> SSHMaster::startMaster()
             if (dup2(out.writeSide.get(), STDOUT_FILENO) == -1)
                 throw SysError("duping over stdout");
 
-            OsStrings args = {"ssh", hostnameAndUser.c_str(), "-M", "-N", "-S", state->socketPath.string()};
+            OsStrings args = {"ssh", hostnameAndUser.c_str(), "-M", "-N"};
             if (verbosity >= lvlChatty)
                 args.push_back("-v");
-            addCommonSSHOpts(args);
+            addCommonSSHOpts(args, state->socketPath);
             auto env = createSSHEnv();
             nix::execvpe(args.begin()->c_str(), stringsToCharPtrs(args).data(), stringsToCharPtrs(env).data());
 

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -116,9 +116,12 @@ void SSHMaster::addCommonSSHOpts(OsStrings & args)
     args.push_back(OS_STR("-oLocalCommand=echo started"));
 }
 
-bool SSHMaster::isMasterRunning()
+bool SSHMaster::isMasterRunning(std::filesystem::path socketPath)
 {
-    OsStrings args = {OS_STR("-O"), OS_STR("check"), string_to_os_string(hostnameAndUser)};
+    assert(useMaster);
+
+    OsStrings args = {
+        OS_STR("-O"), OS_STR("check"), string_to_os_string(hostnameAndUser), OS_STR("-S"), socketPath.string()};
     addCommonSSHOpts(args);
 
     auto res = runProgram(RunOptions{.program = "ssh", .args = std::move(args), .mergeStderrToStdout = true});
@@ -151,7 +154,7 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(OsStrings && comm
 #ifdef _WIN32 // TODO re-enable on Windows, once we can start processes.
     throw UnimplementedError("cannot yet SSH on windows because spawning processes is not yet implemented");
 #else
-    std::filesystem::path socketPath = startMaster();
+    auto socketPath = startMaster();
 
     Pipe in, out;
     in.create();
@@ -185,8 +188,7 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(OsStrings && comm
             if (!fakeSSH) {
                 args = {"ssh", hostnameAndUser.c_str(), "-x"};
                 addCommonSSHOpts(args);
-                if (!socketPath.empty())
-                    args.insert(args.end(), {"-S", socketPath.string()});
+                args.insert(args.end(), {"-S", socketPath ? socketPath->string() : "none"});
                 if (verbosity >= lvlChatty)
                     args.push_back("-v");
                 args.splice(args.end(), std::move(extraSshArgs));
@@ -207,7 +209,7 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(OsStrings && comm
 
     // Wait for the SSH connection to be established,
     // So that we don't overwrite the password prompt with our progress bar.
-    if (!fakeSSH && !useMaster && !isMasterRunning()) {
+    if (!fakeSSH && !(socketPath && isMasterRunning(*socketPath))) {
         std::string reply;
         try {
             reply = readLine(out.readSide.get());
@@ -229,10 +231,10 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(OsStrings && comm
 
 #ifndef _WIN32 // TODO re-enable on Windows, once we can start processes.
 
-std::filesystem::path SSHMaster::startMaster()
+std::optional<std::filesystem::path> SSHMaster::startMaster()
 {
     if (!useMaster)
-        return {};
+        return std::nullopt;
 
     auto state(state_.lock());
 
@@ -249,7 +251,7 @@ std::filesystem::path SSHMaster::startMaster()
 
     auto suspension = logger->suspend();
 
-    if (isMasterRunning())
+    if (isMasterRunning(state->socketPath))
         return state->socketPath;
 
     state->sshMaster = startProcess(


### PR DESCRIPTION
## Motivation

Updated version of https://github.com/NixOS/nix/pull/15351 and https://github.com/DeterminateSystems/nix-src/pull/311 to fix SSH connection sharing using a master connection.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved SSH master connection handling by enhancing control socket support.
  * When a socket path is configured, the system reuses the SSH master via the specified control socket; when not configured, it behaves as a non-multiplexed flow.
  * Connection-establishment checks were updated to align with whether a control socket is in use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->