### PR TITLE
Fix terminateHandler() on macOS     

### DIFF
--- a/nix-meson-build-support/common/cxa-throw/is-logic-error.hh
+++ b/nix-meson-build-support/common/cxa-throw/is-logic-error.hh
@@ -5,9 +5,31 @@
 #include <stdexcept>
 #include <typeinfo>
 #include <cstring>
+#include <cstdio>
 
 #ifndef CXA_THROW_ON_LOGIC_ERROR
 #  define CXA_THROW_ON_LOGIC_ERROR() abort()
+#endif
+
+#include <cxxabi.h>
+
+#ifndef __GLIBCXX__
+/* libc++abi implements the Itanium ABI RTTI classes but, unlike
+   libstdc++, doesn't declare them in <cxxabi.h>. Their layout is
+   fixed by the ABI, so declare what we need. */
+namespace __cxxabiv1 {
+class __class_type_info : public std::type_info
+{
+public:
+    ~__class_type_info() override;
+};
+
+class __si_class_type_info : public __class_type_info
+{
+public:
+    const __class_type_info * __base_type;
+};
+} // namespace __cxxabiv1
 #endif
 
 static bool is_logic_error(const std::type_info * tinfo)

--- a/src/libutil/include/nix/util/error.hh
+++ b/src/libutil/include/nix/util/error.hh
@@ -460,6 +460,12 @@ void throwExceptionSelfCheck();
 void panic(std::string_view msg);
 
 /**
+ * Log the current exception (if any) and call abort().
+ */
+[[noreturn]]
+void onTerminate();
+
+/**
  * Run a function, printing an error and returning on exception.
  * Useful for wrapping a `main` function that may throw
  *

--- a/src/nix/crash-handler.cc
+++ b/src/nix/crash-handler.cc
@@ -31,10 +31,12 @@ void logFatal(std::string const & s)
 #endif
 }
 
+} // namespace
+
 void onTerminate()
 {
     logFatal(
-        "Determinate Nix crashed. This is a bug. Please report this at https://github.com/DeterminateSystems/nix-src/issues with the following information included:\n");
+        "\nDeterminate Nix crashed. This is a bug. Please report this at https://github.com/DeterminateSystems/nix-src/issues with the following information included:\n");
     try {
         std::exception_ptr eptr = std::current_exception();
         if (eptr) {
@@ -55,7 +57,6 @@ void onTerminate()
 
     std::abort();
 }
-} // namespace
 
 void registerCrashHandler()
 {

--- a/src/nix/crash.cc
+++ b/src/nix/crash.cc
@@ -51,6 +51,11 @@ struct CmdCrash : Command
             panic("test panic");
         }
 
+        else if (type == "abort") {
+            printError("Triggering an abort...");
+            std::abort();
+        }
+
         else if (type == "terminate") {
             printError("Triggering an std::terminate...");
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -406,9 +406,7 @@ static void terminateHandler()
         }
     }
 
-    // Call the original terminate handler.
-    std::set_terminate(nullptr);
-    std::terminate();
+    onTerminate();
 }
 
 void mainWrapped(int argc, char ** argv)

--- a/tests/functional/sentry.sh
+++ b/tests/functional/sentry.sh
@@ -27,7 +27,7 @@ waitForCrashDump() {
     return 1
 }
 
-for type in segfault assert logic-error panic terminate; do
+for type in segfault assert logic-error panic terminate abort; do
     if [[ $type = logic-error && $(uname) = Darwin ]]; then continue; fi
 
     rm -rf "$sentryDir"


### PR DESCRIPTION
## Motivation

On macOS, calling `std::set_terminate(nullptr)` to restore the original terminate handler is ineffective, since `std::terminate()` calls the handler recorded in the exception. So we end up in an infinite  recursion of `terminateHandler()` calls, which eventually overflows the stack, leading to an unhelpful crash report.
    
So instead, just call `onTerminate()` to print the stack trace and abort.
    
(On Linux / libstdc++, `std::terminate()` calls the global terminate handler so we don't have this issue.)

Also added some hackery to make the __cxa_throw interposer build with libc++ on Linux, and added an `abort` mode to `nix __crash`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `abort` option to the crash-testing command, allowing users to simulate process termination explicitly.

* **Bug Fixes**
  * Improved termination handling so unexpected failures consistently produce a crash report and log the active exception when available.
  * Improved crash diagnostics with clearer formatting in termination messages.

* **Tests**
  * Expanded crash-reporting coverage to include the new `abort` scenario alongside existing crash types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->