### PR TITLE
Don't run OPENSSL_cleanup() at exit

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <regex>
 
+#include <openssl/crypto.h>
 #include <sodium.h>
 #include <boost/lexical_cast.hpp>
 #include <stdint.h>
@@ -41,6 +42,21 @@ void initLibUtil()
 
     if (sodium_init() == -1)
         throw Error("could not initialise libsodium");
+
+    /* Prevent OpenSSL from registering its atexit() handler
+       (OPENSSL_cleanup()). If we exit() while other threads that use
+       OpenSSL are still running, OPENSSL_cleanup() frees OpenSSL's
+       thread-local state handlers; when those threads then exit, their
+       thread-specific-data destructors (init_thread_stop()) crash on
+       the freed state. This happens in particular in nix-daemon
+       connection children, where library destructors run by _dl_fini()
+       (e.g. aws-crt-cpp's) stop their worker threads *after*
+       OPENSSL_cleanup() has already run. Since we're exiting anyway,
+       skipping the cleanup is harmless. This must run before any other
+       use of OpenSSL, since only the first initialisation takes
+       effect. */
+    if (OPENSSL_init_crypto(OPENSSL_INIT_NO_ATEXIT, nullptr) != 1)
+        throw Error("could not initialise OpenSSL");
 }
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Motivation

This hopefully fixes the most common sentry crash report right now (139 reports in the last 5 days) where Nix (usually the daemon) crashes on exit because OpenSSL cleanup runs while other threads (like aws-crt-cpp) are still using it. The fix is to not run OpenSSL cleanup.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenSSL initialization reliability.
  * Prevented automatic cleanup behavior that could cause shutdown-related issues.
  * Added clear error reporting when cryptographic initialization fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->