### PR TITLE
Make LocalStore::optimisePath_() non-recursive

### DIFF
--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -100,194 +100,210 @@ Strings LocalStore::readDirectoryIgnoringInodes(const std::filesystem::path & pa
 }
 
 void LocalStore::optimisePath_(
-    Activity * act, OptimiseStats & stats, const std::filesystem::path & path, InodeHash & inodeHash, RepairFlag repair)
+    Activity * act,
+    OptimiseStats & stats,
+    const std::filesystem::path & path_,
+    InodeHash & inodeHash,
+    RepairFlag repair)
 {
-    checkInterrupt();
+    /* Walk the tree iteratively rather than recursively: a deeply nested
+       store path (e.g. a large source tree) could otherwise overflow the
+       stack, which is especially likely when this runs on a small
+       coroutine stack (e.g. via addToStoreFromDump's sourceToSink). */
+    std::vector<std::filesystem::path> stack;
+    stack.push_back(path_);
 
-    auto st = lstat(path);
+    while (!stack.empty()) {
+        auto path = std::move(stack.back());
+        stack.pop_back();
+
+        checkInterrupt();
+
+        auto st = lstat(path);
 
 #ifdef __APPLE__
-    /* HFS/macOS has some undocumented security feature disabling hardlinking for
-       special files within .app dirs. Known affected paths include
-       *.app/Contents/{PkgInfo,Resources/\*.lproj,_CodeSignature} and .DS_Store.
-       See https://github.com/NixOS/nix/issues/1443 and
-       https://github.com/NixOS/nix/pull/2230 for more discussion. */
+        /* HFS/macOS has some undocumented security feature disabling hardlinking for
+           special files within .app dirs. Known affected paths include
+           *.app/Contents/{PkgInfo,Resources/\*.lproj,_CodeSignature} and .DS_Store.
+           See https://github.com/NixOS/nix/issues/1443 and
+           https://github.com/NixOS/nix/pull/2230 for more discussion. */
 
-    if (std::regex_search(path.string(), std::regex("\\.app/Contents/.+$"))) {
-        debug("%s is not allowed to be linked in macOS", PathFmt(path));
-        return;
-    }
-#endif
-
-    if (S_ISDIR(st.st_mode)) {
-        Strings names = readDirectoryIgnoringInodes(path, inodeHash);
-        for (auto & i : names)
-            optimisePath_(act, stats, path / i, inodeHash, repair);
-        return;
-    }
-
-    /* We can hard link regular files and maybe symlinks. */
-    if (!S_ISREG(st.st_mode)
-#if CAN_LINK_SYMLINK
-        && !S_ISLNK(st.st_mode)
-#endif
-    )
-        return;
-
-    /* Sometimes SNAFUs can cause files in the Nix store to be
-       modified, in particular when running programs as root under
-       NixOS (example: $fontconfig/var/cache being modified).  Skip
-       those files.  FIXME: check the modification time. */
-    if (S_ISREG(st.st_mode) && (st.st_mode & S_IWUSR)) {
-        warn("skipping suspicious writable file '%s'", PathFmt(path));
-        return;
-    }
-
-    /* This can still happen on top-level files. */
-    if (st.st_nlink > 1 && inodeHash.count(st.st_ino)) {
-        debug("%s is already linked, with %d other file(s)", PathFmt(path), st.st_nlink - 2);
-        return;
-    }
-
-    /* Hash the file.  Note that hashPath() returns the hash over the
-       NAR serialisation, which includes the execute bit on the file.
-       Thus, executable and non-executable files with the same
-       contents *won't* be linked (which is good because otherwise the
-       permissions would be screwed up).
-
-       Also note that if `path' is a symlink, then we're hashing the
-       contents of the symlink (i.e. the result of readlink()), not
-       the contents of the target (which may not even exist). */
-    Hash hash = ({
-        hashPath(
-            {make_ref<PosixSourceAccessor>(), CanonPath(path.string())},
-            FileSerialisationMethod::NixArchive,
-            HashAlgorithm::SHA256)
-            .hash;
-    });
-    debug("%s has hash '%s'", PathFmt(path), hash.to_string(HashFormat::Nix32, true));
-
-    /* Check if this is a known hash. */
-    std::filesystem::path linkPath = std::filesystem::path{linksDir} / hash.to_string(HashFormat::Nix32, false);
-
-    /* Maybe delete the link, if it has been corrupted. */
-    if (std::filesystem::exists(std::filesystem::symlink_status(linkPath))) {
-        auto stLink = lstat(linkPath);
-        if (st.st_size != stLink.st_size || (repair && hash != ({
-                                                           hashPath(
-                                                               makeFSSourceAccessor(linkPath),
-                                                               FileSerialisationMethod::NixArchive,
-                                                               HashAlgorithm::SHA256)
-                                                               .hash;
-                                                       }))) {
-            // XXX: Consider overwriting linkPath with our valid version.
-            warn("removing corrupted link %s", PathFmt(linkPath));
-            warn(
-                "There may be more corrupted paths."
-                "\nYou should run `nix-store --verify --check-contents --repair` to fix them all");
-            std::filesystem::remove(linkPath);
+        if (std::regex_search(path.string(), std::regex("\\.app/Contents/.+$"))) {
+            debug("%s is not allowed to be linked in macOS", PathFmt(path));
+            continue;
         }
-    }
+#endif
 
-    if (!std::filesystem::exists(std::filesystem::symlink_status(linkPath))) {
-        /* Nope, create a hard link in the links directory. */
+        if (S_ISDIR(st.st_mode)) {
+            Strings names = readDirectoryIgnoringInodes(path, inodeHash);
+            for (auto & i : names)
+                stack.push_back(path / i);
+            continue;
+        }
+
+        /* We can hard link regular files and maybe symlinks. */
+        if (!S_ISREG(st.st_mode)
+#if CAN_LINK_SYMLINK
+            && !S_ISLNK(st.st_mode)
+#endif
+        )
+            continue;
+
+        /* Sometimes SNAFUs can cause files in the Nix store to be
+           modified, in particular when running programs as root under
+           NixOS (example: $fontconfig/var/cache being modified).  Skip
+           those files.  FIXME: check the modification time. */
+        if (S_ISREG(st.st_mode) && (st.st_mode & S_IWUSR)) {
+            warn("skipping suspicious writable file '%s'", PathFmt(path));
+            continue;
+        }
+
+        /* This can still happen on top-level files. */
+        if (st.st_nlink > 1 && inodeHash.count(st.st_ino)) {
+            debug("%s is already linked, with %d other file(s)", PathFmt(path), st.st_nlink - 2);
+            continue;
+        }
+
+        /* Hash the file.  Note that hashPath() returns the hash over the
+           NAR serialisation, which includes the execute bit on the file.
+           Thus, executable and non-executable files with the same
+           contents *won't* be linked (which is good because otherwise the
+           permissions would be screwed up).
+
+           Also note that if `path' is a symlink, then we're hashing the
+           contents of the symlink (i.e. the result of readlink()), not
+           the contents of the target (which may not even exist). */
+        Hash hash = ({
+            hashPath(
+                {make_ref<PosixSourceAccessor>(), CanonPath(path.string())},
+                FileSerialisationMethod::NixArchive,
+                HashAlgorithm::SHA256)
+                .hash;
+        });
+        debug("%s has hash '%s'", PathFmt(path), hash.to_string(HashFormat::Nix32, true));
+
+        /* Check if this is a known hash. */
+        std::filesystem::path linkPath = std::filesystem::path{linksDir} / hash.to_string(HashFormat::Nix32, false);
+
+        /* Maybe delete the link, if it has been corrupted. */
+        if (std::filesystem::exists(std::filesystem::symlink_status(linkPath))) {
+            auto stLink = lstat(linkPath);
+            if (st.st_size != stLink.st_size || (repair && hash != ({
+                                                               hashPath(
+                                                                   makeFSSourceAccessor(linkPath),
+                                                                   FileSerialisationMethod::NixArchive,
+                                                                   HashAlgorithm::SHA256)
+                                                                   .hash;
+                                                           }))) {
+                // XXX: Consider overwriting linkPath with our valid version.
+                warn("removing corrupted link %s", PathFmt(linkPath));
+                warn(
+                    "There may be more corrupted paths."
+                    "\nYou should run `nix-store --verify --check-contents --repair` to fix them all");
+                std::filesystem::remove(linkPath);
+            }
+        }
+
+        if (!std::filesystem::exists(std::filesystem::symlink_status(linkPath))) {
+            /* Nope, create a hard link in the links directory. */
+            try {
+                std::filesystem::create_hard_link(path, linkPath);
+                inodeHash.insert(st.st_ino);
+            } catch (std::filesystem::filesystem_error & e) {
+                if (e.code() == std::errc::file_exists) {
+                    /* Fall through if another process created ‘linkPath’ before
+                       we did. */
+                }
+
+                else if (e.code() == std::errc::no_space_on_device) {
+                    /* On ext4, that probably means the directory index is
+                       full.  When that happens, it's fine to ignore it: we
+                       just effectively disable deduplication of this
+                       file.
+                       */
+                    printInfo("cannot link %s to '%s': %s", PathFmt(linkPath), PathFmt(path), e.code().message());
+                    continue;
+                }
+
+                else
+                    throw SystemError(e.code(), "creating hard link from %1% to %2%", PathFmt(linkPath), PathFmt(path));
+            }
+        }
+
+        /* Yes!  We've seen a file with the same contents.  Replace the
+           current file with a hard link to that file. */
+        auto stLink = lstat(linkPath);
+
+        if (st.st_ino == stLink.st_ino) {
+            debug("%1% is already linked to %2%", PathFmt(path), PathFmt(linkPath));
+            continue;
+        }
+
+        printMsg(lvlTalkative, "linking %1% to %2%", PathFmt(path), PathFmt(linkPath));
+
+        /* Make the containing directory writable, but only if it's not
+           the store itself (we don't want or need to mess with its
+           permissions). */
+        const auto dirOfPath = path.parent_path();
+        bool mustToggle = dirOfPath != config->realStoreDir.get();
+        if (mustToggle)
+            makeWritable(dirOfPath);
+
+        /* When we're done, make the directory read-only again and reset
+           its timestamp back to 0. */
+        MakeReadOnly makeReadOnly(mustToggle ? dirOfPath : std::filesystem::path{});
+
+        std::filesystem::path tempLink = makeTempPath(config->realStoreDir.get(), ".tmp-link");
+
         try {
-            std::filesystem::create_hard_link(path, linkPath);
+            std::filesystem::create_hard_link(linkPath, tempLink);
             inodeHash.insert(st.st_ino);
         } catch (std::filesystem::filesystem_error & e) {
-            if (e.code() == std::errc::file_exists) {
-                /* Fall through if another process created ‘linkPath’ before
-                   we did. */
+            if (e.code() == std::errc::too_many_links) {
+                /* Too many links to the same file (>= 32000 on most file
+                   systems).  This is likely to happen with empty files.
+                   Just shrug and ignore. */
+                if (st.st_size)
+                    printInfo("%1% has maximum number of links", PathFmt(linkPath));
+                continue;
             }
+            throw SystemError(e.code(), "creating hard link from %1% to %2%", PathFmt(linkPath), PathFmt(tempLink));
+        }
 
-            else if (e.code() == std::errc::no_space_on_device) {
-                /* On ext4, that probably means the directory index is
-                   full.  When that happens, it's fine to ignore it: we
-                   just effectively disable deduplication of this
-                   file.
-                   */
-                printInfo("cannot link %s to '%s': %s", PathFmt(linkPath), PathFmt(path), e.code().message());
-                return;
+        /* Atomically replace the old file with the new hard link. */
+        try {
+            std::filesystem::rename(tempLink, path);
+        } catch (std::filesystem::filesystem_error & e) {
+            {
+                std::error_code ec;
+                remove(tempLink, ec); /* Clean up after ourselves. */
+                if (ec)
+                    printError("unable to unlink %1%: %2%", PathFmt(tempLink), ec.message());
             }
-
-            else
-                throw SystemError(e.code(), "creating hard link from %1% to %2%", PathFmt(linkPath), PathFmt(path));
+            if (e.code() == std::errc::too_many_links) {
+                /* Some filesystems generate too many links on the rename,
+                   rather than on the original link.  (Probably it
+                   temporarily increases the st_nlink field before
+                   decreasing it again.) */
+                debug("%s has reached maximum number of links", PathFmt(linkPath));
+                continue;
+            }
+            throw SystemError(e.code(), "renaming %1% to %2%", PathFmt(tempLink), PathFmt(path));
         }
-    }
 
-    /* Yes!  We've seen a file with the same contents.  Replace the
-       current file with a hard link to that file. */
-    auto stLink = lstat(linkPath);
+        stats.filesLinked++;
+        stats.bytesFreed += st.st_size;
 
-    if (st.st_ino == stLink.st_ino) {
-        debug("%1% is already linked to %2%", PathFmt(path), PathFmt(linkPath));
-        return;
-    }
-
-    printMsg(lvlTalkative, "linking %1% to %2%", PathFmt(path), PathFmt(linkPath));
-
-    /* Make the containing directory writable, but only if it's not
-       the store itself (we don't want or need to mess with its
-       permissions). */
-    const auto dirOfPath = path.parent_path();
-    bool mustToggle = dirOfPath != config->realStoreDir.get();
-    if (mustToggle)
-        makeWritable(dirOfPath);
-
-    /* When we're done, make the directory read-only again and reset
-       its timestamp back to 0. */
-    MakeReadOnly makeReadOnly(mustToggle ? dirOfPath : std::filesystem::path{});
-
-    std::filesystem::path tempLink = makeTempPath(config->realStoreDir.get(), ".tmp-link");
-
-    try {
-        std::filesystem::create_hard_link(linkPath, tempLink);
-        inodeHash.insert(st.st_ino);
-    } catch (std::filesystem::filesystem_error & e) {
-        if (e.code() == std::errc::too_many_links) {
-            /* Too many links to the same file (>= 32000 on most file
-               systems).  This is likely to happen with empty files.
-               Just shrug and ignore. */
-            if (st.st_size)
-                printInfo("%1% has maximum number of links", PathFmt(linkPath));
-            return;
-        }
-        throw SystemError(e.code(), "creating hard link from %1% to %2%", PathFmt(linkPath), PathFmt(tempLink));
-    }
-
-    /* Atomically replace the old file with the new hard link. */
-    try {
-        std::filesystem::rename(tempLink, path);
-    } catch (std::filesystem::filesystem_error & e) {
-        {
-            std::error_code ec;
-            remove(tempLink, ec); /* Clean up after ourselves. */
-            if (ec)
-                printError("unable to unlink %1%: %2%", PathFmt(tempLink), ec.message());
-        }
-        if (e.code() == std::errc::too_many_links) {
-            /* Some filesystems generate too many links on the rename,
-               rather than on the original link.  (Probably it
-               temporarily increases the st_nlink field before
-               decreasing it again.) */
-            debug("%s has reached maximum number of links", PathFmt(linkPath));
-            return;
-        }
-        throw SystemError(e.code(), "renaming %1% to %2%", PathFmt(tempLink), PathFmt(path));
-    }
-
-    stats.filesLinked++;
-    stats.bytesFreed += st.st_size;
-
-    if (act)
-        act->result(
-            resFileLinked,
-            st.st_size
+        if (act)
+            act->result(
+                resFileLinked,
+                st.st_size
 #ifndef _WIN32
-            ,
-            st.st_blocks
+                ,
+                st.st_blocks
 #endif
-        );
+            );
+    }
 }
 
 void LocalStore::optimiseStore(OptimiseStats & stats)


### PR DESCRIPTION

## Motivation

I encountered this failure during a test:

```
$ nix-instantiate --store /tmp/nix-gc-test '<nixpkgs>' -A hello --add-root x --auto-optimise-store
error: stack overflow (possible infinite recursion)
```

This turned out to be due to the recursion in `optimisePath_()` when called from a coroutine (which has a small stack):

```
  #0  0x00007ffff7e3e45d in nix::drainFD (fd=0, sink=..., opts=...) at ../src/libutil/file-descriptor.cc:131
  #1  0x00007ffff7ee6369 in nix::PosixSourceAccessor::readFile (this=0x55555617e2d0, path=..., sink=..., sizeCallback=...) at ../src/libutil/posix-source-accessor.cc:66
  #2  0x00007ffff7d38ad5 in nix::SourceAccessor::dumpPath(nix::CanonPath const&, nix::Sink&, nix::fun<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>&)::$_0::operator()(nix::CanonPath const&) const (this=0x7fffa7d64978, path=...) at ../src/libutil/archive.cc:48
  #3  0x00007ffff7d36efc in nix::SourceAccessor::dumpPath(nix::CanonPath const&, nix::Sink&, nix::fun<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>&)::$_1::operator()<$_1>(this $_1 const&, nix::CanonPath const&, unsigned long) (dump=..., path=..., depth=0) at ../src/libutil/archive.cc:72
  #4  0x00007ffff7d36bec in nix::SourceAccessor::dumpPath (this=0x55555617e310, path=..., sink=..., filter=...) at ../src/libutil/archive.cc:58
  #5  0x00007ffff7f1e3fa in nix::SourcePath::dumpPath (this=0x7fffa7d65f90, sink=..., filter=...) at ../src/libutil/source-path.cc:49
  #6  0x00007ffff7e3cb85 in nix::dumpPath (path=..., sink=..., method=nix::FileSerialisationMethod::NixArchive, filter=...) at ../src/libutil/file-content-address.cc:73
  #7  0x00007ffff7e3ccbd in nix::hashPath (path=..., method=nix::FileSerialisationMethod::NixArchive, ha=nix::HashAlgorithm::SHA256, filter=...) at ../src/libutil/file-content-address.cc:93
  #8  0x00007ffff763f02f in nix::LocalStore::optimisePath_ (this=0x555555eaeb00, act=0x0, stats=..., path=Python Exception <class 'gdb.error'>: No type named std::filesystem::__cxx11::path::_Cmpt.

      filesystem::path "/tmp/nix-gc-test/nix/store/9figz32vbiblaw5x3li1hc8q9qwlwf27-source/pkgs/desktops/pantheon/libraries/granite/7/default.nix", inodeHash=..., repair=nix::NoRepair)
      at ../src/libstore/optimise-store.cc:162
  #9  0x00007ffff763e70b in nix::LocalStore::optimisePath_ (this=0x555555eaeb00, act=0x0, stats=..., path=Python Exception <class 'gdb.error'>: No type named std::filesystem::__cxx11::path::_Cmpt.

      filesystem::path "/tmp/nix-gc-test/nix/store/9figz32vbiblaw5x3li1hc8q9qwlwf27-source/pkgs/desktops/pantheon/libraries/granite/7", inodeHash=..., repair=nix::NoRepair)
      at ../src/libstore/optimise-store.cc:125
  ...
  #25 0x00007ffff7f058ad in nix::sourceToSink(nix::fun<void (nix::Source&)>)::SourceToSink::operator()(std::basic_string_view<char, std::char_traits<char> >)::{lambda(boost::coroutines2::detail::pull_coroutine<bool>&)#1}::operator()(boost::coroutines2::detail::pull_coroutine<bool>&) const (this=0x7fffa7d73c98, yield=...) at ../src/libutil/serialise.cc:361
  ...
  #32 0x00007ffff3af918f in make_fcontext () from /nix/store/5xkyx9gi1s8mqp1ki1hsx8hwpr4dncxk-boost-1.87.0/lib/libboost_context.so.1.87.0
```

So let's make `optimisePath_()` non-recursive to ensure constant stack space.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of store optimization logic with no changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->