### PR TITLE
Fix exceptions not being caught in nix::Pid::~Pid

### DIFF
--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -51,11 +51,13 @@ Pid::Pid(pid_t pid)
 }
 
 Pid::~Pid()
-try {
-    if (pid != -1)
-        kill(/*allowInterrupts=*/false);
-} catch (...) {
-    ignoreExceptionInDestructor();
+{
+    try {
+        if (pid != -1)
+            kill(/*allowInterrupts=*/false);
+    } catch (...) {
+        ignoreExceptionInDestructor();
+    }
 }
 
 void Pid::operator=(pid_t pid)


### PR DESCRIPTION
Using function try blocks with destructors causes the exception to be rethrown instead of properly caught.

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

ref: https://github.com/Shopify/tecnix/commit/f59d310168acf48a57d5b031bceeccf570229189, https://github.com/NixOS/nix/pull/16031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvement with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->