### PR TITLE
Fix assertion failure in processSandboxSetupMessages()

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1099,12 +1099,12 @@ void DerivationBuilderImpl::processSandboxSetupMessages()
             try {
                 return readLine(builderOut.get());
             } catch (Error & e) {
-                auto status = pid.wait();
+                auto status = pid != -1 ? pid.wait() : 0;
                 e.addTrace(
                     {},
                     "while waiting for the build environment for '%s' to initialize (%s, previous messages: %s)",
                     store.printStorePath(drvPath),
-                    statusToString(status),
+                    status ? statusToString(status) : "no status",
                     concatStringsSep("\n", msgs));
                 throw;
             }


### PR DESCRIPTION

## Motivation

This fixes the following Sentry crash report:

```
libnixutil.so.2.34.80xff807ce5e404 nix::panic (error.cc:459)
libnixutil.so.2.34.80xff807ceed68c __wrap___assert_fail (wrap-assert-fail.cc:18)
libnixutil.so.2.34.80xff807cee2834 nix::Pid::wait (processes.cc:100)
libnixstore.so.2.34.80xff807cc4fcfc operator() (derivation-builder.cc:1102)
libnixstore.so.2.34.80xff807cc4fcfc nix::DerivationBuilderImpl::processSandboxSetupMessages (derivation-builder.cc:1111)
libnixstore.so.2.34.80xff807cc5d390 .LTHUNK39.lto_priv.4 (linux-derivation-builder.cc:477)
libnixstore.so.2.34.80xff807cc4b10c nix::DerivationBuilderImpl::startBuild (derivation-builder.cc:895)
```

This happens because in the Linux sandbox, if the sandbox helper fails, `pid` is not initialised yet so we can't wait for it.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sandbox setup errors when the builder process is unavailable.
  * Prevented unnecessary process waits and ensured clearer diagnostic status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->