### PR TITLE
Populate the srcToStore cache when we have a fetcher cache hit

### DIFF
--- a/src/libfetchers/fetch-to-store.cc
+++ b/src/libfetchers/fetch-to-store.cc
@@ -82,6 +82,7 @@ std::pair<StorePath, Hash> fetchToStore2(
                     path,
                     store.printStorePath(storePath),
                     hash.to_string(HashFormat::SRI, true));
+                settings.srcToStore->cache.insert_or_assign(srcToStoreKey, std::make_tuple(storePath, hash, mode));
                 return {storePath, hash};
             }
             debug("source path '%s' not in store", path);


### PR DESCRIPTION

## Motivation

This saves tens of thousands of calls to SQLite and to `makeFixedOutputPathFromCA()`. (E.g. instantiating `nixpkgs#firefox` was doing 4744 fetcher cache checks for `/pkgs/stdenv/generic/source-stdenv.sh`.)

This gave a speedup doing `nix eval --json nixpkgs#firefox` from 2.02s to 1.70s.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source caching by recording successfully resolved cached paths for future lookups.
  * Subsequent fetches can now reuse cache results more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->