### PR TITLE
fix: ssh socket hygiene

### DIFF
--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -259,8 +259,17 @@ std::optional<std::filesystem::path> SSHMaster::startMaster()
 
             close(out.readSide.get());
 
+            int nullFd = open("/dev/null", O_RDWR);
+            if (nullFd == -1)
+                throw SysError("opening /dev/null");
+
             if (dup2(out.writeSide.get(), STDOUT_FILENO) == -1)
                 throw SysError("duping over stdout");
+            if (dup2(nullFd, STDIN_FILENO) == -1)
+                throw SysError("duping over stdin");
+            if (dup2(logFD != -1 ? logFD : nullFd, STDERR_FILENO) == -1)
+                throw SysError("duping over stderr");
+            unix::closeExtraFDs();
 
             OsStrings args = {"ssh", hostnameAndUser.c_str(), "-M", "-N", "-oControlPersist=no"};
             if (verbosity >= lvlChatty)


### PR DESCRIPTION
## Motivation

I have experienced my nix builds getting stuck on reading from remote build hook, in `Worker::waitForInput()`, where it polls on the socket that belongs to the ssh master process, and waits for it to be EOF, but it never is, as the command is persistent ssh master.

I'm not sure if this is a symptom of a larger problem I have somewhere in my setup, but it seems that ssh master should not keep references to stdin/stderr of the remote build hook process (ssh master is only supposed to "echo started" here).

Unfortunately I'm not sure how to reproduce that.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH control master startup on non-Windows systems by cleaning up process input/output handling.
  * Reduced the chance of stray file descriptors being left open during launch, helping improve stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->