### PR TITLE
Allow local networking in libmicrohttpd and functional tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
 
   build_x86_64-linux:
     uses: ./.github/workflows/build.yml
+    # Determinate Secure Packages is a private flake dependency that external
+    # (fork) contributors can't access, so only build it for non-fork PRs.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'DeterminateSystems/nix-src'
     with:
       system: x86_64-linux
       runner: namespace-profile-linuxamd32c64g-cache
@@ -50,7 +53,9 @@ jobs:
 
   build_x86_64-linux_no_dsp:
     uses: ./.github/workflows/build.yml
-    if: github.event_name == 'merge_group'
+    # Build the non-DSP flake in the merge queue and for external (fork) PRs,
+    # which can't access Determinate Secure Packages.
+    if: github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'DeterminateSystems/nix-src')
     with:
       flake: .
       system: x86_64-linux
@@ -64,6 +69,7 @@ jobs:
 
   build_aarch64-linux:
     uses: ./.github/workflows/build.yml
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'DeterminateSystems/nix-src'
     with:
       system: aarch64-linux
       runner: UbuntuLatest32Cores128GArm
@@ -76,7 +82,7 @@ jobs:
 
   build_aarch64-linux_no_dsp:
     uses: ./.github/workflows/build.yml
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'DeterminateSystems/nix-src')
     with:
       flake: .
       system: aarch64-linux
@@ -91,6 +97,7 @@ jobs:
 
   build_aarch64-darwin:
     uses: ./.github/workflows/build.yml
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'DeterminateSystems/nix-src'
     with:
       system: aarch64-darwin
       runner: namespace-profile-mac-m2-12c28g
@@ -103,7 +110,7 @@ jobs:
 
   build_aarch64-darwin_no_dsp:
     uses: ./.github/workflows/build.yml
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'DeterminateSystems/nix-src')
     with:
       flake: .
       system: aarch64-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,7 @@ jobs:
           path: downloaded
       - name: Move downloaded artifacts to artifacts directory
         run: |
+          shopt -s nullglob
           for dir in ./downloaded/*; do
             arch="$(basename "$dir")"
             mv "$dir"/*.xz ./artifacts/"${arch}"

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -151,5 +151,8 @@ scope: {
   libmicrohttpd = pkgs.libmicrohttpd.overrideDerivation (old: {
     # Don't pull in gnutls since it's pretty big and we don't need it.
     configureFlags = old.configureFlags or [ ] ++ [ "--without-gnutls" ];
+
+    # Required for configuration detection for getsockname (for automatic port allocation for `nix serve`)
+    __darwinAllowLocalNetworking = true;
   });
 }

--- a/tests/functional/package.nix
+++ b/tests/functional/package.nix
@@ -100,6 +100,9 @@ mkMesonDerivation (
 
     _NIX_TEST_EXTRA_CONFIG = lib.optionalString lazyTrees "lazy-trees = true";
 
+    # Required for HTTP `nix serve`-based tests in binary-cache.sh
+    __darwinAllowLocalNetworking = true;
+
     meta = {
       platforms = lib.platforms.unix;
     };


### PR DESCRIPTION
## Motivation

Functional tests cannot currently be built by Darwin when the sandbox is enabled after #428 because localhost port binds (used by the functional tests for `nix serve` testing in `tests/functional/binary-cache.sh`) require `__darwinAllowLocalNetworking = true` on the `nix-functional-tests` derivation

This is additionally required on the `libmicrohttpd` derivation because when building it on Darwin with the sandbox enabled, it does a configure check for `getsockbyname`[1] that requires `bind`ing and if that fails (and the `MHD_USE_GETSOCKNAME` feature therefore gets disabled), then the functionality that allows binding to a random port and getting back the port number actually bound for the HTTP daemon[2] is disabled (and Determinate Nix uses this functionality[3] to determine the port number when passed `--port 0`, in particular in its functional tests for `nix serve`[4])

## Context

References:
[1]: https://github.com/Karlson2k/libmicrohttpd/blob/master/configure.ac#L2543-L2624
[2]: https://github.com/Karlson2k/libmicrohttpd/blob/d2375954a17f8a2aca323691d55ce7aa3d0336b9/src/microhttpd/daemon.c#L8548-L8633
[3]: https://github.com/DeterminateSystems/nix-src/blob/72c5eeb1d93009d9716ac0fd49ba5a9e034a3edc/src/nix/serve.cc#L279-L284
[4]: https://github.com/DeterminateSystems/nix-src/blob/72c5eeb1d93009d9716ac0fd49ba5a9e034a3edc/tests/functional/binary-cache.sh#L64-L76

We've had this shipped in Tecnix so that CI passes on Darwin: https://github.com/Shopify/tecnix/commit/13ef0d020b113ac274150662e3f4d72eba18687b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Enabled local networking support on macOS (Darwin) for both runtime and testing builds to improve compatibility with automatic port allocation.  
  * Updated CI job conditions to ensure secure-package (DSP) dependent builds only run for trusted events/sources, while still running non-DSP builds for forked pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->