### PR TITLE
Don't report SIGQUIT to Sentry

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -175,6 +175,15 @@ void initNix(bool loadConfig)
     act.sa_handler = sigHandler;
     if (sigaction(SIGUSR1, &act, 0))
         throw SysError("handling SIGUSR1");
+
+    /* Reset SIGQUIT to its default disposition. In particular, this
+       unregisters any crash handler installed by `sentry_init()`
+       (which runs before us): SIGQUIT is a user-initiated "quit with
+       core dump" action (e.g. Ctrl-\ at a terminal), not a crash, so
+       it should not be reported. */
+    act.sa_handler = SIG_DFL;
+    if (sigaction(SIGQUIT, &act, 0))
+        throw SysError("handling SIGQUIT");
 #endif
 
 #ifdef __APPLE__
@@ -198,8 +207,6 @@ void initNix(bool loadConfig)
         throw SysError("handling SIGHUP");
     if (sigaction(SIGPIPE, &act, 0))
         throw SysError("handling SIGPIPE");
-    if (sigaction(SIGQUIT, &act, 0))
-        throw SysError("handling SIGQUIT");
     if (sigaction(SIGTRAP, &act, 0))
         throw SysError("handling SIGTRAP");
 #endif


### PR DESCRIPTION
## Motivation

Reset SIGQUIT to its default handler (overriding the Sentry handler). Since SIGQUIT is a user-initiated core dump, we don't want to report these to Sentry.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signal handling on non-Windows systems.
  * Ensured quit signals use the expected default behavior during initialization.
  * Added error reporting when signal configuration cannot be applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->