### PR TITLE
fixup: make binary cache nuclear option more general

### DIFF
--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -77,8 +77,8 @@ struct NarInfoDiskCacheSettings : public virtual Config
           To wipe the lookup cache completely:
 
           ```shell-session
-          $ rm $HOME/.cache/nix/binary-cache-v*.sqlite*
-          # rm /root/.cache/nix/binary-cache-v*.sqlite*
+          $ rm $HOME/.cache/nix/binary-cache-*.sqlite*
+          # rm /root/.cache/nix/binary-cache-*.sqlite*
           ```
         )"};
 


### PR DESCRIPTION
Recently, we added a `binary-cache-detsys-v1.sqlite` file, and these instructions would not remove that.

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the cache cleanup command in the `narinfo-cache-negative-ttl` setting notes.
  * Updated the example to remove all matching binary cache SQLite files, not just a narrower versioned subset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->