### PR TITLE
Fix INITIAL_MARK_STACK_SIZE override in boehm-gc

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -22,30 +22,34 @@ scope: {
       inherit stdenv;
     }).overrideAttrs
       (attrs: {
-        # Increase the initial mark stack size to avoid stack
-        # overflows, since these inhibit parallel marking (see
-        # GC_mark_some()). To check whether the mark stack is too
-        # small, run Nix with GC_PRINT_STATS=1 and look for messages
-        # such as `Mark stack overflow`, `No room to copy back mark
-        # stack`, and `Grew mark stack to ... frames`.
-        NIX_CFLAGS_COMPILE = [
-          "-DINITIAL_MARK_STACK_SIZE=1048576"
-        ]
-        # For some reason that is not clear, it is wanting to use libgcc_eh which is not available.
-        # Force this to be built with compiler-rt & libunwind over libgcc_eh works.
-        # Issue: https://github.com/NixOS/nixpkgs/issues/177129
-        ++
-          lib.optionals
-            (
-              stdenv.cc.isClang
-              && stdenv.hostPlatform.isStatic
-              && stdenv.cc.libcxx != null
-              && stdenv.cc.libcxx.isLLVM
-            )
+        env = (attrs.env or { }) // {
+          # Increase the initial mark stack size to avoid stack
+          # overflows, since these inhibit parallel marking (see
+          # GC_mark_some()). To check whether the mark stack is too
+          # small, run Nix with GC_PRINT_STATS=1 and look for messages
+          # such as `Mark stack overflow`, `No room to copy back mark
+          # stack`, and `Grew mark stack to ... frames`.
+          NIX_CFLAGS_COMPILE = toString (
             [
-              "-rtlib=compiler-rt"
-              "-unwindlib=libunwind"
-            ];
+              "-DINITIAL_MARK_STACK_SIZE=1048576"
+            ]
+            # For some reason that is not clear, it is wanting to use libgcc_eh which is not available.
+            # Force this to be built with compiler-rt & libunwind over libgcc_eh works.
+            # Issue: https://github.com/NixOS/nixpkgs/issues/177129
+            ++
+              lib.optionals
+                (
+                  stdenv.cc.isClang
+                  && stdenv.hostPlatform.isStatic
+                  && stdenv.cc.libcxx != null
+                  && stdenv.cc.libcxx.isLLVM
+                )
+                [
+                  "-rtlib=compiler-rt"
+                  "-unwindlib=libunwind"
+                ]
+          );
+        };
 
         buildInputs =
           (attrs.buildInputs or [ ])


### PR DESCRIPTION
## Motivation

Nixpkgs now uses structured attrs (i.e. `env.<VAR>`), so this override wasn't working anymore. It makes a huge performance impact once GC kicks in (e.g. it speeds up a 12-core `nix search nixpkgs` from 10.5 to 6.5 seconds).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration handling to combine compiler flags more consistently.
  * Preserved existing compiler-specific options while improving how environment settings are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->