### PR TITLE
Drop soversion

### DIFF
--- a/nix-meson-build-support/common/meson.build
+++ b/nix-meson-build-support/common/meson.build
@@ -76,9 +76,6 @@ if is_using_libstdcxx
   add_project_arguments('-D_GLIBCXX_USE_TBB_PAR_BACKEND=0', language : 'cpp')
 endif
 
-# Darwin ld doesn't like "X.Y.ZpreABCD+W"
-nix_soversion = meson.project_version().split('+')[0].split('pre')[0]
-
 cxx = meson.get_compiler('cpp')
 
 # Clang does not support prelinking on static builds

--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -113,7 +113,6 @@ this_library = library(
   'nixcmd',
   sources,
   config_priv_h,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libexpr-c/meson.build
+++ b/src/libexpr-c/meson.build
@@ -50,7 +50,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixexprc',
   sources,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libexpr-test-support/meson.build
+++ b/src/libexpr-test-support/meson.build
@@ -44,7 +44,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nix-expr-test-support',
   sources,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -253,7 +253,6 @@ this_library = library(
   parser_tab[1],
   lexer_tab[1],
   generated_headers,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags + link_args,

--- a/src/libfetchers-c/meson.build
+++ b/src/libfetchers-c/meson.build
@@ -53,7 +53,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixfetchersc',
   sources,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -71,7 +71,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixfetchers',
   sources,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libflake-c/meson.build
+++ b/src/libflake-c/meson.build
@@ -53,7 +53,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixflakec',
   sources,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libflake/meson.build
+++ b/src/libflake/meson.build
@@ -59,7 +59,6 @@ this_library = library(
   'nixflake',
   sources,
   generated_headers,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libmain-c/meson.build
+++ b/src/libmain-c/meson.build
@@ -45,7 +45,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixmainc',
   sources,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libmain/meson.build
+++ b/src/libmain/meson.build
@@ -77,7 +77,6 @@ this_library = library(
   'nixmain',
   sources,
   config_priv_h,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -48,7 +48,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixstorec',
   sources,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libstore-test-support/meson.build
+++ b/src/libstore-test-support/meson.build
@@ -50,7 +50,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nix-store-test-support',
   sources,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -400,7 +400,6 @@ this_library = library(
   generated_headers,
   sources,
   config_priv_h,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags + link_args,

--- a/src/libutil-c/meson.build
+++ b/src/libutil-c/meson.build
@@ -53,7 +53,6 @@ this_library = library(
   'nixutilc',
   sources,
   config_priv_h,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libutil-test-support/meson.build
+++ b/src/libutil-test-support/meson.build
@@ -41,7 +41,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nix-util-test-support',
   sources,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -216,7 +216,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixutil',
   sources,
-  soversion : nix_soversion,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,


### PR DESCRIPTION


## Motivation

This was introduced upstream for reasons that don't really apply to us (e.g. Fedora packaging guidelines), but we don't need them, they imply an ABI stability that doesn't exist anyway, and the soversions are mostly just annoying in devshells.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved macOS linker compatibility issues caused by shared-library version strings.
  * Updated library builds to avoid applying explicit shared-object version metadata, improving compatibility across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->