### PR TITLE
nix search: Print total number of derivations

### DIFF
--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -90,6 +90,7 @@ struct CmdSearch : InstallableValueCommand, MixJSON
             jsonOut.emplace(json::object());
 
         std::atomic<uint64_t> results = 0;
+        std::atomic<uint64_t> total = 0;
 
         FutureVector futures(*state->executor);
 
@@ -118,6 +119,8 @@ struct CmdSearch : InstallableValueCommand, MixJSON
                 };
 
                 if (cursor.isDerivation()) {
+                    total++;
+
                     DrvName name(cursor.getAttr(state->s.name)->getString());
 
                     auto aMeta = cursor.maybeGetAttr(state->s.meta);
@@ -209,7 +212,7 @@ struct CmdSearch : InstallableValueCommand, MixJSON
         if (!json && !results)
             throw Error("no results for the given search term(s)!");
 
-        notice("Found %d matching packages.", results);
+        notice("Found %d matching packages out of %d.", results, total);
     }
 };
 

--- a/tests/functional/flakes/search.sh
+++ b/tests/functional/flakes/search.sh
@@ -39,9 +39,9 @@ cat > "$flake1Dir/flake.nix" <<EOF
 }
 EOF
 
-expectStderr 0 nix search flake1 ^ | grepQuiet "Found 3 matching packages."
+expectStderr 0 nix search flake1 ^ | grepQuiet "Found 3 matching packages out of 3."
 expectStderr 0 nix search flake1 ^ | grepQuiet "legacyPackages.$system.xyzzy"
-expectStderr 0 nix search flake1#foo ^ | grepQuiet "Found 1 matching packages."
+expectStderr 0 nix search flake1#foo ^ | grepQuiet "Found 1 matching packages out of 1."
 expectStderr 1 nix search flake1#bar ^
 expectStderr 0 nix search flake1#packages.other-system ^ | grepQuiet "packages.other-system.bar"
 expectStderr 0 nix search "flake1#otherSchema.$system" ^ | grepQuiet "otherSchema.$system.aap"


### PR DESCRIPTION
## Motivation

This makes `nix search` report the total number of packages in addition to the number of matching packages:
```
# nix search nixpkgs fizzbuzz
...
Found 2 out of 108473 matching packages.
```
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `nix search` now reports how many total packages were scanned alongside the number of matches, giving more informative results.
  * Updated search output wording to be more precise for matching-package counts.
* **Tests**
  * Adjusted search command expectations to match the updated output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->