### PR TITLE
Fix disabling OpenSSL's atexit handler

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -21,6 +21,10 @@ namespace nix {
 
 void initLibUtil()
 {
+    static std::atomic_flag done = ATOMIC_FLAG_INIT;
+    if (done.test_and_set())
+        return;
+
     // Check that exception handling works. Exception handling has been observed
     // not to work on darwin when the linker flags aren't quite right.
     // In this case we don't want to expose the user to some unrelated uncaught

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -422,6 +422,9 @@ void mainWrapped(int argc, char ** argv)
     }
 #endif
 
+    /* This must be called before Sentry since both initialize OpenSSL. */
+    initLibUtil();
+
     bool sentryEnabled = false;
 
 #if HAVE_SENTRY


### PR DESCRIPTION

## Motivation

Followup to #560. This didn't work when Sentry is enabled, because it initializes OpenSSL first. So we now call `initLibUtil()` before Sentry.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup reliability by ensuring core library initialization runs consistently.
  * Prevented repeated initialization work during the same process, helping avoid redundant setup and potential initialization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->