### PR TITLE
Fix data race initializing AttrCursor::_value

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -359,11 +359,12 @@ EvalCache::EvalCache(
 
 Value * EvalCache::getRootValue()
 {
-    if (!value) {
+    auto value(this->value.lock());
+    if (!*value) {
         debug("getting root value");
-        value = RootValue(rootLoader());
+        *value = RootValue(rootLoader());
     }
-    return *value;
+    return **value;
 }
 
 ref<AttrCursor> EvalCache::getRoot()
@@ -378,7 +379,7 @@ AttrCursor::AttrCursor(
     , cachedValue(std::move(cachedValue))
 {
     if (value)
-        _value = RootValue(value);
+        *_value.lock() = RootValue(value);
 }
 
 AttrKey AttrCursor::getKey()
@@ -394,18 +395,23 @@ AttrKey AttrCursor::getKey()
 
 Value & AttrCursor::getValue()
 {
-    if (!_value) {
+    /* Note: this lock is held while the value is being evaluated,
+       so concurrent calls block until the value is available. Lock
+       ordering is strictly child -> parent, so this cannot
+       deadlock. */
+    auto value(_value.lock());
+    if (!*value) {
         if (parent) {
             auto & vParent = parent->first->getValue();
             root->state.forceAttrs(vParent, noPos, "while searching for an attribute");
             auto attr = vParent.attrs()->get(parent->second);
             if (!attr)
                 throw Error("attribute '%s' is unexpectedly missing", getAttrPathStr());
-            _value = RootValue(attr->value);
+            *value = RootValue(attr->value);
         } else
-            _value = RootValue(root->getRootValue());
+            *value = RootValue(root->getRootValue());
     }
-    return **_value;
+    return ***value;
 }
 
 void AttrCursor::fetchCachedValue()

--- a/src/libexpr/include/nix/expr/eval-cache.hh
+++ b/src/libexpr/include/nix/expr/eval-cache.hh
@@ -45,7 +45,7 @@ public:
 private:
     typedef fun<Value *()> RootLoader;
     RootLoader rootLoader;
-    RootValue value;
+    Sync<RootValue> value;
 
     Value * getRootValue();
 
@@ -112,7 +112,7 @@ public:
 private:
     using Parent = std::optional<std::pair<ref<AttrCursor>, Symbol>>;
     const Parent parent;
-    RootValue _value;
+    Sync<RootValue> _value;
     std::optional<std::pair<AttrId, AttrValue>> cachedValue;
 
     AttrKey getKey();


### PR DESCRIPTION
## Motivation

This field could be lazily initialized by multiple threads, clobbering each other's `RootValue`. Since #546 this has been much more likely to lead to a crash. (Previously `RootValue` was an `std::shared_ptr`, which was not safe either but unlikely to crash.)

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation cache synchronization and value handling.
  * Prevented potential inconsistencies when cached expressions and attribute values are evaluated concurrently.
  * Improved reliability when retrieving cached root and attribute values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->