### PR TITLE
Sync with upstream 2.34.8

### DIFF
--- a/scripts/install-nix-from-tarball.sh
+++ b/scripts/install-nix-from-tarball.sh
@@ -28,14 +28,15 @@ fi
 
 OS="$(uname -s)"
 
-# macOS support for 10.12.6 or higher
+# Since nixpkgs 25.11 the minimum deployment target is macOS 14.0
 if [ "$OS" = "Darwin" ]; then
+    # shellcheck disable=SC2034
     IFS='.' read -r macos_major macos_minor macos_patch << EOF
 $(sw_vers -productVersion)
 EOF
-    if [ "$macos_major" -lt 10 ] || { [ "$macos_major" -eq 10 ] && [ "$macos_minor" -lt 12 ]; } || { [ "$macos_minor" -eq 12 ] && [ "$macos_patch" -lt 6 ]; }; then
+    if [ "$macos_major" -lt 14 ]; then
         # patch may not be present; command substitution for simplicity
-        echo "$0: macOS $(sw_vers -productVersion) is not supported, upgrade to 10.12.6 or higher"
+        echo "$0: macOS $(sw_vers -productVersion) is not supported, upgrade to 14.0 or higher"
         exit 1
     fi
 fi

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -798,6 +798,8 @@ struct curlFileTransfer : public FileTransfer
     private:
         bool quitting = false;
     public:
+        bool work = false;
+
         void quit()
         {
             quitting = true;
@@ -853,12 +855,14 @@ struct curlFileTransfer : public FileTransfer
     void stopWorkerThread()
     {
         /* Signal the worker thread to exit. */
-        state_.lock()->quit();
-        wakeupMulti();
+        auto state(state_.lock());
+        state->quit();
+        wakeupMulti(*state);
     }
 
-    void wakeupMulti()
+    void wakeupMulti(State & state)
     {
+        state.work = true;
         if (auto ec = ::curl_multi_wakeup(curlm.get()))
             throw curlMultiError(ec);
     }
@@ -908,25 +912,12 @@ struct curlFileTransfer : public FileTransfer
                 }
             }
 
-            /* Wait for activity, including wakeup events. */
-            long maxSleepTimeMs = items.empty() ? 10000 : 100;
-            auto sleepTimeMs = nextWakeup != std::chrono::steady_clock::time_point()
-                                   ? std::max(
-                                         0,
-                                         (int) std::chrono::duration_cast<std::chrono::milliseconds>(
-                                             nextWakeup - std::chrono::steady_clock::now())
-                                             .count())
-                                   : maxSleepTimeMs;
-
-            int numfds = 0;
-            mc = curl_multi_poll(curlm.get(), nullptr, 0, sleepTimeMs, &numfds);
-            if (mc != CURLM_OK)
-                throw curlMultiError(mc);
-
             nextWakeup = std::chrono::steady_clock::time_point();
 
             std::vector<std::shared_ptr<TransferItem>> incoming;
+            std::vector<std::weak_ptr<Item>> unpause;
             auto now = std::chrono::steady_clock::now();
+            bool haveWork;
 
             {
                 auto state(state_.lock());
@@ -948,7 +939,9 @@ struct curlFileTransfer : public FileTransfer
                         break;
                     }
                 }
+                unpause = std::exchange(state->unpause, {});
                 quit = state->isQuitting();
+                haveWork = std::exchange(state->work, false);
             }
 
             for (auto & item : incoming) {
@@ -959,14 +952,10 @@ struct curlFileTransfer : public FileTransfer
                 items[item->req] = item;
             }
 
-            /* NOTE: Unpausing may invoke callbacks to flush all buffers. */
-            auto unpause = [&]() {
-                auto state(state_.lock());
-                auto res = state->unpause;
-                state->unpause.clear();
-                return res;
-            }();
+            if (quit)
+                break;
 
+            /* NOTE: Unpausing may invoke callbacks to flush all buffers. */
             for (auto & item : unpause) {
                 /* The transfer might have completed (failed) between it getting
                    enqueued for unpause and by the time the worker thread picked
@@ -976,6 +965,26 @@ struct curlFileTransfer : public FileTransfer
                     continue;
                 static_cast<TransferItem &>(*ptr).unpause();
             }
+
+            /* Wait for activity, including wakeup events. */
+            long maxSleepTimeMs = items.empty() ? 10000 : 100;
+            auto sleepTimeMs = nextWakeup != std::chrono::steady_clock::time_point()
+                                   ? std::max(
+                                         0,
+                                         (int) std::chrono::duration_cast<std::chrono::milliseconds>(
+                                             nextWakeup - std::chrono::steady_clock::now())
+                                             .count())
+                                   : maxSleepTimeMs;
+
+            /* Since https://github.com/curl/curl/commit/2a2104f3cff44bb28bb570a093be52bbeeed8f23 (8.21),
+               curl_multi_perform seems to swallow queued up events ¯\_(ツ)_/¯. */
+            if (haveWork)
+                sleepTimeMs = 0;
+
+            int numfds = 0;
+            mc = curl_multi_poll(curlm.get(), nullptr, 0, sleepTimeMs, &numfds);
+            if (mc != CURLM_OK)
+                throw curlMultiError(mc);
         }
 
         debug("download thread shutting down");
@@ -1012,9 +1021,9 @@ struct curlFileTransfer : public FileTransfer
                 throw nix::Error("cannot enqueue download request because the download thread is shutting down");
             state->incoming.push(item);
             item->enqueued = true; /* Now any exceptions should be reported via the callback. */
+            wakeupMulti(*state);
         }
 
-        wakeupMulti();
         return ItemHandle(item.get_ptr());
     }
 
@@ -1034,7 +1043,7 @@ struct curlFileTransfer : public FileTransfer
     {
         auto state(state_.lock());
         state->unpause.push_back(std::move(item));
-        wakeupMulti();
+        wakeupMulti(*state);
     }
 
     void unpauseTransfer(ItemHandle handle) override

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -575,6 +575,7 @@ static void opDumpDB(Strings opFlags, Strings opArgs)
 
 static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
 {
+    auto localStore = ensureLocalStore();
     ValidPathInfos infos;
 
     while (1) {
@@ -592,7 +593,7 @@ static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
             /* !!! races */
             if (canonicalise)
                 canonicalisePathMetaData(
-                    store->printStorePath(info->path),
+                    localStore->toRealPath(info->path),
                     {NIX_WHEN_SUPPORT_ACLS(settings.getLocalSettings().ignoredAcls)});
             if (!hashGiven) {
                 HashResult hash = hashPath(
@@ -606,7 +607,7 @@ static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
         }
     }
 
-    ensureLocalStore()->registerValidPaths(infos);
+    localStore->registerValidPaths(infos);
 }
 
 static void opLoadDB(Strings opFlags, Strings opArgs)

--- a/tests/functional/chroot-store.sh
+++ b/tests/functional/chroot-store.sh
@@ -60,6 +60,15 @@ PATH7=$(nix path-info --store "local://$TEST_ROOT/x%2Bchroot" "$CORRECT_PATH")
 # Path gets decoded.
 [[ ! -d "$TEST_ROOT/x%2Bchroot" ]]
 
+# Regression test: `nix-store --register-validity` against a chroot store must
+# canonicalise the real (chroot-prefixed) path, not the logical store path
+# (which does not exist on the host filesystem).
+regPath=$NIX_STORE_DIR/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-reg
+touch "$TEST_ROOT/x/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-reg"
+[[ ! -e "$regPath" ]]
+(echo "$regPath" && echo && echo 0) | nix-store --store "local?root=$TEST_ROOT/x" --register-validity
+nix-store --store "$TEST_ROOT/x" --check-validity "$regPath"
+
 # Ensure store info trusted works with local store
 nix --store "$TEST_ROOT/x" store info --json | jq -e '.trusted'
 


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of downloads so queued transfers wake up and poll more reliably, reducing missed work and stalled activity.
  * Corrected validity registration for chroot-backed local stores so paths resolve to the real filesystem location inside the chroot.
  * Updated the macOS minimum supported version to 14.0+, with a clearer compatibility check and error message.

* **Tests**
  * Added regression coverage for chroot store validity registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->