### PR TITLE
Fix LocalStore::addMultipleToStore SinkToSource destructor unsoundness

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1248,6 +1248,13 @@ void LocalStore::addMultipleToStore(
 
             auto & info = item->first;
 
+            /* Make sure that the Source object is destroyed when
+               we're done. In particular, a SinkToSource object must
+               be destroyed to ensure that the destructors on its
+               stack frame are run; this includes
+               LegacySSHStore::narFromPath()'s connection lock. */
+            auto source = std::move(item->second);
+
             MaintainCount<decltype(nrRunning)> mc(nrRunning);
             showProgress();
 
@@ -1271,7 +1278,7 @@ void LocalStore::addMultipleToStore(
                 notice("reusing previously unpacked path at '%s'", printStorePath(info.path));
                 act.setExpected(actCopyPath, bytesExpected -= info.narSize);
             } else {
-                doAddToStore(info, *item->second, repair);
+                doAddToStore(info, *source, repair);
                 /* The path has been unpacked, so mark it as such. */
                 writeFile(unpackedMarker, "");
             }


### PR DESCRIPTION
c.f. https://github.com/DeterminateSystems/nix-src/pull/480#discussion_r3429473700
Picked from https://github.com/Shopify/tecnix/commit/08bee037eb243b1c02c56629fc7ca4d2852c5f10

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Thanks @lilyinstarlight!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup in batch storage operations for enhanced stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->