### PR TITLE
Increase the sourceToSink/sinkToSource coroutine stack sizes

### DIFF
--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -34,8 +34,7 @@ static GlobalConfig::Register rArchiveSettings(&archiveSettings);
 
 /* Maximum directory nesting depth for dumpPath()/parseDump(). Bounds
    stack usage so deep trees cannot overflow the (possibly coroutine)
-   stack these run on. Chosen to fit comfortably in the default 128 KiB
-   boost coroutine stack. */
+   stack these run on. */
 static constexpr size_t narMaxDepth = 64;
 
 PathFilter defaultPathFilter = [](const std::string &) { return true; };

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -322,6 +322,13 @@ CompressedSource::CompressedSource(RestartableSource & source, CompressionAlgo c
 {
 }
 
+/* 512KiB is a conservative estimate for deeply nested NARs, which are limited
+   to 64 levels. We also tend to allocate rather large buffers on the stack, so
+   we should leave plenty of headroom. Note that no evaluation is supposed to
+   happen on sourceToSink/sinkToSource coroutine stacks (for Boehm GC reasons),
+   which requires much more stack space. */
+static constexpr size_t defaultCoroutineStackSize = 512 * 1024;
+
 std::unique_ptr<FinishSink> sourceToSink(fun<void(Source &)> reader)
 {
     struct SourceToSink : FinishSink
@@ -345,8 +352,9 @@ std::unique_ptr<FinishSink> sourceToSink(fun<void(Source &)> reader)
             cur = in;
 
             if (!coro) {
-                coro =
-                    coro_t::push_type(boost::coroutines2::protected_fixedsize_stack(), [&](coro_t::pull_type & yield) {
+                coro = coro_t::push_type(
+                    boost::coroutines2::protected_fixedsize_stack(defaultCoroutineStackSize),
+                    [&](coro_t::pull_type & yield) {
                         LambdaSource source([&](char * out, size_t out_len) {
                             if (cur.empty()) {
                                 yield();
@@ -403,8 +411,9 @@ std::unique_ptr<Source> sinkToSource(fun<void(Sink &)> writer, fun<void()> eof)
         {
             bool hasCoro = coro.has_value();
             if (!hasCoro) {
-                coro =
-                    coro_t::pull_type(boost::coroutines2::protected_fixedsize_stack(), [&](coro_t::push_type & yield) {
+                coro = coro_t::pull_type(
+                    boost::coroutines2::protected_fixedsize_stack(defaultCoroutineStackSize),
+                    [&](coro_t::push_type & yield) {
                         LambdaSink sink([&](std::string_view data) {
                             if (!data.empty()) {
                                 yield(data);


### PR DESCRIPTION

## Motivation

Upstream https://github.com/NixOS/nix/pull/16027.

We had too little headroom previously, since the default stack size if 128KiB and half of that is typically consumed by a 64KiB buffer for copying between Source/Sink.

512KiB should be more than enough for the limit that we have (64 levels in NARs , which usually also bounds the recursion depth with some constant factor).


<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated comments describing archive handling behavior.

* **Chores**
  * Optimized memory stack allocation for internal data processing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->