### PR TITLE
Don't abort if NIX_GET_COMPLETIONS is out of range

### DIFF
--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -273,7 +273,8 @@ void RootArgs::parseCmdline(const Strings & _cmdline, bool allowShebang)
 
     if (auto s = getEnv("NIX_GET_COMPLETIONS")) {
         size_t n = std::stoi(*s);
-        assert(n > 0 && n <= cmdline.size());
+        if (n < 1 || n > cmdline.size())
+            throw UsageError("NIX_GET_COMPLETIONS must be between 1 and the number of arguments");
         *std::next(cmdline.begin(), n - 1) += completionMarker;
         completions = std::make_shared<Completions>();
         verbosity = lvlError;


### PR DESCRIPTION

## Motivation

Fixes Sentry crash report DETERMINATE-NIX-2B (~30 events).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of the `NIX_GET_COMPLETIONS` setting.
  * Invalid completion values now produce a clear usage error instead of being silently accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->