### PR TITLE
LocalStore::doAddToStore(): Check NAR size before NAR hash

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1060,19 +1060,19 @@ void LocalStore::doAddToStore(const ValidPathInfo & info, Source & source, Repai
 
     auto hashResult = hashSink.finish();
 
-    if (hashResult.hash != info.narHash)
-        throw Error(
-            "hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",
-            printStorePath(info.path),
-            info.narHash.to_string(HashFormat::SRI, true),
-            hashResult.hash.to_string(HashFormat::SRI, true));
-
     if (hashResult.numBytesDigested != info.narSize)
         throw Error(
             "size mismatch importing path '%s';\n  specified: %s\n  got:       %s",
             printStorePath(info.path),
             info.narSize,
             hashResult.numBytesDigested);
+
+    if (hashResult.hash != info.narHash)
+        throw Error(
+            "hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",
+            printStorePath(info.path),
+            info.narHash.to_string(HashFormat::SRI, true),
+            hashResult.hash.to_string(HashFormat::SRI, true));
 
     if (info.ca) {
         auto & specified = *info.ca;

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -158,13 +158,26 @@ wait "$pid2"
 [[ $(cat "$TEST_ROOT/log1" "$TEST_ROOT/log2" | grep -c "downloading.*nar'") -eq 1 ]]
 
 
-# Test whether Nix notices if the NAR doesn't match the hash in the NAR info.
+# Test whether Nix notices if the NAR doesn't match the file size in the NAR info.
 clearStore
 
 nar=$cacheDir/$(nix path-info --json --store "file://$cacheDir" "$depPath" | jq -r .[].url)
 mv "$nar" "$nar".good
 mkdir -p "$TEST_ROOT/empty"
 nix-store --dump "$TEST_ROOT/empty" | xz > "$nar"
+
+expect 1 nix-build --substituters "$httpBinaryCacheUrl" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" 2>&1 | tee "$TEST_ROOT/log"
+grepQuiet "size mismatch" "$TEST_ROOT/log"
+
+mv "$nar".good "$nar"
+
+
+# Test whether Nix notices if the NAR doesn't match the hash in the NAR info.
+clearStore
+
+nar=$cacheDir/$(nix path-info --json --store "file://$cacheDir" "$depPath" | jq -r .[].url)
+mv "$nar" "$nar".good
+xz -cd <"$nar".good | sed 's/foo/Foo/' | xz -c >"$nar"
 
 expect 1 nix-build --substituters "$httpBinaryCacheUrl" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" 2>&1 | tee "$TEST_ROOT/log"
 grepQuiet "hash mismatch" "$TEST_ROOT/log"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Same as #510, to get around our CI being broken for PRs from external contributors.

If the file size is wrong, the hash is almost certainly wrong. Checking the size first provides useful information that is not shown otherwise.

Size mismatch indicates issues like truncated files, whereas hash mismatch for the matching file size suggests data corruption. Reporting the correct condition helps troubleshoot the issue.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 

---

Closes #510 