### PR TITLE
LocalStore: Reduce number of SQLite calls

### DIFF
--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -77,6 +77,14 @@ struct SQLite
     void exec(const std::string & stmt);
 
     uint64_t getLastInsertedRowId();
+
+    /**
+     * Set the value returned by `getLastInsertedRowId()`. Since only
+     * successful inserts update the last-inserted rowid, this can be
+     * used to detect whether an upsert statement performed an insert
+     * or an update.
+     */
+    void setLastInsertedRowId(uint64_t id);
 };
 
 /**

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -119,7 +119,11 @@ struct LocalStorePathInfo : ValidPathInfo
         , id(id)
     {
     }
+
+    void anchor() override;
 };
+
+void LocalStorePathInfo::anchor() {}
 
 struct LocalStore::State::Stmts
 {

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -103,6 +103,24 @@ bool LocalStoreConfig::getDefaultRequireSigs()
     return settings.requireSigs;
 }
 
+/**
+ * A `ValidPathInfo` that also records the id of the corresponding row
+ * in the `ValidPaths` table of the SQLite database. This allows
+ * `queryValidPathId()` to return the id from `pathInfoCache` without
+ * consulting the database.
+ */
+struct LocalStorePathInfo : ValidPathInfo
+{
+    uint64_t id;
+
+    LocalStorePathInfo(ValidPathInfo info, uint64_t id)
+        : UnkeyedValidPathInfo(info)
+        , ValidPathInfo(std::move(info))
+        , id(id)
+    {
+    }
+};
+
 struct LocalStore::State::Stmts
 {
     /* Some precompiled SQLite statements. */
@@ -773,7 +791,8 @@ uint64_t LocalStore::addValidPath(State & state, const ValidPathInfo & info)
         }
     }
 
-    pathInfoCache->lock()->upsert(info.path, PathInfoCacheValue{.value = std::make_shared<const ValidPathInfo>(info)});
+    pathInfoCache->lock()->upsert(
+        info.path, PathInfoCacheValue{.value = std::make_shared<const LocalStorePathInfo>(info, id)});
 
     return id;
 }
@@ -808,7 +827,7 @@ std::shared_ptr<const ValidPathInfo> LocalStore::queryPathInfoInternal(State & s
         throw Error("invalid-path entry for '%s': %s", printStorePath(path), e.what());
     }
 
-    auto info = std::make_shared<ValidPathInfo>(path, UnkeyedValidPathInfo(*this, narHash));
+    auto info = std::make_shared<LocalStorePathInfo>(ValidPathInfo(path, UnkeyedValidPathInfo(*this, narHash)), id);
 
     info->registrationTime = useQueryPathInfo.getInt(2);
 
@@ -859,6 +878,14 @@ void LocalStore::updatePathInfo(State & state, const ValidPathInfo & info)
 
 uint64_t LocalStore::queryValidPathId(State & state, const StorePath & path)
 {
+    /* Avoid a database query if the id is in `pathInfoCache`. */
+    {
+        auto cache(pathInfoCache->lock());
+        if (auto res = cache->getOrNullptr(path))
+            if (auto info = dynamic_cast<const LocalStorePathInfo *>(res->value.get()))
+                return info->id;
+    }
+
     auto use(state.stmts->QueryValidPathId.use().apply(printStorePath(path)));
     if (!use.next())
         throw InvalidPath("path '%s' is not valid", printStorePath(path));
@@ -1016,6 +1043,10 @@ void LocalStore::registerValidPaths(const ValidPathInfos & infos)
             auto referrer = ids.at(i.path);
             for (auto & j : i.references) {
                 auto k = ids.find(j);
+                /* Note that queryValidPathId() uses pathInfoCache, so it's possible that path `j` has been
+                 * garbage-collected. But that's fine: the foreign key constraint on Refs will detect that the ID is no
+                 * longer valid. Path IDs are never reused so there is no possibility that ID now refers to another
+                 * path. */
                 state->stmts->AddReference.use()
                     .apply(referrer)
                     .apply(k != ids.end() ? k->second : queryValidPathId(*state, j))

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -110,6 +110,7 @@ struct LocalStore::State::Stmts
     SQLiteStmt UpdatePathInfo;
     SQLiteStmt AddReference;
     SQLiteStmt QueryPathInfo;
+    SQLiteStmt QueryValidPathId;
     SQLiteStmt QueryReferences;
     SQLiteStmt QueryReferrers;
     SQLiteStmt InvalidatePath;
@@ -367,6 +368,7 @@ LocalStore::LocalStore(ref<const Config> config)
         state->db,
         fmt("select id, hash, registrationTime, deriver, narSize, ultimate, sigs, ca%s from ValidPaths where path = ?;",
             experimentalFeatureSettings.isEnabled(Xp::Provenance) ? ", provenance" : ""));
+    state->stmts->QueryValidPathId.create(state->db, "select id from ValidPaths where path = ?;");
     state->stmts->QueryReferences.create(
         state->db, "select path from Refs join ValidPaths on reference = id where referrer = ?;");
     state->stmts->QueryReferrers.create(
@@ -857,7 +859,7 @@ void LocalStore::updatePathInfo(State & state, const ValidPathInfo & info)
 
 uint64_t LocalStore::queryValidPathId(State & state, const StorePath & path)
 {
-    auto use(state.stmts->QueryPathInfo.use().apply(printStorePath(path)));
+    auto use(state.stmts->QueryValidPathId.use().apply(printStorePath(path)));
     if (!use.next())
         throw InvalidPath("path '%s' is not valid", printStorePath(path));
     return use.getInt(0);
@@ -865,7 +867,7 @@ uint64_t LocalStore::queryValidPathId(State & state, const StorePath & path)
 
 bool LocalStore::isValidPath_(State & state, const StorePath & path)
 {
-    return state.stmts->QueryPathInfo.use().apply(printStorePath(path)).next();
+    return state.stmts->QueryValidPathId.use().apply(printStorePath(path)).next();
 }
 
 bool LocalStore::isValidPathUncached(const StorePath & path)

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -355,7 +355,9 @@ LocalStore::LocalStore(ref<const Config> config)
     /* Prepare SQL statements. */
     state->stmts->RegisterValidPath.create(
         state->db,
-        fmt("insert into ValidPaths (path, hash, registrationTime, deriver, narSize, ultimate, sigs, ca%s) values (?, ?, ?, ?, ?, ?, ?, ?%s);",
+        fmt("insert into ValidPaths (path, hash, registrationTime, deriver, narSize, ultimate, sigs, ca%s) values (?, ?, ?, ?, ?, ?, ?, ?%s) "
+            "on conflict (path) do update set hash = excluded.hash, narSize = excluded.narSize, ultimate = excluded.ultimate, sigs = excluded.sigs, ca = excluded.ca "
+            "returning id;",
             experimentalFeatureSettings.isEnabled(Xp::Provenance) ? ", provenance" : "",
             experimentalFeatureSettings.isEnabled(Xp::Provenance) ? ", ?" : ""));
     state->stmts->UpdatePathInfo.create(
@@ -734,8 +736,18 @@ uint64_t LocalStore::addValidPath(State & state, const ValidPathInfo & info)
                      .apply(renderContentAddress(info.ca), (bool) info.ca);
     if (experimentalFeatureSettings.isEnabled(Xp::Provenance))
         query.apply(info.provenance ? info.provenance->to_json_str() : "", (bool) info.provenance);
-    query.exec();
-    uint64_t id = state.db.getLastInsertedRowId();
+    /* Valid ids start at 1, so a last-inserted rowid of 0 signals
+       that the upsert did an update rather than an insert. */
+    state.db.setLastInsertedRowId(0);
+    if (!query.next())
+        throw Error("registering path '%s' in the Nix database did not return an id", printStorePath(info.path));
+    uint64_t id = query.getInt(0);
+
+    /* If the path was already valid (i.e. the upsert did an update
+       rather than an insert), the derivation outputs have already
+       been registered, so we're done. */
+    if (state.db.getLastInsertedRowId() != id)
+        return id;
 
     /* If this is a derivation, then store the derivation outputs in
        the database.  This is useful for the garbage collector: it can
@@ -990,20 +1002,23 @@ void LocalStore::registerValidPaths(const ValidPathInfos & infos)
 
         SQLiteTxn txn(state->db);
         StorePathSet paths;
+        std::unordered_map<StorePath, uint64_t> ids;
 
         for (auto & [_, i] : infos) {
             assert(i.narHash.algo == HashAlgorithm::SHA256);
-            if (isValidPath_(*state, i.path))
-                updatePathInfo(*state, i);
-            else
-                addValidPath(*state, i);
+            ids.insert_or_assign(i.path, addValidPath(*state, i));
             paths.insert(i.path);
         }
 
         for (auto & [_, i] : infos) {
-            auto referrer = queryValidPathId(*state, i.path);
-            for (auto & j : i.references)
-                state->stmts->AddReference.use().apply(referrer).apply(queryValidPathId(*state, j)).exec();
+            auto referrer = ids.at(i.path);
+            for (auto & j : i.references) {
+                auto k = ids.find(j);
+                state->stmts->AddReference.use()
+                    .apply(referrer)
+                    .apply(k != ids.end() ? k->second : queryValidPathId(*state, j))
+                    .exec();
+            }
         }
 
         /* Do a topological sort of the paths.  This will throw an

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -144,6 +144,11 @@ uint64_t SQLite::getLastInsertedRowId()
     return sqlite3_last_insert_rowid(db);
 }
 
+void SQLite::setLastInsertedRowId(uint64_t id)
+{
+    sqlite3_set_last_insert_rowid(db, id);
+}
+
 void SQLiteStmt::create(sqlite3 * db, const std::string & sql)
 {
     checkInterrupt();


### PR DESCRIPTION
## Motivation

Use SQLite upserts and cache path IDs to reduce the number of SQLite calls.

This reduces the number of SQLite calls instantiating my NixOS config on an empty store from 379086 to 225397.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
