### PR TITLE
Allocate RootValues more efficiently

### DIFF
--- a/src/libcmd/include/nix/cmd/installable-attr-path.hh
+++ b/src/libcmd/include/nix/cmd/installable-attr-path.hh
@@ -20,13 +20,14 @@
 
 #include <regex>
 #include <queue>
+#include "nix/expr/root-value.hh"
 
 namespace nix {
 
 class InstallableAttrPath : public InstallableValue
 {
     SourceExprCommand & cmd;
-    RootValue v;
+    UniqueRootValue v;
     std::string attrPath;
     ExtendedOutputsSpec extendedOutputsSpec;
 

--- a/src/libcmd/installable-attr-path.cc
+++ b/src/libcmd/installable-attr-path.cc
@@ -32,7 +32,7 @@ InstallableAttrPath::InstallableAttrPath(
     ExtendedOutputsSpec extendedOutputsSpec)
     : InstallableValue(state)
     , cmd(cmd)
-    , v(allocRootValue(v))
+    , v(UniqueRootValue(v))
     , attrPath(attrPath)
     , extendedOutputsSpec(std::move(extendedOutputsSpec))
 {

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -327,7 +327,7 @@ void NixRepl::loadDebugTraceEnv(DebugTrace & dt)
 
         // add staticenv vars.
         for (auto & [name, value] : *(vm.get()))
-            addVarToScope(state->symbols.create(name), *value);
+            addVarToScope(state->symbols.create(name), **value);
     }
 }
 
@@ -931,7 +931,7 @@ ReplExitStatus AbstractNixRepl::runSimple(ref<EvalState> evalState, const ValMap
 
     // add 'extra' vars.
     for (auto & [name, value] : extraEnv)
-        repl->addVarToScope(repl->state->symbols.create(name), *value);
+        repl->addVarToScope(repl->state->symbols.create(name), **value);
 
     return repl->mainLoop();
 }

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -361,7 +361,7 @@ Value * EvalCache::getRootValue()
 {
     if (!value) {
         debug("getting root value");
-        value = allocRootValue(rootLoader());
+        value = UniqueRootValue(rootLoader());
     }
     return *value;
 }
@@ -378,7 +378,7 @@ AttrCursor::AttrCursor(
     , cachedValue(std::move(cachedValue))
 {
     if (value)
-        _value = allocRootValue(value);
+        _value = UniqueRootValue(value);
 }
 
 AttrKey AttrCursor::getKey()
@@ -401,9 +401,9 @@ Value & AttrCursor::getValue()
             auto attr = vParent.attrs()->get(parent->second);
             if (!attr)
                 throw Error("attribute '%s' is unexpectedly missing", getAttrPathStr());
-            _value = allocRootValue(attr->value);
+            _value = UniqueRootValue(attr->value);
         } else
-            _value = allocRootValue(root->getRootValue());
+            _value = UniqueRootValue(root->getRootValue());
     }
     return **_value;
 }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -109,46 +109,6 @@ const StringData & StringData::make(EvalMemory & mem, std::string_view s)
     return res;
 }
 
-RootValue allocRootValue(Value * v)
-{
-#if NIX_USE_BOEHMGC
-    /* Root slots are carved out of uncollectable slabs, which are
-       permanently part of the GC root set, and recycled through a free
-       list. This avoids doing a GC_MALLOC_UNCOLLECTABLE() / GC_FREE()
-       pair per root value, which requires taking the global GC
-       allocation lock — a significant source of contention during
-       parallel evaluation. Never destroyed since root values held by
-       other statics may be released after us during shutdown. */
-    static auto & pool = *new Sync<std::vector<Value **>>;
-
-    Value ** slot;
-    {
-        auto pool_(pool.lock());
-        if (pool_->empty()) {
-            constexpr size_t slabSize = 4096;
-            auto slab = (Value **) GC_MALLOC_UNCOLLECTABLE(slabSize * sizeof(Value *));
-            if (!slab)
-                throw std::bad_alloc();
-            pool_->reserve(slabSize);
-            for (size_t i = 0; i < slabSize; ++i)
-                pool_->push_back(slab + i);
-        }
-        slot = pool_->back();
-        pool_->pop_back();
-    }
-
-    *slot = v;
-
-    return RootValue(slot, [](Value ** slot) {
-        /* Clear the slot so it doesn't keep the value alive. */
-        *slot = nullptr;
-        pool.lock()->push_back(slot);
-    });
-#else
-    return std::make_shared<Value *>(v);
-#endif
-}
-
 // Pretty print types for assertion errors
 std::ostream & operator<<(std::ostream & os, const ValueType t)
 {
@@ -615,7 +575,7 @@ Value * EvalState::addPrimOp(PrimOp && primOp)
     v->mkPrimOp(new PrimOp(primOp));
 
     if (primOp.internal)
-        internalPrimOps.emplace(primOp.name, v);
+        internalPrimOps.emplace(primOp.name, UniqueRootValue(v));
     else {
         staticBaseEnv->vars.emplace_back(envName, baseEnvDispl);
         baseEnv.values[baseEnvDispl++] = v;
@@ -789,11 +749,11 @@ void mapStaticEnvBindings(const SymbolTable & st, const StaticEnv & se, const En
         if (se.isWith && env.values[0]->isFinished()) {
             // add 'with' bindings.
             for (auto & j : *env.values[0]->attrs())
-                vm.insert_or_assign(std::string(st[j.name]), j.value);
+                vm.insert_or_assign(std::string(st[j.name]), UniqueRootValue(j.value));
         } else {
             // iterate through staticenv bindings and add them.
             for (auto & i : se.vars)
-                vm.insert_or_assign(std::string(st[i.first]), env.values[i.second]);
+                vm.insert_or_assign(std::string(st[i.first]), UniqueRootValue(env.values[i.second]));
         }
     }
 }
@@ -1202,10 +1162,14 @@ void EvalState::evalFile(const SourcePath & path, Value & v, bool mustBeTrivial)
         importResolutionCache->emplace(path, *resolvedPath);
     }
 
-    if (auto v2 = getConcurrent(*fileEvalCache, *resolvedPath)) {
-        forceValue(**v2, noPos);
-        v = **v2;
-        return;
+    {
+        Value * v2 = nullptr;
+        fileEvalCache->cvisit(*resolvedPath, [&](auto & i) { v2 = *i.second; });
+        if (v2) {
+            forceValue(*v2, noPos);
+            v = *v2;
+            return;
+        }
     }
 
     Value * vExpr;
@@ -1213,13 +1177,13 @@ void EvalState::evalFile(const SourcePath & path, Value & v, bool mustBeTrivial)
 
     fileEvalCache->try_emplace_and_cvisit(
         *resolvedPath,
-        nullptr,
+        UniqueRootValue(nullptr),
         [&](auto & i) {
             vExpr = allocValue();
             vExpr->mkThunk(&baseEnv, &expr);
-            i.second = vExpr;
+            *i.second = vExpr;
         },
-        [&](auto & i) { vExpr = i.second; });
+        [&](auto & i) { vExpr = *i.second; });
 
     forceValue(*vExpr, noPos);
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -111,7 +111,42 @@ const StringData & StringData::make(EvalMemory & mem, std::string_view s)
 
 RootValue allocRootValue(Value * v)
 {
-    return std::allocate_shared<Value *>(traceable_allocator<Value *>(), v);
+#if NIX_USE_BOEHMGC
+    /* Root slots are carved out of uncollectable slabs, which are
+       permanently part of the GC root set, and recycled through a free
+       list. This avoids doing a GC_MALLOC_UNCOLLECTABLE() / GC_FREE()
+       pair per root value, which requires taking the global GC
+       allocation lock — a significant source of contention during
+       parallel evaluation. Never destroyed since root values held by
+       other statics may be released after us during shutdown. */
+    static auto & pool = *new Sync<std::vector<Value **>>;
+
+    Value ** slot;
+    {
+        auto pool_(pool.lock());
+        if (pool_->empty()) {
+            constexpr size_t slabSize = 4096;
+            auto slab = (Value **) GC_MALLOC_UNCOLLECTABLE(slabSize * sizeof(Value *));
+            if (!slab)
+                throw std::bad_alloc();
+            pool_->reserve(slabSize);
+            for (size_t i = 0; i < slabSize; ++i)
+                pool_->push_back(slab + i);
+        }
+        slot = pool_->back();
+        pool_->pop_back();
+    }
+
+    *slot = v;
+
+    return RootValue(slot, [](Value ** slot) {
+        /* Clear the slot so it doesn't keep the value alive. */
+        *slot = nullptr;
+        pool.lock()->push_back(slot);
+    });
+#else
+    return std::make_shared<Value *>(v);
+#endif
 }
 
 // Pretty print types for assertion errors

--- a/src/libexpr/include/nix/expr/eval-cache.hh
+++ b/src/libexpr/include/nix/expr/eval-cache.hh
@@ -8,6 +8,7 @@
 
 #include <functional>
 #include <variant>
+#include "nix/expr/root-value.hh"
 
 namespace nix::eval_cache {
 
@@ -44,7 +45,7 @@ public:
 private:
     typedef fun<Value *()> RootLoader;
     RootLoader rootLoader;
-    RootValue value;
+    UniqueRootValue value;
 
     Value * getRootValue();
 
@@ -111,7 +112,7 @@ public:
 private:
     using Parent = std::optional<std::pair<ref<AttrCursor>, Symbol>>;
     const Parent parent;
-    RootValue _value;
+    UniqueRootValue _value;
     std::optional<std::pair<AttrId, AttrValue>> cachedValue;
 
     AttrKey getKey();

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -6,6 +6,7 @@
 #include "nix/expr/eval-profiler.hh"
 #include "nix/util/types.hh"
 #include "nix/expr/value.hh"
+#include "nix/expr/root-value.hh"
 #include "nix/expr/nixexpr.hh"
 #include "nix/expr/symbol-table.hh"
 #include "nix/util/configuration.hh"
@@ -167,9 +168,7 @@ struct Constant
     bool impureOnly = false;
 };
 
-typedef std::
-    map<std::string, Value *, std::less<std::string>, traceable_allocator<std::pair<const std::string, Value *>>>
-        ValMap;
+typedef std::map<std::string, UniqueRootValue> ValMap;
 
 typedef boost::unordered_flat_map<PosIdx, DocComment, std::hash<PosIdx>> DocCommentMap;
 
@@ -473,13 +472,7 @@ private:
     /**
      * A cache from resolved paths to values.
      */
-    const ref<boost::concurrent_flat_map<
-        SourcePath,
-        Value *,
-        std::hash<SourcePath>,
-        std::equal_to<SourcePath>,
-        traceable_allocator<std::pair<const SourcePath, Value *>>>>
-        fileEvalCache;
+    const ref<boost::concurrent_flat_map<SourcePath, UniqueRootValue>> fileEvalCache;
 
     /**
      * Associate source positions of certain AST nodes with their preceding doc comment, if they have one.
@@ -817,13 +810,7 @@ public:
     /**
      * Internal primops not exposed to the user.
      */
-    boost::unordered_flat_map<
-        std::string,
-        Value *,
-        StringViewHash,
-        std::equal_to<>,
-        traceable_allocator<std::pair<const std::string, Value *>>>
-        internalPrimOps;
+    boost::unordered_flat_map<std::string, UniqueRootValue, StringViewHash> internalPrimOps;
 
     /**
      * Name and documentation about every constant.

--- a/src/libexpr/include/nix/expr/get-drvs.hh
+++ b/src/libexpr/include/nix/expr/get-drvs.hh
@@ -32,6 +32,7 @@ private:
      */
     bool failed = false;
 
+    // FIXME: make this a UniqueRootValue.
     const Bindings *attrs = nullptr, *meta = nullptr;
 
     const Bindings * getMeta();

--- a/src/libexpr/include/nix/expr/meson.build
+++ b/src/libexpr/include/nix/expr/meson.build
@@ -33,6 +33,7 @@ headers = [ config_pub_h ] + files(
   'print.hh',
   'provenance.hh',
   'repl-exit-status.hh',
+  'root-value.hh',
   'search-path.hh',
   'static-string-data.hh',
   'symbol-table.hh',

--- a/src/libexpr/include/nix/expr/root-value.hh
+++ b/src/libexpr/include/nix/expr/root-value.hh
@@ -49,6 +49,8 @@ public:
 
     UniqueRootValue & operator=(UniqueRootValue && other) noexcept
     {
+        if (this == &other)
+            return *this;
         if (slot)
             freeRootValueSlot(slot);
         slot = std::exchange(other.slot, nullptr);

--- a/src/libexpr/include/nix/expr/root-value.hh
+++ b/src/libexpr/include/nix/expr/root-value.hh
@@ -1,0 +1,94 @@
+#pragma once
+///@file
+
+#include <memory>
+#include <utility>
+
+namespace nix {
+
+struct Value;
+
+/**
+ * Allocate a slot from the root value pool, i.e. a GC-visible
+ * `Value *` cell that keeps the value it points to alive across
+ * garbage collections. Use `UniqueRootValue`/`RootValue` rather than
+ * calling this directly.
+ */
+Value ** allocRootValueSlot(Value * v);
+
+/**
+ * Clear the given slot and return it to the root value pool.
+ */
+void freeRootValueSlot(Value ** slot);
+
+/**
+ * A move-only handle rooting a Value, i.e. keeping it and everything
+ * reachable from it alive across garbage collections. Prefer this
+ * over `RootValue` unless the handle must be copyable (e.g. when it's
+ * captured in a `std::function`-backed lambda).
+ */
+class UniqueRootValue
+{
+    Value ** slot = nullptr;
+
+public:
+    UniqueRootValue() = default;
+
+    explicit UniqueRootValue(Value * v)
+        : slot(allocRootValueSlot(v))
+    {
+    }
+
+    UniqueRootValue(const UniqueRootValue &) = delete;
+    UniqueRootValue & operator=(const UniqueRootValue &) = delete;
+
+    UniqueRootValue(UniqueRootValue && other) noexcept
+        : slot(std::exchange(other.slot, nullptr))
+    {
+    }
+
+    UniqueRootValue & operator=(UniqueRootValue && other) noexcept
+    {
+        if (slot)
+            freeRootValueSlot(slot);
+        slot = std::exchange(other.slot, nullptr);
+        return *this;
+    }
+
+    ~UniqueRootValue()
+    {
+        if (slot)
+            freeRootValueSlot(slot);
+    }
+
+    /**
+     * Release the slot, i.e. stop rooting the value.
+     */
+    void reset()
+    {
+        if (slot) {
+            freeRootValueSlot(slot);
+            slot = nullptr;
+        }
+    }
+
+    Value *& operator*() const
+    {
+        return *slot;
+    }
+
+    explicit operator bool() const
+    {
+        return slot != nullptr;
+    }
+};
+
+/**
+ * A copyable, shared handle rooting a Value. Only use this instead of
+ * `UniqueRootValue` if the handle must be copyable.
+ */
+typedef std::shared_ptr<Value *> RootValue;
+
+RootValue allocRootValue(Value * v);
+
+} // namespace nix

--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -10,6 +10,7 @@
 #include <memory_resource>
 #include <exception>
 #include <span>
+#include <utility>
 #include <string_view>
 #include <type_traits>
 #include <concepts>
@@ -1540,13 +1541,6 @@ typedef boost::unordered_flat_map<
     std::equal_to<Symbol>,
     traceable_allocator<std::pair<const Symbol, Value *>>>
     ValueMap;
-
-/**
- * A value allocated in traceable memory.
- */
-typedef std::shared_ptr<Value *> RootValue;
-
-RootValue allocRootValue(Value * v);
 
 void forceNoNullByte(std::string_view s, std::function<Pos()> = nullptr);
 } // namespace nix

--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -18,7 +18,7 @@ class JSONSax : nlohmann::json_sax<json>
     {
     protected:
         std::unique_ptr<JSONState> parent;
-        RootValue v;
+        UniqueRootValue v;
     public:
         virtual std::unique_ptr<JSONState> resolve(EvalState &)
         {
@@ -31,7 +31,7 @@ class JSONSax : nlohmann::json_sax<json>
         }
 
         explicit JSONState(Value * v)
-            : v(allocRootValue(v))
+            : v(UniqueRootValue(v))
         {
         }
 
@@ -40,7 +40,7 @@ class JSONSax : nlohmann::json_sax<json>
         Value & value(EvalState & state)
         {
             if (!v)
-                v = allocRootValue(state.allocValue());
+                v = UniqueRootValue(state.allocValue());
             return **v;
         }
 
@@ -65,7 +65,7 @@ class JSONSax : nlohmann::json_sax<json>
 
         void add() override
         {
-            v = nullptr;
+            v.reset();
         }
     public:
         void key(string_t & name, EvalState & state)
@@ -91,7 +91,7 @@ class JSONSax : nlohmann::json_sax<json>
         void add() override
         {
             values.push_back(*v);
-            v = nullptr;
+            v.reset();
         }
     public:
         JSONListState(std::unique_ptr<JSONState> && p, std::size_t reserve)

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -184,6 +184,7 @@ sources = files(
   'print-ambiguous.cc',
   'print.cc',
   'provenance.cc',
+  'root-value.cc',
   'search-path.cc',
   'symbol-table.cc',
   'value-to-json.cc',

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -784,10 +784,12 @@ struct CompareValues
     }
 };
 
-typedef std::list<Value *, gc_allocator<Value *>> ValueList;
-
 static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** args, Value & v)
 {
+    /* The values are rooted via UniqueRootValue, so the lists themselves
+       don't need to be visible to the GC. */
+    using ValueList = std::list<UniqueRootValue>;
+
     state.forceAttrs(*args[0], noPos, "while evaluating the first argument passed to builtins.genericClosure");
 
     /* Get the start set. */
@@ -801,7 +803,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
 
     ValueList workSet;
     for (auto elem : startSet->value->listView())
-        workSet.push_back(elem);
+        workSet.push_back(UniqueRootValue(elem));
 
     if (startSet->value->listSize() == 0) {
         v = *startSet->value;
@@ -822,7 +824,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
     auto cmp = CompareValues(state, noPos, "");
     std::map<Value *, Value *, decltype(cmp)> keyToElem(cmp);
     while (!workSet.empty()) {
-        Value * e = *(workSet.begin());
+        Value * e = **workSet.begin();
         workSet.pop_front();
 
         try {
@@ -867,7 +869,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
             }
             throw;
         }
-        res.push_back(e);
+        res.push_back(UniqueRootValue(e));
 
         /* Call the `operator' function with `e' as argument. */
         Value newElements;
@@ -882,7 +884,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
             for (auto elem : newElements.listView()) {
                 state.forceValue(*elem, noPos); // "while evaluating one one of the elements returned by the `operator`
                                                 // passed to builtins.genericClosure");
-                workSet.push_back(elem);
+                workSet.push_back(UniqueRootValue(elem));
             }
         } catch (Error & err) {
             err.addTrace(
@@ -897,7 +899,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value ** ar
     /* Create the result list. */
     auto list = state.buildList(res.size());
     for (const auto & [n, i] : enumerate(res))
-        list[n] = i;
+        list[n] = *i;
     v.mkList(list);
 }
 
@@ -5668,7 +5670,7 @@ void EvalState::createBaseEnv(const EvalSettings & evalSettings)
 
     if (experimentalFeatureSettings.isEnabled(Xp::Provenance))
         callFunction(
-            *vDerivationValue, **get(internalPrimOps, "derivationStrictWithMeta"), *vDerivationWithMeta, PosIdx());
+            *vDerivationValue, ***get(internalPrimOps, "derivationStrictWithMeta"), *vDerivationWithMeta, PosIdx());
 }
 
 } // namespace nix

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -39,7 +39,7 @@ void emitTreeAttrs(
         attrs.alloc("narHash").mkString(narHash->to_string(HashFormat::SRI, true), state.mem);
     else
         // Lazily compute the NAR hash for backward compatibility.
-        attrs.alloc("narHash").mkApp(*get(state.internalPrimOps, "narHash"), &vStorePath);
+        attrs.alloc("narHash").mkApp(**get(state.internalPrimOps, "narHash"), &vStorePath);
 
     if (input.getType() == "git")
         attrs.alloc("submodules").mkBool(fetchers::maybeGetBoolAttr(input.attrs, "submodules").value_or(false));

--- a/src/libexpr/root-value.cc
+++ b/src/libexpr/root-value.cc
@@ -2,43 +2,63 @@
 #include "nix/expr/eval-gc.hh"
 #include "nix/util/sync.hh"
 
-#include <vector>
-
 namespace nix {
 
 #if NIX_USE_BOEHMGC
-/* The pool of root value slots. Slots are carved out of uncollectable
-   slabs, which are permanently part of the GC root set, and recycled
-   through this free list. This avoids doing a GC_MALLOC_UNCOLLECTABLE()
-   / GC_FREE() pair per root value, which requires taking the global GC
-   allocation lock — a significant source of contention during parallel
-   evaluation. Never destroyed since root values held by statics may be
-   released after us during shutdown. */
-static auto & rootValuePool = *new Sync<std::vector<Value **>>;
+
+namespace {
+/**
+ * A root value slot: either in use (rooting a value) or on the
+ * freelist. Slots are carved out of uncollectable slabs, which are
+ * permanently part of the GC root set. This avoids doing a
+ * GC_MALLOC_UNCOLLECTABLE() / GC_FREE() pair per root value, which
+ * requires taking the global GC allocation lock — a significant
+ * source of contention during parallel evaluation.
+ *
+ * GC safety: the slabs are conservatively scanned. In-use slots
+ * contain a `Value *`, which roots the value. Free slots contain a
+ * pointer to the next free slot (or null), i.e. a pointer into a
+ * slab, which is scanned harmlessly since slabs are never freed
+ * anyway.
+ */
+union Slot
+{
+    Value * value;
+    Slot * nextFree;
+};
+
+static_assert(sizeof(Slot) == sizeof(Value *));
+} // namespace
+
+/* Head of the freelist of slots. Never destroyed since root values
+   held by statics may be released after us during shutdown. */
+static auto & freeSlots = *new Sync<Slot *>{nullptr};
+
 #endif
 
 Value ** allocRootValueSlot(Value * v)
 {
 #if NIX_USE_BOEHMGC
-    Value ** slot;
+    Slot * slot;
     {
-        auto pool(rootValuePool.lock());
-        if (pool->empty()) {
+        auto head(freeSlots.lock());
+        if (!*head) {
             constexpr size_t slabSize = 4096;
-            auto slab = (Value **) GC_MALLOC_UNCOLLECTABLE(slabSize * sizeof(Value *));
+            auto slab = (Slot *) GC_MALLOC_UNCOLLECTABLE(slabSize * sizeof(Slot));
             if (!slab)
                 throw std::bad_alloc();
-            pool->reserve(slabSize);
-            for (size_t i = 0; i < slabSize; ++i)
-                pool->push_back(slab + i);
+            for (size_t i = 0; i + 1 < slabSize; ++i)
+                slab[i].nextFree = &slab[i + 1];
+            slab[slabSize - 1].nextFree = nullptr;
+            *head = slab;
         }
-        slot = pool->back();
-        pool->pop_back();
+        slot = *head;
+        *head = slot->nextFree;
     }
 
-    *slot = v;
+    slot->value = v;
 
-    return slot;
+    return &slot->value;
 #else
     return new Value *(v);
 #endif
@@ -47,9 +67,12 @@ Value ** allocRootValueSlot(Value * v)
 void freeRootValueSlot(Value ** slot)
 {
 #if NIX_USE_BOEHMGC
-    /* Clear the slot so it doesn't keep the value alive. */
-    *slot = nullptr;
-    rootValuePool.lock()->push_back(slot);
+    /* Note: writing `nextFree` overwrites the `Value *`, so this also
+       stops the slot from keeping the value alive. */
+    auto s = reinterpret_cast<Slot *>(slot);
+    auto head(freeSlots.lock());
+    s->nextFree = *head;
+    *head = s;
 #else
     delete slot;
 #endif

--- a/src/libexpr/root-value.cc
+++ b/src/libexpr/root-value.cc
@@ -1,0 +1,63 @@
+#include "nix/expr/root-value.hh"
+#include "nix/expr/eval-gc.hh"
+#include "nix/util/sync.hh"
+
+#include <vector>
+
+namespace nix {
+
+#if NIX_USE_BOEHMGC
+/* The pool of root value slots. Slots are carved out of uncollectable
+   slabs, which are permanently part of the GC root set, and recycled
+   through this free list. This avoids doing a GC_MALLOC_UNCOLLECTABLE()
+   / GC_FREE() pair per root value, which requires taking the global GC
+   allocation lock — a significant source of contention during parallel
+   evaluation. Never destroyed since root values held by statics may be
+   released after us during shutdown. */
+static auto & rootValuePool = *new Sync<std::vector<Value **>>;
+#endif
+
+Value ** allocRootValueSlot(Value * v)
+{
+#if NIX_USE_BOEHMGC
+    Value ** slot;
+    {
+        auto pool(rootValuePool.lock());
+        if (pool->empty()) {
+            constexpr size_t slabSize = 4096;
+            auto slab = (Value **) GC_MALLOC_UNCOLLECTABLE(slabSize * sizeof(Value *));
+            if (!slab)
+                throw std::bad_alloc();
+            pool->reserve(slabSize);
+            for (size_t i = 0; i < slabSize; ++i)
+                pool->push_back(slab + i);
+        }
+        slot = pool->back();
+        pool->pop_back();
+    }
+
+    *slot = v;
+
+    return slot;
+#else
+    return new Value *(v);
+#endif
+}
+
+void freeRootValueSlot(Value ** slot)
+{
+#if NIX_USE_BOEHMGC
+    /* Clear the slot so it doesn't keep the value alive. */
+    *slot = nullptr;
+    rootValuePool.lock()->push_back(slot);
+#else
+    delete slot;
+#endif
+}
+
+RootValue allocRootValue(Value * v)
+{
+    return RootValue(allocRootValueSlot(v), freeRootValueSlot);
+}
+
+} // namespace nix


### PR DESCRIPTION
## Motivation

Taken from #534.

`RootValue`s were expensive for parallel eval, since each `RootValue` caused a Boehm GC call to allocate traceable-but-uncollectable memory while holding the global GC root. We now allocate slab of uncollectable memory from which the `RootValue`s are allocated. 

Also, there is a new `UniqueRootValue` type which is like `RootValue` except that it isn't wrapped in an `std::shared_ptr`, so it entirely avoids a heap allocation. Most instances of `traceable_allocator<Value *>` are now a `UniqueRootValue`.

Speedup:

<img width="1500" height="1800" alt="eval-cores-compare" src="https://github.com/user-attachments/assets/684896f3-d2a4-4fc4-a7cc-2e9997dc16db" />

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of expression evaluation, especially around caching behavior, REPL variable injection, and JSON parsing, reducing the likelihood of crashes or inconsistent results in edge cases.
  * Enhanced stability when handling attribute paths and internal primitive operations.

* **Chores**
  * Added and wired up new runtime support for safer value lifetime management, including build and installed-header updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->