### PR TITLE
Don't ignore substitution failures for BasicDerivation inputSrcs

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -99,7 +99,7 @@ Goal::Co DerivationBuildingGoal::gaveUpOnSubstitution(bool storeDerivation)
                 "dependency '%s' of '%s' does not exist, and substitution is disabled",
                 worker.store.printStorePath(i),
                 worker.store.printStorePath(drvPath));
-        waitees.insert(upcast_goal(worker.makePathSubstitutionGoal(i)));
+        waitees.insert(upcast_goal(worker.makePathSubstitutionGoal(i, true)));
     }
 
     co_await await(std::move(waitees));

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -122,6 +122,7 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
                 auto * cap = getDerivationCA(*drv);
                 waitees.insert(upcast_goal(worker.makePathSubstitutionGoal(
                     checkResult->first.outPath,
+                    false,
                     buildMode == bmRepair ? Repair : NoRepair,
                     cap ? std::optional{*cap} : std::nullopt)));
             }
@@ -376,7 +377,7 @@ Goal::Co DerivationGoal::repairClosure()
             worker.store.printStorePath(drvPath));
         auto drvPath2 = outputsToDrv.find(i);
         if (drvPath2 == outputsToDrv.end())
-            waitees.insert(upcast_goal(worker.makePathSubstitutionGoal(i, Repair)));
+            waitees.insert(upcast_goal(worker.makePathSubstitutionGoal(i, false, Repair)));
         else
             waitees.insert(worker.makeGoal(
                 DerivedPath::Built{

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -99,7 +99,7 @@ void Store::ensurePath(const StorePath & path)
         return;
 
     Worker worker(*this, *this);
-    GoalPtr goal = worker.makePathSubstitutionGoal(path);
+    GoalPtr goal = worker.makePathSubstitutionGoal(path, true);
     Goals goals = {goal};
 
     worker.run(goals);
@@ -114,7 +114,7 @@ void Store::ensurePath(const StorePath & path)
 void Store::repairPath(const StorePath & path)
 {
     Worker worker(*this, *this);
-    GoalPtr goal = worker.makePathSubstitutionGoal(path, Repair);
+    GoalPtr goal = worker.makePathSubstitutionGoal(path, true, Repair);
     Goals goals = {goal};
 
     worker.run(goals);

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -12,9 +12,14 @@
 namespace nix {
 
 PathSubstitutionGoal::PathSubstitutionGoal(
-    const StorePath & storePath, Worker & worker, RepairFlag repair, std::optional<ContentAddress> ca)
+    const StorePath & storePath,
+    Worker & worker,
+    bool pathRequired,
+    RepairFlag repair,
+    std::optional<ContentAddress> ca)
     : Goal(worker, init())
     , storePath(storePath)
+    , pathRequired(pathRequired)
     , repair(repair)
     , ca(ca)
 {
@@ -141,7 +146,7 @@ Goal::Co PathSubstitutionGoal::init()
            paths referenced by this one. */
         for (auto & i : info->references)
             if (i != storePath) /* ignore self-references */
-                waitees.insert(worker.makePathSubstitutionGoal(i));
+                waitees.insert(worker.makePathSubstitutionGoal(i, pathRequired));
 
         co_await await(std::move(waitees));
 
@@ -169,7 +174,7 @@ Goal::Co PathSubstitutionGoal::init()
        In that case the calling derivation should just do a
        build. */
     co_return doneFailure(
-        substituterFailed ? ecFailed : ecNoSubstituters,
+        substituterFailed || pathRequired ? ecFailed : ecNoSubstituters,
         BuildResult::Failure{{
             .status = BuildResult::Failure::NoSubstituters,
             .msg = HintFmt(

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -106,10 +106,10 @@ std::shared_ptr<DerivationBuildingGoal> Worker::makeDerivationBuildingGoal(
     return initGoalIfNeeded(derivationBuildingGoals[drvPath], drvPath, drv, *this, buildMode, storeDerivation);
 }
 
-std::shared_ptr<PathSubstitutionGoal>
-Worker::makePathSubstitutionGoal(const StorePath & path, RepairFlag repair, std::optional<ContentAddress> ca)
+std::shared_ptr<PathSubstitutionGoal> Worker::makePathSubstitutionGoal(
+    const StorePath & path, bool pathRequired, RepairFlag repair, std::optional<ContentAddress> ca)
 {
-    return initGoalIfNeeded(substitutionGoals[path], path, *this, repair, ca);
+    return initGoalIfNeeded(substitutionGoals[path], path, *this, pathRequired, repair, ca);
 }
 
 std::shared_ptr<DrvOutputSubstitutionGoal> Worker::makeDrvOutputSubstitutionGoal(const DrvOutput & id)
@@ -125,7 +125,7 @@ GoalPtr Worker::makeGoal(const DerivedPath & req, BuildMode buildMode)
                 return makeDerivationTrampolineGoal(bfd.drvPath, bfd.outputs, buildMode);
             },
             [&](const DerivedPath::Opaque & bo) -> GoalPtr {
-                return makePathSubstitutionGoal(bo.path, buildMode == bmRepair ? Repair : NoRepair);
+                return makePathSubstitutionGoal(bo.path, false, buildMode == bmRepair ? Repair : NoRepair);
             },
         },
         req.raw());

--- a/src/libstore/include/nix/store/build/substitution-goal.hh
+++ b/src/libstore/include/nix/store/build/substitution-goal.hh
@@ -19,6 +19,11 @@ struct PathSubstitutionGoal : public Goal
     StorePath storePath;
 
     /**
+     * Whether, if there are not substituters, to return ecNoSubstituters or ecFailed.
+     */
+    bool pathRequired;
+
+    /**
      * Whether to try to repair a valid path.
      */
     RepairFlag repair;
@@ -45,6 +50,7 @@ public:
     PathSubstitutionGoal(
         const StorePath & storePath,
         Worker & worker,
+        bool pathRequired,
         RepairFlag repair = NoRepair,
         std::optional<ContentAddress> ca = std::nullopt);
     ~PathSubstitutionGoal();

--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -235,7 +235,10 @@ public:
      * @ref PathSubstitutionGoal "substitution goal"
      */
     std::shared_ptr<PathSubstitutionGoal> makePathSubstitutionGoal(
-        const StorePath & storePath, RepairFlag repair = NoRepair, std::optional<ContentAddress> ca = std::nullopt);
+        const StorePath & storePath,
+        bool pathRequired = false,
+        RepairFlag repair = NoRepair,
+        std::optional<ContentAddress> ca = std::nullopt);
     std::shared_ptr<DrvOutputSubstitutionGoal> makeDrvOutputSubstitutionGoal(const DrvOutput & id);
 
     /**


### PR DESCRIPTION

## Motivation

Previously, substitution failures for the `inputSrcs` of `BasicDerivation` were silently ignored, leading to inscrutable " 1 dependency failed" errors.

You now get:

```
error: path '/nix/store/ksv7jr3gl2damnbnn6rcigrzh8wql0rc-missing-dependency' is required, but there is no substituter that can build it
error: Cannot build '/nix/store/vis7l3rjqbb75kimqds2cqbm4wkf3qa2-test.drv'.
Reason: 1 dependency failed.
Output paths:
  /nix/store/y600378sad3qj81vn46g1lavwp7scgzl-test
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how missing substitution inputs/outputs are handled: paths marked as required now fail hard instead of falling back to “no substituters” behavior.
  * Updated substitution-goal creation and propagation so required paths consistently surface failures during derivation and store path ensuring/repair flows.
  * Refined exit-status behavior for substitution failures to better reflect “required” semantics across the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->