### PR TITLE
On Linux, don't hang if the sandbox helper dies before opening the pty slave

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -339,9 +339,22 @@ protected:
     }
 
     /**
-     * Open the slave side of the pseudoterminal and use it as stderr.
+     * Open the slave side of the pseudoterminal.
      */
-    void openSlave();
+    AutoCloseFD openSlaveNoDup();
+
+    /**
+     * Open the slave side of the pseudoterminal and use it as stderr.
+     * FIXME: This is called in the child. It should really be called in the parent (except for the dup to stderr),
+     * since if the child fails before opening the slave, the parent will hang forever reading from the master. However,
+     * opening the slave in the parent causes random failures on macOS. See c536e00c9deeac58bc4b3299dbc702604c32adbe.
+     */
+    void openSlave()
+    {
+        auto builderOut = openSlaveNoDup();
+        if (dup2(builderOut.get(), STDERR_FILENO) == -1)
+            throw SysError("cannot pipe standard error into log file");
+    }
 
     /**
      * Called by prepareBuild() to start the child process for the
@@ -1029,7 +1042,7 @@ void DerivationBuilderImpl::prepareSandbox()
         throw Error("feature 'uid-range' is not supported on this platform");
 }
 
-void DerivationBuilderImpl::openSlave()
+AutoCloseFD DerivationBuilderImpl::openSlaveNoDup()
 {
     std::string slaveName = getPtsName(builderOut.get());
 
@@ -1047,8 +1060,7 @@ void DerivationBuilderImpl::openSlave()
     if (tcsetattr(builderOut.get(), TCSANOW, &term))
         throw SysError("putting pseudoterminal into raw mode");
 
-    if (dup2(builderOut.get(), STDERR_FILENO) == -1)
-        throw SysError("cannot pipe standard error into log file");
+    return builderOut;
 }
 
 #if NIX_WITH_AWS_AUTH

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -474,7 +474,12 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
         sendPid.writeSide.close();
 
         if (auto status = helper.wait(); !statusOk(status)) {
+            // Ensure the slave side of the pseudoterminal has been opened at least once so that reading from the master
+            // doesn't hang.
+            openSlaveNoDup();
+
             processSandboxSetupMessages();
+
             // Only reached if the child process didn't send an exception.
             throw Error("unable to start build process: %s", statusToString(status));
         }


### PR DESCRIPTION
## Motivation

We should really open the slave in the parent, but we can't because that causes random failures on macOS. So as a workaround, also open the slave in the parent if the helper dies.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of terminal setup during build sandbox initialization.
  * Ensured diagnostic and status messages remain available when sandbox setup encounters an error.
  * Standardized pseudoterminal configuration to support consistent error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->