### PR TITLE
Make logging functions noexcept

### DIFF
--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -19,12 +19,12 @@ public:
         return oss.str();
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s) noexcept override
     {
         oss << s << std::endl;
     }
 
-    void logEI(const ErrorInfo & ei) override
+    void logEI(const ErrorInfo & ei) noexcept override
     {
         showErrorInfo(oss, ei, loggerSettings.showTrace.get());
     }

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -175,7 +175,7 @@ public:
         return printBuildLogs;
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s) noexcept override
     {
         if (lvl > verbosity)
             return;
@@ -183,7 +183,7 @@ public:
         log(*state, lvl, s);
     }
 
-    void logEI(const ErrorInfo & ei) override
+    void logEI(const ErrorInfo & ei) noexcept override
     {
         auto state(state_.lock());
 
@@ -193,7 +193,7 @@ public:
         log(*state, ei.level, oss.view());
     }
 
-    void log(State & state, Verbosity lvl, std::string_view s)
+    void log(State & state, Verbosity lvl, std::string_view s) noexcept
     {
         if (state.active) {
             writeToStderr("\r\e[K" + filterANSIEscapes(s, !isTTY) + ANSI_NORMAL "\n");
@@ -203,7 +203,7 @@ public:
         }
     }
 
-    void logActivity(State & state, Verbosity lvl, ActInfo & act)
+    void logActivity(State & state, Verbosity lvl, ActInfo & act) noexcept
     {
         if (!act.logged && lvl <= verbosity && !act.s.empty() && act.type != actBuildWaiting) {
             log(state, lvl, act.s + "...");
@@ -217,7 +217,7 @@ public:
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent) noexcept override
     {
         auto state(state_.lock());
 
@@ -237,12 +237,6 @@ public:
             auto machineName = getS(fields, 1);
             if (machineName != "")
                 i->s += fmt(" on " ANSI_BOLD "%s" ANSI_NORMAL, machineName);
-
-            // Used to be curRound and nrRounds, but the
-            // implementation was broken for a long time.
-            if (getI(fields, 2) != 1 || getI(fields, 3) != 1) {
-                throw Error("log message indicated repeating builds, but this is not currently implemented");
-            }
             i->name = DrvName(name).name;
         }
 
@@ -292,7 +286,7 @@ public:
         return false;
     }
 
-    void stopActivity(ActivityId act) override
+    void stopActivity(ActivityId act) noexcept override
     {
         auto state(state_.lock());
 
@@ -314,7 +308,7 @@ public:
         update(*state);
     }
 
-    void result(ActivityId act, ResultType type, const std::vector<Field> & fields) override
+    void result(ActivityId act, ResultType type, const std::vector<Field> & fields) noexcept override
     {
         auto state(state_.lock());
 
@@ -393,7 +387,7 @@ public:
         }
     }
 
-    void update(State & state)
+    void update(State & state) noexcept
     {
         state.haveUpdate = true;
         updateCV.notify_one();
@@ -406,7 +400,7 @@ public:
      * with text selection in some terminals, including libvte-based terminal
      * emulators.
      */
-    void redraw(std::string newOutput)
+    void redraw(std::string newOutput) noexcept
     {
         auto lastOutput(lastOutput_.lock());
         if (newOutput != *lastOutput) {
@@ -415,7 +409,7 @@ public:
         }
     }
 
-    std::chrono::milliseconds draw(State & state)
+    std::chrono::milliseconds draw(State & state) noexcept
     {
         auto nextWakeup = std::chrono::milliseconds::max();
 
@@ -475,7 +469,7 @@ public:
         return nextWakeup;
     }
 
-    std::string getStatus(State & state)
+    std::string getStatus(State & state) noexcept
     {
         std::string res;
 

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -69,7 +69,7 @@ struct TunnelLogger : public Logger
     {
     }
 
-    void enqueueMsg(const std::string & s)
+    void enqueueMsg(const std::string & s) noexcept
     {
         auto state(state_.lock());
 
@@ -80,15 +80,18 @@ struct TunnelLogger : public Logger
                 to.flush();
             } catch (...) {
                 /* Write failed; that means that the other side is
-                   gone. */
+                   gone, so stop sending it messages. Note that we
+                   don't propagate the error, since logging must not
+                   throw. The client's death will be detected
+                   elsewhere (e.g. by `MonitorFdHup` or by the next
+                   protocol read/write). */
                 state->canSendStderr = false;
-                throw;
             }
         } else
             state->pendingMsgs.push_back(s);
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s) noexcept override
     {
         if (lvl > verbosity)
             return;
@@ -98,7 +101,7 @@ struct TunnelLogger : public Logger
         enqueueMsg(buf.s);
     }
 
-    void logEI(const ErrorInfo & ei) override
+    void logEI(const ErrorInfo & ei) noexcept override
     {
         if (ei.level > verbosity)
             return;
@@ -151,7 +154,7 @@ struct TunnelLogger : public Logger
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent) noexcept override
     {
         if (clientVersion.number < WorkerProto::Version::Number{1, 20}) {
             if (!s.empty())
@@ -164,7 +167,7 @@ struct TunnelLogger : public Logger
         enqueueMsg(buf.s);
     }
 
-    void stopActivity(ActivityId act) override
+    void stopActivity(ActivityId act) noexcept override
     {
         if (clientVersion.number < WorkerProto::Version::Number{1, 20})
             return;
@@ -173,7 +176,7 @@ struct TunnelLogger : public Logger
         enqueueMsg(buf.s);
     }
 
-    void result(ActivityId act, ResultType type, const Fields & fields) override
+    void result(ActivityId act, ResultType type, const Fields & fields) noexcept override
     {
         if (clientVersion.number < WorkerProto::Version::Number{1, 20})
             return;

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -225,13 +225,9 @@ struct curlFileTransfer : public FileTransfer
                     curl_multi_remove_handle(fileTransfer.curlm.get(), req);
                 curl_easy_cleanup(req);
             }
-            try {
-                if (!done && enqueued)
-                    fail(FileTransferError(
-                        Interrupted, {}, "%s of '%s' was interrupted", Uncolored(request.noun()), request.uri));
-            } catch (...) {
-                ignoreExceptionInDestructor();
-            }
+            if (!done && enqueued)
+                fail(FileTransferError(
+                    Interrupted, {}, "%s of '%s' was interrupted", Uncolored(request.noun()), request.uri));
         }
 
         void failEx(std::exception_ptr ex) noexcept

--- a/src/libutil-c/nix_api_util.cc
+++ b/src/libutil-c/nix_api_util.cc
@@ -33,7 +33,7 @@ public:
             vtable.destroy(userdata);
     }
 
-    void log(nix::Verbosity lvl, std::string_view s) override
+    void log(nix::Verbosity lvl, std::string_view s) noexcept override
     {
         if (!vtable.log)
             return;
@@ -41,7 +41,7 @@ public:
         vtable.log(userdata, static_cast<nix_verbosity>(lvl), buf.c_str());
     }
 
-    void logEI(const nix::ErrorInfo & ei) override
+    void logEI(const nix::ErrorInfo & ei) noexcept override
     {
         if (!vtable.log)
             return;
@@ -57,7 +57,7 @@ public:
         nix::ActivityType type,
         const std::string & s,
         const Fields & /*fields*/,
-        nix::ActivityId parent) override
+        nix::ActivityId parent) noexcept override
     {
         if (!vtable.start_activity)
             return;
@@ -65,13 +65,13 @@ public:
             userdata, act, static_cast<nix_verbosity>(lvl), static_cast<nix_activity_type>(type), s.c_str(), parent);
     }
 
-    void stopActivity(nix::ActivityId act) override
+    void stopActivity(nix::ActivityId act) noexcept override
     {
         if (vtable.stop_activity)
             vtable.stop_activity(userdata, act);
     }
 
-    void result(nix::ActivityId act, nix::ResultType type, const Fields & fields) override
+    void result(nix::ActivityId act, nix::ResultType type, const Fields & fields) noexcept override
     {
         if (!vtable.result_string)
             return;

--- a/src/libutil/include/nix/util/logging.hh
+++ b/src/libutil/include/nix/util/logging.hh
@@ -141,22 +141,27 @@ public:
         return false;
     }
 
-    virtual void log(Verbosity lvl, std::string_view s) = 0;
+    /* Note: logging functions must be noexcept, since they're often
+       called in contexts where exceptions cannot be handled (such as
+       in completion callbacks or destructors). Implementations should
+       handle failure to write the message (e.g. by ignoring it or
+       disabling the logger). */
+    virtual void log(Verbosity lvl, std::string_view s) noexcept = 0;
 
-    void log(std::string_view s)
+    void log(std::string_view s) noexcept
     {
         log(lvlInfo, s);
     }
 
-    virtual void logEI(const ErrorInfo & ei) = 0;
+    virtual void logEI(const ErrorInfo & ei) noexcept = 0;
 
-    void logEI(Verbosity lvl, ErrorInfo ei)
+    void logEI(Verbosity lvl, ErrorInfo ei) noexcept
     {
         ei.level = lvl;
         logEI(ei);
     }
 
-    virtual void warn(const std::string & msg);
+    virtual void warn(const std::string & msg) noexcept;
 
     virtual void startActivity(
         ActivityId act,
@@ -164,13 +169,13 @@ public:
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) {};
+        ActivityId parent) noexcept {};
 
-    virtual void stopActivity(ActivityId act) {};
+    virtual void stopActivity(ActivityId act) noexcept {};
 
-    virtual void result(ActivityId act, ResultType type, const Fields & fields) {};
+    virtual void result(ActivityId act, ResultType type, const Fields & fields) noexcept {};
 
-    virtual void result(ActivityId act, ResultType type, const nlohmann::json & json) {};
+    virtual void result(ActivityId act, ResultType type, const nlohmann::json & json) noexcept {};
 
     virtual void writeToStdout(std::string_view s);
 
@@ -375,6 +380,6 @@ inline void warn(const std::string & fs, const Args &... args)
         warn(args);                   \
     }
 
-void writeToStderr(std::string_view s);
+void writeToStderr(std::string_view s) noexcept;
 
 } // namespace nix

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -42,7 +42,7 @@ void setCurActivity(const ActivityId activityId)
  */
 Logger * logger = makeSimpleLogger(true).release();
 
-void Logger::warn(const std::string & msg)
+void Logger::warn(const std::string & msg) noexcept
 {
     log(lvlWarn, ANSI_WARNING "warning:" ANSI_NORMAL " " + msg);
 }
@@ -86,7 +86,7 @@ public:
         return printBuildLogs;
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s) noexcept override
     {
         if (lvl > verbosity)
             return;
@@ -124,7 +124,7 @@ public:
         writeToStderr(prefix + filterANSIEscapes(s, !tty) + "\n");
     }
 
-    void logEI(const ErrorInfo & ei) override
+    void logEI(const ErrorInfo & ei) noexcept override
     {
         std::ostringstream oss;
         showErrorInfo(oss, ei, loggerSettings.showTrace.get());
@@ -138,13 +138,13 @@ public:
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent) noexcept override
     {
         if (lvl <= verbosity && !s.empty())
             log(lvl, s + "...");
     }
 
-    void result(ActivityId act, ResultType type, const Fields & fields) override
+    void result(ActivityId act, ResultType type, const Fields & fields) noexcept override
     {
         if (type == resBuildLogLine && printBuildLogs) {
             auto lastLine = fields[0].s;
@@ -158,7 +158,7 @@ public:
 
 Verbosity verbosity = lvlInfo;
 
-static void writeFullLogging(Descriptor fd, std::string_view s)
+static void writeFullLogging(Descriptor fd, std::string_view s) noexcept
 {
     try {
         writeFull(fd, s, false);
@@ -170,7 +170,7 @@ static void writeFullLogging(Descriptor fd, std::string_view s)
     }
 }
 
-void writeToStderr(std::string_view s)
+void writeToStderr(std::string_view s) noexcept
 {
     writeFullLogging(getStandardError(), s);
 }
@@ -289,7 +289,7 @@ struct JSONLogger : Logger
         }
     }
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s) noexcept override
     {
         nlohmann::json json;
         json["action"] = "msg";
@@ -298,7 +298,7 @@ struct JSONLogger : Logger
         write(std::move(json));
     }
 
-    void logEI(const ErrorInfo & ei) override
+    void logEI(const ErrorInfo & ei) noexcept override
     {
         std::ostringstream oss;
         showErrorInfo(oss, ei, loggerSettings.showTrace.get());
@@ -331,7 +331,7 @@ struct JSONLogger : Logger
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent) noexcept override
     {
         nlohmann::json json;
         json["action"] = "start";
@@ -344,7 +344,7 @@ struct JSONLogger : Logger
         write(std::move(json));
     }
 
-    void stopActivity(ActivityId act) override
+    void stopActivity(ActivityId act) noexcept override
     {
         nlohmann::json json;
         json["action"] = "stop";
@@ -352,7 +352,7 @@ struct JSONLogger : Logger
         write(std::move(json));
     }
 
-    void result(ActivityId act, ResultType type, const Fields & fields) override
+    void result(ActivityId act, ResultType type, const Fields & fields) noexcept override
     {
         nlohmann::json json;
         json["action"] = "result";
@@ -362,7 +362,7 @@ struct JSONLogger : Logger
         write(std::move(json));
     }
 
-    void result(ActivityId act, ResultType type, const nlohmann::json & j) override
+    void result(ActivityId act, ResultType type, const nlohmann::json & j) noexcept override
     {
         nlohmann::json json;
         json["action"] = "result";

--- a/src/libutil/tee-logger.cc
+++ b/src/libutil/tee-logger.cc
@@ -29,13 +29,13 @@ struct TeeLogger : Logger
             logger->resume();
     };
 
-    void log(Verbosity lvl, std::string_view s) override
+    void log(Verbosity lvl, std::string_view s) noexcept override
     {
         for (auto & logger : loggers)
             logger->log(lvl, s);
     }
 
-    void logEI(const ErrorInfo & ei) override
+    void logEI(const ErrorInfo & ei) noexcept override
     {
         for (auto & logger : loggers)
             logger->logEI(ei);
@@ -47,25 +47,25 @@ struct TeeLogger : Logger
         ActivityType type,
         const std::string & s,
         const Fields & fields,
-        ActivityId parent) override
+        ActivityId parent) noexcept override
     {
         for (auto & logger : loggers)
             logger->startActivity(act, lvl, type, s, fields, parent);
     }
 
-    void stopActivity(ActivityId act) override
+    void stopActivity(ActivityId act) noexcept override
     {
         for (auto & logger : loggers)
             logger->stopActivity(act);
     }
 
-    void result(ActivityId act, ResultType type, const Fields & fields) override
+    void result(ActivityId act, ResultType type, const Fields & fields) noexcept override
     {
         for (auto & logger : loggers)
             logger->result(act, type, fields);
     }
 
-    void result(ActivityId act, ResultType type, const nlohmann::json & json) override
+    void result(ActivityId act, ResultType type, const nlohmann::json & json) noexcept override
     {
         for (auto & logger : loggers)
             logger->result(act, type, json);


### PR DESCRIPTION
## Motivation

Make the logging functions `noexcept`, and in particular, make sure that `TunnelLogger` doesn't throw. This (probably) fixes a daemon crash where the client has disconnected, and `~TransferItem()` calls a `HttpBinaryCacheStore` callback which in turn calls `printError()` in `HttpBinaryCacheStore::maybeDisable()`.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of logging, progress reporting, and activity tracking by preventing exceptions from escaping during message handling.
  * File transfer cleanup now reports interrupted transfers consistently instead of silently suppressing failures.
  * Client-facing logging continues safely when sending diagnostic output fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->