### PR TITLE
Make NIX_COUNT_CALLS thread-safe

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -338,12 +338,14 @@ EvalState::EvalState(
     , baseEnv(mem.allocEnv(BASE_ENV_SIZE))
 #endif
     , staticBaseEnv{std::make_shared<StaticEnv>(nullptr, nullptr)}
+    , countCalls(getEnv("NIX_COUNT_CALLS").value_or("0") != "0")
+    , primOpCalls(make_ref<decltype(primOpCalls)::element_type>())
+    , functionCalls(make_ref<decltype(functionCalls)::element_type>())
+    , attrSelects(make_ref<decltype(attrSelects)::element_type>())
     , executor{make_ref<Executor>(settings)}
 {
     corepkgsFS->setPathDisplay("<nix", ">");
     internalFS->setPathDisplay("«nix-internal»", "");
-
-    countCalls = getEnv("NIX_COUNT_CALLS").value_or("0") != "0";
 
     static_assert(sizeof(Env) <= 16, "environment must be <= 16 bytes");
 
@@ -942,7 +944,7 @@ void Value::mkPath(const SourcePath & path, EvalMemory & mem)
         forceAttrs(*env->values[0], fromWith->pos, "while evaluating the first subexpression of a with expression");
         if (auto j = env->values[0]->attrs()->get(var.name)) {
             if (countCalls) [[unlikely]]
-                attrSelects[j->pos]++;
+                attrSelects->try_emplace_or_visit(j->pos, 1, [](auto & i) { i.second++; });
             return j->value;
         }
         if (!fromWith->parentWith) [[unlikely]]
@@ -1488,7 +1490,7 @@ void ExprSelect::eval(EvalState & state, Env & env, Value & v)
             vAttrs = j->value;
             pos2 = j->pos;
             if (state.countCalls)
-                state.attrSelects[pos2]++;
+                state.attrSelects->try_emplace_or_visit(pos2, 1, [](auto & i) { i.second++; });
         }
 
         state.forceValue(*vAttrs, pos2 ? pos2 : this->pos);
@@ -1704,7 +1706,7 @@ void EvalState::callFunction(Value & fun, std::span<Value *> args, Value & vRes,
 
                 nrPrimOpCalls++;
                 if (countCalls)
-                    primOpCalls[fn->name]++;
+                    primOpCalls->try_emplace_or_visit(fn->name, 1, [](auto & i) { i.second++; });
 
                 try {
                     auto pos = vCur.determinePos(noPos);
@@ -1752,7 +1754,7 @@ void EvalState::callFunction(Value & fun, std::span<Value *> args, Value & vRes,
                 auto fn = primOp->primOp();
                 nrPrimOpCalls++;
                 if (countCalls)
-                    primOpCalls[fn->name]++;
+                    primOpCalls->try_emplace_or_visit(fn->name, 1, [](auto & i) { i.second++; });
 
                 try {
                     // TODO:
@@ -1826,7 +1828,7 @@ void ExprCall::eval(EvalState & state, Env & env, Value & v)
 // prevents tail-call optimisation.
 void EvalState::incrFunctionCall(ExprLambda * fun)
 {
-    functionCalls[fun]++;
+    functionCalls->try_emplace_or_visit(fun, 1, [](auto & i) { i.second++; });
 }
 
 void EvalState::autoCallFunction(const Bindings & args, Value & fun, Value & res)
@@ -3081,11 +3083,16 @@ void EvalState::printStatistics()
 #endif
 
     if (countCalls) {
-        topObj["primops"] = primOpCalls;
+        {
+            auto & obj = topObj["primops"];
+            obj = json::object();
+            primOpCalls->visit_all([&](auto & i) { obj[i.first] = i.second; });
+        }
         {
             auto & list = topObj["functions"];
             list = json::array();
-            for (auto & [fun, count] : functionCalls) {
+            functionCalls->visit_all([&](auto & i) {
+                auto & [fun, count] = i;
                 json obj = json::object();
                 if (fun->name)
                     obj["name"] = (std::string_view) symbols[fun->name];
@@ -3099,12 +3106,12 @@ void EvalState::printStatistics()
                 }
                 obj["count"] = count;
                 list.push_back(obj);
-            }
+            });
         }
         {
-            auto list = topObj["attributes"];
+            auto & list = topObj["attributes"];
             list = json::array();
-            for (auto & i : attrSelects) {
+            attrSelects->visit_all([&](auto & i) {
                 json obj = json::object();
                 if (auto pos = positions[i.first]) {
                     if (auto path = std::get_if<SourcePath>(&pos.origin))
@@ -3114,7 +3121,7 @@ void EvalState::printStatistics()
                 }
                 obj["count"] = i.second;
                 list.push_back(obj);
-            }
+            });
         }
     }
 

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -1086,23 +1086,21 @@ public:
     Counter nrSpuriousWakeups;
 
 private:
-    bool countCalls;
+    const bool countCalls;
 
-    // FIXME: make thread-safe.
-    typedef boost::unordered_flat_map<std::string, size_t, StringViewHash, std::equal_to<>> PrimOpCalls;
-    PrimOpCalls primOpCalls;
+    typedef boost::concurrent_flat_map<std::string, size_t, StringViewHash, std::equal_to<>> PrimOpCalls;
+    const ref<PrimOpCalls> primOpCalls;
 
-    typedef boost::unordered_flat_map<ExprLambda *, size_t> FunctionCalls;
-    FunctionCalls functionCalls;
+    typedef boost::concurrent_flat_map<ExprLambda *, size_t> FunctionCalls;
+    const ref<FunctionCalls> functionCalls;
 
     /** Evaluation/call profiler. */
     MultiEvalProfiler profiler;
 
     void incrFunctionCall(ExprLambda * fun);
 
-    // FIXME: make thread-safe.
-    typedef boost::unordered_flat_map<PosIdx, size_t, std::hash<PosIdx>> AttrSelects;
-    AttrSelects attrSelects;
+    typedef boost::concurrent_flat_map<PosIdx, size_t, std::hash<PosIdx>> AttrSelects;
+    const ref<AttrSelects> attrSelects;
 
     friend struct ExprOpUpdate;
     friend struct ExprOpConcatLists;

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3215,7 +3215,7 @@ void prim_getAttr(EvalState & state, const PosIdx pos, Value ** args, Value & v)
     auto i = state.getAttr(state.symbols.create(attr), args[1]->attrs(), "in the attribute set under consideration");
     // !!! add to stack trace?
     if (state.countCalls && i->pos)
-        state.attrSelects[i->pos]++;
+        state.attrSelects->try_emplace_or_visit(i->pos, 1, [](auto & j) { j.second++; });
     state.forceValue(*i->value, pos);
     v = *i->value;
 }


### PR DESCRIPTION
## Motivation

The `primOpCalls`, `functionCalls` and `attrSelects` maps were plain `unordered_flat_map`s updated from evaluator threads, so running with `NIX_COUNT_CALLS=1` crashed when parallel evaluation was enabled. Turn them into `boost::concurrent_flat_maps` and update them using `try_emplace_or_visit()`.

Also fix a pre-existing bug in `printStatistics()` where the "attributes" list was built into a copy of the JSON node, so the output always contained `"attributes": null`.

Assisted-by: Claude Fable 5 <noreply@anthropic.com>
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of call, function, primitive operation, and attribute-selection statistics when evaluations occur concurrently.
  * Preserved accurate statistics reporting while enabling safer concurrent updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->