### PR TITLE
Prevent LocalCommand 'started' leak on stale SSH master socket

### DIFF
--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -6,11 +6,6 @@
 #include "nix/util/exec.hh"
 #include "nix/util/base-n.hh"
 
-#ifndef _WIN32
-#  include <sys/wait.h>
-#  include <cerrno>
-#endif
-
 namespace nix {
 
 static std::string parsePublicHostKey(std::string_view host, std::string_view sshPublicHostKey)
@@ -254,20 +249,9 @@ std::optional<std::filesystem::path> SSHMaster::startMaster()
 
     auto state(state_.lock());
 
-    if (state->sshMaster != INVALID_DESCRIPTOR) {
-        // Check if master is still alive before returning cached socket.
-        pid_t result = waitpid(state->sshMaster, nullptr, WNOHANG);
-        if (result == 0)
-            return state->socketPath;
-        if (result == -1) {
-            if (errno == EINTR)
-                return state->socketPath; // assume alive; worst case SSH falls back
-            if (errno != ECHILD)
-                warn("waitpid failed for SSH master %d: %s", (pid_t) state->sshMaster, strerror(errno));
-        }
-        // Master gone — release Pid to avoid kill()/wait() on already-reaped child.
-        state->sshMaster.release();
-    }
+    // Check if the master is still alive before returning the cached socket.
+    if (state->sshMaster != INVALID_DESCRIPTOR && state->sshMaster.isAlive())
+        return state->socketPath;
 
     state->socketPath = tmpDir->path() / "ssh.sock";
 

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -6,6 +6,11 @@
 #include "nix/util/exec.hh"
 #include "nix/util/base-n.hh"
 
+#ifndef _WIN32
+#  include <sys/wait.h>
+#  include <cerrno>
+#endif
+
 namespace nix {
 
 static std::string parsePublicHostKey(std::string_view host, std::string_view sshPublicHostKey)
@@ -193,6 +198,16 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(OsStrings && comm
                 if (verbosity >= lvlChatty)
                     args.push_back("-v");
                 args.splice(args.end(), std::move(extraSshArgs));
+                // Override LocalCommand to no-op on command SSHs; master
+                // already consumed "started". On fallback, "echo started"
+                // would leak into the nix protocol stream. #441
+                if (useMaster) {
+                    for (auto & arg : args) {
+                        if (arg.starts_with(OS_STR("-oLocalCommand="))) {
+                            arg = OS_STR("-oLocalCommand=true");
+                        }
+                    }
+                }
                 args.push_back("--");
             }
 
@@ -208,9 +223,9 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(OsStrings && comm
     in.readSide = INVALID_DESCRIPTOR;
     out.writeSide = INVALID_DESCRIPTOR;
 
-    // Wait for the SSH connection to be established,
-    // So that we don't overwrite the password prompt with our progress bar.
-    if (!fakeSSH && !(socketPath && isMasterRunning(*socketPath))) {
+    // Skip readLine when useMaster: SSH connects via master socket, or
+    // falls back to direct connection where LocalCommand is now a no-op.
+    if (!fakeSSH && !useMaster && !(socketPath && isMasterRunning(*socketPath))) {
         std::string reply;
         try {
             reply = readLine(out.readSide.get());
@@ -239,8 +254,21 @@ std::optional<std::filesystem::path> SSHMaster::startMaster()
 
     auto state(state_.lock());
 
-    if (state->sshMaster != INVALID_DESCRIPTOR)
-        return state->socketPath;
+    if (state->sshMaster != INVALID_DESCRIPTOR) {
+        // Check if master is still alive before returning cached socket.
+        pid_t result = waitpid(state->sshMaster, nullptr, WNOHANG);
+        if (result == 0)
+            return state->socketPath;
+        if (result == -1) {
+            if (errno == EINTR)
+                return state->socketPath; // assume alive; worst case SSH falls back
+            if (errno != ECHILD)
+                warn("waitpid failed for SSH master %d: %s",
+                     (pid_t) state->sshMaster, strerror(errno));
+        }
+        // Master gone — release Pid to avoid kill()/wait() on already-reaped child.
+        state->sshMaster.release();
+    }
 
     state->socketPath = tmpDir->path() / "ssh.sock";
 

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -263,8 +263,7 @@ std::optional<std::filesystem::path> SSHMaster::startMaster()
             if (errno == EINTR)
                 return state->socketPath; // assume alive; worst case SSH falls back
             if (errno != ECHILD)
-                warn("waitpid failed for SSH master %d: %s",
-                     (pid_t) state->sshMaster, strerror(errno));
+                warn("waitpid failed for SSH master %d: %s", (pid_t) state->sshMaster, strerror(errno));
         }
         // Master gone — release Pid to avoid kill()/wait() on already-reaped child.
         state->sshMaster.release();

--- a/src/libutil/include/nix/util/processes.hh
+++ b/src/libutil/include/nix/util/processes.hh
@@ -61,6 +61,13 @@ public:
 
     // TODO: Implement for Windows
 #ifndef _WIN32
+    /**
+     * Check whether the child process is still running, without
+     * blocking. If it has exited (or was reaped elsewhere), the child
+     * is reaped if necessary and this object is reset so that the
+     * destructor won't kill()/wait() an already-dead process.
+     */
+    bool isAlive();
     void setSeparatePG(bool separatePG);
     void setKillSignal(int signal);
     void setKillTimeout(std::chrono::milliseconds duration);

--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -130,6 +130,25 @@ int Pid::wait(bool allowInterrupts)
     }
 }
 
+bool Pid::isAlive()
+{
+    assert(pid != -1);
+    pid_t res = waitpid(pid, nullptr, WNOHANG);
+    if (res == 0)
+        return true;
+    if (res == -1) {
+        if (errno == EINTR)
+            /* Assume it's still alive; the caller can check again later. */
+            return true;
+        if (errno != ECHILD)
+            warn("waitpid failed for PID %d: %s", pid, strerror(errno));
+    }
+    /* The process has exited and been reaped (or was already reaped
+       elsewhere). Reset so the destructor doesn't kill()/wait() it. */
+    release();
+    return false;
+}
+
 void Pid::setSeparatePG(bool separatePG)
 {
     this->separatePG = separatePG;


### PR DESCRIPTION
## Motivation
When `maxConnections > 1` (the Determinate default is 64), `SSHMaster` creates SSH masters with `-M -N`. Command SSHs connect through the master socket. When the master dies (`ControlPersist=no` is the default with `-M`), the socket becomes stale. The next command SSH falls back to a direct connection, which runs `LocalCommand=echo started`. Since `startCommand()` skips reading `"started"` when `useMaster=true` (it assumes the master already consumed it), the string leaks into the nix protocol stream:
```
error: cannot open connection to remote store 'ssh-ng://build@10.10.127.43': protocol mismatch, got 'started'
```
Upstream Nix defaults `maxConnections` to 1, so `useMaster=false` and the bug is never reachable. Determinate's default of 64 enables SSH master mode, exposing this latent code path.
## Context
- **Upstream issue:** NixOS/nix#14132 — "SSH `ControlMaster auto` breaks `ssh-ng://` remote store"
- **Related:** NixOS/nix#8329 — same bug variant with `ControlPersist=yes`
- **Origin of `LocalCommand`:** NixOS/nix#8018 / PR #8018 — introduced `LocalCommand=echo started` to prevent progress bar output from garbling SSH password prompts
- **Determinate issue:** DeterminateSystems/nix-src#441 — "Remote store access fails when using SSH multiplexing"
The `LocalCommand=echo started` mechanism was designed for the `useMaster=false` case (direct connections). When `useMaster=true`, the code correctly skips reading `"started"` from command SSHs because OpenSSH does not run `LocalCommand` on connections through a live master socket. The bug only manifests when the master is dead and the command SSH falls back to a direct connection.
## Implementation
Two changes in `src/libstore/ssh.cc`:
### 1. Override `LocalCommand` to no-op on command SSHs when `useMaster=true`
In `startCommand()`, after `extraSshArgs` are spliced into the args list:
```cpp
if (useMaster)
    args.push_back(OS_STR("-oLocalCommand=true"));
```
SSH processes `-o` options in order; the last value for a keyword wins. `addCommonSSHOpts()` adds `-oLocalCommand=echo started` earlier. Our override `-oLocalCommand=true` (the POSIX no-op command) comes later and wins.
**Behavioral matrix after fix:**
| Scenario | `LocalCommand` fires? | What runs? | stdout output |
|---|---|---|---|
| Through live multiplex | No | — | Nothing (correct) |
| Direct connection (no master) | Yes | `echo started` | `"started"` consumed by `startCommand()` (correct) |
| Fallback (stale socket) | Yes | `true` (no-op) | Nothing (correct) |
### 2. (Optional) Change `ControlPersist` from `no` to `15m`
In `startMaster()`:
```cpp
- OsStrings args = {"ssh", hostnameAndUser.c_str(), "-M", "-N", "-oControlPersist=no"};
+ OsStrings args = {"ssh", hostnameAndUser.c_str(), "-M", "-N", "-oControlPersist=15m"};
```
This keeps masters alive longer, reducing the frequency of master death and fallback scenarios. Not required for the fix (Vector 4 handles the fallback correctly), but a pragmatic performance optimization.
## Alternative Approaches Considered
1. **Always consume `"started"` in `startCommand()`** — Broken. When `useMaster=true` and master is alive, command SSH stdout is the nix protocol stream. `readLine()` would read `WORKER_MAGIC_2` as `"started"`, causing immediate failure.
2. **Detect dead master before consuming `"started"`** — Inherently racy. `isMasterRunning()` is a point-in-time check; the master can die between the check and the read (TOCTOU).
3. **`-F /dev/null` to ignore SSH config** — Breaks SSH config-based `ProxyJump`, `IdentityFile`, and `StrictHostKeyChecking`.
4. **Set `max-connections=1` for `ssh-ng` in `machines.cc`** — Limits functionality. Defeats the purpose of the `maxConnections=64` default.
The chosen approach (no-op `LocalCommand` override) is deterministic, eliminates the bug at the producer side, has no race conditions, and is backward compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of SSH command sessions when master connections end and fall back to direct connections.
  * Prevented master “started” handshake output from being written into the protocol stream during fallback, avoiding potential protocol corruption.
  * Made cached SSH control-socket reuse more robust by verifying the master process is still running before reusing it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->