### PR TITLE
LocalStore::doAddToStore(): Check NAR size before NAR hash

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1060,19 +1060,19 @@ void LocalStore::doAddToStore(const ValidPathInfo & info, Source & source, Repai
 
     auto hashResult = hashSink.finish();
 
-    if (hashResult.hash != info.narHash)
-        throw Error(
-            "hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",
-            printStorePath(info.path),
-            info.narHash.to_string(HashFormat::SRI, true),
-            hashResult.hash.to_string(HashFormat::SRI, true));
-
     if (hashResult.numBytesDigested != info.narSize)
         throw Error(
             "size mismatch importing path '%s';\n  specified: %s\n  got:       %s",
             printStorePath(info.path),
             info.narSize,
             hashResult.numBytesDigested);
+
+    if (hashResult.hash != info.narHash)
+        throw Error(
+            "hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",
+            printStorePath(info.path),
+            info.narHash.to_string(HashFormat::SRI, true),
+            hashResult.hash.to_string(HashFormat::SRI, true));
 
     if (info.ca) {
         auto & specified = *info.ca;

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -158,13 +158,26 @@ wait "$pid2"
 [[ $(cat "$TEST_ROOT/log1" "$TEST_ROOT/log2" | grep -c "downloading.*nar'") -eq 1 ]]
 
 
-# Test whether Nix notices if the NAR doesn't match the hash in the NAR info.
+# Test whether Nix notices if the NAR doesn't match the file size in the NAR info.
 clearStore
 
 nar=$cacheDir/$(nix path-info --json --store "file://$cacheDir" "$depPath" | jq -r .[].url)
 mv "$nar" "$nar".good
 mkdir -p "$TEST_ROOT/empty"
 nix-store --dump "$TEST_ROOT/empty" | xz > "$nar"
+
+expect 1 nix-build --substituters "$httpBinaryCacheUrl" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" 2>&1 | tee "$TEST_ROOT/log"
+grepQuiet "size mismatch" "$TEST_ROOT/log"
+
+mv "$nar".good "$nar"
+
+
+# Test whether Nix notices if the NAR doesn't match the hash in the NAR info.
+clearStore
+
+nar=$cacheDir/$(nix path-info --json --store "file://$cacheDir" "$depPath" | jq -r .[].url)
+mv "$nar" "$nar".good
+xz -cd <"$nar".good | sed 's/foo/Foo/' | xz -c >"$nar"
 
 expect 1 nix-build --substituters "$httpBinaryCacheUrl" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" 2>&1 | tee "$TEST_ROOT/log"
 grepQuiet "hash mismatch" "$TEST_ROOT/log"


### PR DESCRIPTION
If the file size is wrong, the hash is almost certainly wrong. Checking the size first provides useful information that is not shown otherwise.

Size mismatch indicates issues like truncated files, whereas hash mismatch for the matching file size suggests data corruption. Reporting the correct condition helps troubleshoot the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation order for binary cache integrity checks to detect size mismatches before hash mismatches.

* **Tests**
  * Added regression test for NAR size mismatch detection in binary cache.
  * Enhanced hash mismatch regression test with improved corruption method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->