### PR TITLE
libfetchers: Add an fh-resolve input scheme

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -310,6 +310,21 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(const Settings
         storePath = computeStorePath(store);
 
     auto makeStoreAccessor = [&]() -> std::pair<ref<SourceAccessor>, Input> {
+        auto narHash = store.queryPathInfo(*storePath)->narHash;
+
+        /* If the store path is input-addressed (i.e. it comes from a
+           `storePath` attribute rather than being computed from the
+           NAR hash), its validity does not imply that it has the
+           expected contents, so verify the NAR hash. */
+        if (narHash != *getNarHash())
+            throw Error(
+                (unsigned int) 102,
+                "NAR hash mismatch in input '%s' at '%s', expected '%s' but got '%s'",
+                to_string(),
+                store.printStorePath(*storePath),
+                getNarHash()->to_string(HashFormat::SRI, true),
+                narHash.to_string(HashFormat::SRI, true));
+
         auto accessor = store.requireStoreObjectAccessor(*storePath);
 
         // FIXME: use the NAR hash for fingerprinting Git trees since it may have a .gitattributes file and we don't
@@ -324,7 +339,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(const Settings
             settings.getCache()->upsert(
                 makeSourcePathToHashCacheKey(
                     *accessor->fingerprint, ContentAddressMethod::Raw::NixArchive, CanonPath::root),
-                {{"hash", store.queryPathInfo(*storePath)->narHash.to_string(HashFormat::SRI, true)}});
+                {{"hash", narHash.to_string(HashFormat::SRI, true)}});
         }
 
         accessor->provenance = std::make_shared<TreeProvenance>(*this);
@@ -427,6 +442,12 @@ std::string Input::getName() const
 
 StorePath Input::computeStorePath(Store & store) const
 {
+    /* If the input records the resolved store path (which may be
+       input-addressed and thus not computable from the NAR hash), use
+       it directly. */
+    if (auto storePath = maybeGetStrAttr(attrs, "storePath"))
+        return store.parseStorePath(*storePath);
+
     auto narHash = getNarHash();
     if (!narHash)
         throw Error("cannot compute store path for unlocked input '%s'", to_string());

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -11,6 +11,7 @@
 #include "nix/util/users.hh"
 #include "nix/store/pathlocks.hh"
 #include "nix/util/environment-variables.hh"
+#include "nix/util/strings.hh"
 
 #include <nlohmann/json.hpp>
 #include <thread>
@@ -291,6 +292,18 @@ void Input::checkNarHash(const std::optional<Hash> & narHash, const std::optiona
             expected->to_string(HashFormat::SRI, true));
 }
 
+void Input::checkStorePath(Store & store, const ValidPathInfo & info) const
+{
+    checkNarHash(info.narHash, store.printStorePath(info.path));
+
+    if (!info.references.empty())
+        throw Error(
+            "store path '%s' of input '%s' has references (%s), which is not supported",
+            store.printStorePath(info.path),
+            to_string(),
+            concatStringsSep(", ", store.printStorePathSet(info.references)));
+}
+
 std::pair<ref<SourceAccessor>, Input> Input::getAccessor(const Settings & settings, Store & store) const
 {
     try {
@@ -319,13 +332,13 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(const Settings
         storePath = computeStorePath(store);
 
     auto makeStoreAccessor = [&]() -> std::pair<ref<SourceAccessor>, Input> {
-        auto narHash = store.queryPathInfo(*storePath)->narHash;
+        auto info = store.queryPathInfo(*storePath);
 
         /* If the store path is input-addressed (i.e. it comes from a
            `storePath` attribute rather than being computed from the
            NAR hash), its validity does not imply that it has the
            expected contents, so verify the NAR hash. */
-        checkNarHash(narHash, store.printStorePath(*storePath));
+        checkStorePath(store, *info);
 
         auto accessor = store.requireStoreObjectAccessor(*storePath);
 
@@ -341,7 +354,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(const Settings
             settings.getCache()->upsert(
                 makeSourcePathToHashCacheKey(
                     *accessor->fingerprint, ContentAddressMethod::Raw::NixArchive, CanonPath::root),
-                {{"hash", narHash.to_string(HashFormat::SRI, true)}});
+                {{"hash", info->narHash.to_string(HashFormat::SRI, true)}});
         }
 
         accessor->provenance = std::make_shared<TreeProvenance>(*this);

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -258,28 +258,37 @@ void Input::checkLocks(Input specified, Input & result)
         return;
     }
 
-    if (auto prevNarHash = specified.getNarHash()) {
-        if (result.getNarHash() != prevNarHash) {
-            if (result.getNarHash())
-                throw Error(
-                    (unsigned int) 102,
-                    "NAR hash mismatch in input '%s', expected '%s' but got '%s'",
-                    specified.to_string(),
-                    prevNarHash->to_string(HashFormat::SRI, true),
-                    result.getNarHash()->to_string(HashFormat::SRI, true));
-            else
-                throw Error(
-                    (unsigned int) 102,
-                    "NAR hash mismatch in input '%s', expected '%s' but got none",
-                    specified.to_string(),
-                    prevNarHash->to_string(HashFormat::SRI, true));
-        }
-    }
+    specified.checkNarHash(result.getNarHash());
 
     if (auto prevRev = specified.getRev()) {
         if (result.getRev() != prevRev)
             throw Error("'rev' attribute mismatch in input '%s', expected %s", result.to_string(), prevRev->gitRev());
     }
+}
+
+void Input::checkNarHash(const std::optional<Hash> & narHash, const std::optional<std::string> & storePath) const
+{
+    auto expected = getNarHash();
+    if (!expected || (narHash && *narHash == *expected))
+        return;
+
+    auto location = storePath ? fmt(" at '%s'", *storePath) : "";
+
+    if (narHash)
+        throw Error(
+            (unsigned int) 102,
+            "NAR hash mismatch in input '%s'%s, expected '%s' but got '%s'",
+            to_string(),
+            location,
+            expected->to_string(HashFormat::SRI, true),
+            narHash->to_string(HashFormat::SRI, true));
+    else
+        throw Error(
+            (unsigned int) 102,
+            "NAR hash mismatch in input '%s'%s, expected '%s' but got none",
+            to_string(),
+            location,
+            expected->to_string(HashFormat::SRI, true));
 }
 
 std::pair<ref<SourceAccessor>, Input> Input::getAccessor(const Settings & settings, Store & store) const
@@ -316,14 +325,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(const Settings
            `storePath` attribute rather than being computed from the
            NAR hash), its validity does not imply that it has the
            expected contents, so verify the NAR hash. */
-        if (narHash != *getNarHash())
-            throw Error(
-                (unsigned int) 102,
-                "NAR hash mismatch in input '%s' at '%s', expected '%s' but got '%s'",
-                to_string(),
-                store.printStorePath(*storePath),
-                getNarHash()->to_string(HashFormat::SRI, true),
-                narHash.to_string(HashFormat::SRI, true));
+        checkNarHash(narHash, store.printStorePath(*storePath));
 
         auto accessor = store.requireStoreObjectAccessor(*storePath);
 

--- a/src/libfetchers/fh-resolve.cc
+++ b/src/libfetchers/fh-resolve.cc
@@ -140,17 +140,11 @@ struct FhResolveInputScheme : InputScheme
         std::optional<StorePath> storePath;
 
         if (auto storePathS = maybeGetStrAttr(input.attrs, "storePath")) {
-            /* Use the previously resolved store path, substituting it
-               if it's not already valid. Note: for final locked inputs,
-               `Input::getAccessorUnchecked()` will usually have done
-               this already via `computeStorePath()`. */
+            /* Use the previously resolved store path. Note: for final
+               locked inputs, `Input::getAccessorUnchecked()` will
+               usually have done this already via
+               `computeStorePath()`. */
             storePath = store.parseStorePath(*storePathS);
-            store.addTempRoot(*storePath);
-            if (!store.isValidPath(*storePath)) {
-                if (fastOnly)
-                    return std::nullopt;
-                store.ensurePath(*storePath);
-            }
         } else {
             if (fastOnly)
                 return std::nullopt;
@@ -169,11 +163,16 @@ struct FhResolveInputScheme : InputScheme
             auto json = nlohmann::json::parse(getFileTransfer()->download(request).data);
 
             storePath = store.parseStorePath(json.at("store_path").get<std::string>());
-            store.addTempRoot(*storePath);
-            if (!store.isValidPath(*storePath))
-                store.ensurePath(*storePath);
 
             input.attrs.insert_or_assign("storePath", store.printStorePath(*storePath));
+        }
+
+        store.addTempRoot(*storePath);
+        if (!store.isValidPath(*storePath)) {
+            if (fastOnly)
+                return std::nullopt;
+            /* Substitute the store path. */
+            store.ensurePath(*storePath);
         }
 
         auto info = store.queryPathInfo(*storePath);

--- a/src/libfetchers/fh-resolve.cc
+++ b/src/libfetchers/fh-resolve.cc
@@ -173,26 +173,16 @@ struct FhResolveInputScheme : InputScheme
 
         auto info = store.queryPathInfo(*storePath);
 
-        if (auto expected = input.getNarHash())
-            if (info->narHash != *expected)
-                throw Error(
-                    (unsigned int) 102,
-                    "NAR hash mismatch in input '%s' at '%s', expected '%s' but got '%s'",
-                    input.to_string(),
-                    store.printStorePath(*storePath),
-                    expected->to_string(HashFormat::SRI, true),
-                    info->narHash.to_string(HashFormat::SRI, true));
+        input.checkNarHash(info->narHash, store.printStorePath(*storePath));
 
         if (!info->references.empty())
             throw Error(
                 "store path '%s' of input '%s' has references (%s), which is not supported by 'fh-resolve' inputs",
                 store.printStorePath(*storePath),
                 input.to_string(),
-                concatStringsSep(
-                    ", ",
-                    info->references | std::views::transform([&](const StorePath & p) {
-                        return store.printStorePath(p);
-                    }) | std::ranges::to<std::vector<std::string>>()));
+                concatStringsSep(", ", info->references | std::views::transform([&](const StorePath & p) {
+                                           return store.printStorePath(p);
+                                       }) | std::ranges::to<std::vector<std::string>>()));
 
         input.attrs.insert_or_assign("narHash", info->narHash.to_string(HashFormat::SRI, true));
 

--- a/src/libfetchers/fh-resolve.cc
+++ b/src/libfetchers/fh-resolve.cc
@@ -1,0 +1,205 @@
+#include "nix/fetchers/fetchers.hh"
+#include "nix/fetchers/fetch-settings.hh"
+#include "nix/store/store-api.hh"
+#include "nix/util/logging.hh"
+#include "nix/util/processes.hh"
+#include "nix/util/strings.hh"
+
+#include <nlohmann/json.hpp>
+
+namespace nix::fetchers {
+
+/* A fetcher that resolves a FlakeHub output reference like
+   `DeterminateSystems/nix-wasm-rust/^0#packages.x86_64-linux.default`
+   to a prebuilt store path, using the `fh` CLI. The store path is
+   substituted rather than fetched as a source tree, so this provides
+   a convenient way for flakes to depend on prebuilt binary artifacts
+   (such as WASM plugins). */
+struct FhResolveInputScheme : InputScheme
+{
+    std::string_view schemeName() const override
+    {
+        return "fh-resolve";
+    }
+
+    std::string schemeDescription() const override
+    {
+        return "Resolves a FlakeHub output reference (`«org»/«project»/«version»#«output»`) to a prebuilt store path using `fh resolve`.";
+    }
+
+    const std::map<std::string, AttributeInfo> & allowedAttrs() const override
+    {
+        static const std::map<std::string, AttributeInfo> attrs = {
+            {
+                "org",
+                {.doc = "The FlakeHub organization (e.g. `DeterminateSystems`)."},
+            },
+            {
+                "project",
+                {.doc = "The name of the flake on FlakeHub (e.g. `nix-wasm-rust`)."},
+            },
+            {
+                "version",
+                {.doc = "The semantic version requirement of the flake (e.g. `^0` or `=0.1.88`)."},
+            },
+            {
+                "output",
+                {.doc = "The flake output attribute path to resolve (e.g. `packages.x86_64-linux.default`)."},
+            },
+            {
+                "storePath",
+                {.required = false, .doc = "The store path that the reference resolved to."},
+            },
+            {
+                "narHash",
+                {.required = false, .doc = "The NAR hash of the resolved store path."},
+            },
+        };
+        return attrs;
+    }
+
+    std::optional<Input> inputFromAttrs(const Settings & settings, const Attrs & attrs) const override
+    {
+        getStrAttr(attrs, "org");
+        getStrAttr(attrs, "project");
+        getStrAttr(attrs, "version");
+        getStrAttr(attrs, "output");
+
+        Input input{};
+        input.attrs = attrs;
+        return input;
+    }
+
+    std::optional<Input> inputFromURL(const Settings & settings, const ParsedURL & url, bool requireTree) const override
+    {
+        if (url.scheme != schemeName())
+            return {};
+
+        auto path = url.pathSegments(/*skipEmpty=*/true) | std::ranges::to<std::vector<std::string>>();
+        if (path.size() != 3)
+            throw BadURL("URL '%s' should have the form 'fh-resolve:«org»/«project»/«version»#«output»'", url);
+
+        if (url.fragment.empty())
+            throw BadURL("URL '%s' lacks an output attribute path (e.g. '#packages.x86_64-linux.default')", url);
+
+        Attrs attrs;
+        attrs.insert_or_assign("type", std::string{schemeName()});
+        attrs.insert_or_assign("org", path[0]);
+        attrs.insert_or_assign("project", path[1]);
+        attrs.insert_or_assign("version", path[2]);
+        attrs.insert_or_assign("output", url.fragment);
+
+        for (auto & [name, value] : url.query)
+            if (name == "narHash" || name == "storePath")
+                attrs.insert_or_assign(name, value);
+            else
+                throw BadURL("URL '%s' has unsupported parameter '%s'", url, name);
+
+        return inputFromAttrs(settings, attrs);
+    }
+
+    ParsedURL toURL(const Input & input, bool abbreviate) const override
+    {
+        auto url = ParsedURL{
+            .scheme = std::string{schemeName()},
+            .path =
+                {getStrAttr(input.attrs, "org"),
+                 getStrAttr(input.attrs, "project"),
+                 getStrAttr(input.attrs, "version")},
+            .fragment = getStrAttr(input.attrs, "output"),
+        };
+        if (!abbreviate) {
+            if (auto storePath = maybeGetStrAttr(input.attrs, "storePath"))
+                url.query.insert_or_assign("storePath", *storePath);
+            if (auto narHash = input.getNarHash())
+                url.query.insert_or_assign("narHash", narHash->to_string(HashFormat::SRI, true));
+        }
+        return url;
+    }
+
+    bool isLocked(const Settings & settings, const Input & input) const override
+    {
+        return maybeGetStrAttr(input.attrs, "storePath").has_value() && input.getNarHash().has_value();
+    }
+
+    std::optional<std::string> getFingerprint(Store & store, const Input & input) const override
+    {
+        if (auto narHash = input.getNarHash())
+            return "fh-resolve:" + narHash->to_string(HashFormat::SRI, true);
+        return std::nullopt;
+    }
+
+    std::optional<std::pair<ref<SourceAccessor>, Input>>
+    getAccessor(const Settings & settings, Store & store, const Input & _input, bool fastOnly) const override
+    {
+        Input input(_input);
+
+        std::optional<StorePath> storePath;
+
+        if (auto storePathS = maybeGetStrAttr(input.attrs, "storePath")) {
+            /* Use the previously resolved store path, substituting it
+               if it's not already valid. Note: for final locked inputs,
+               `Input::getAccessorUnchecked()` will usually have done
+               this already via `computeStorePath()`. */
+            storePath = store.parseStorePath(*storePathS);
+            store.addTempRoot(*storePath);
+            if (!store.isValidPath(*storePath)) {
+                if (fastOnly)
+                    return std::nullopt;
+                store.ensurePath(*storePath);
+            }
+        } else {
+            if (fastOnly)
+                return std::nullopt;
+
+            auto fhRef =
+                fmt("%s/%s/%s#%s",
+                    getStrAttr(input.attrs, "org"),
+                    getStrAttr(input.attrs, "project"),
+                    getStrAttr(input.attrs, "version"),
+                    getStrAttr(input.attrs, "output"));
+
+            Activity act(*logger, lvlTalkative, actUnknown, fmt("resolving FlakeHub reference '%s'", fhRef));
+
+            auto json = nlohmann::json::parse(runProgram("fh", true, {"resolve", "--json", fhRef}));
+
+            storePath = store.parseStorePath(json.at("store_path").get<std::string>());
+            store.addTempRoot(*storePath);
+            if (!store.isValidPath(*storePath))
+                store.ensurePath(*storePath);
+
+            input.attrs.insert_or_assign("storePath", store.printStorePath(*storePath));
+        }
+
+        auto info = store.queryPathInfo(*storePath);
+
+        if (auto expected = input.getNarHash())
+            if (info->narHash != *expected)
+                throw Error(
+                    (unsigned int) 102,
+                    "NAR hash mismatch in input '%s' at '%s', expected '%s' but got '%s'",
+                    input.to_string(),
+                    store.printStorePath(*storePath),
+                    expected->to_string(HashFormat::SRI, true),
+                    info->narHash.to_string(HashFormat::SRI, true));
+
+        if (!info->references.empty())
+            throw Error(
+                "store path '%s' of input '%s' has references (%s), which is not supported by 'fh-resolve' inputs",
+                store.printStorePath(*storePath),
+                input.to_string(),
+                concatStringsSep(
+                    ", ",
+                    info->references | std::views::transform([&](const StorePath & p) {
+                        return store.printStorePath(p);
+                    }) | std::ranges::to<std::vector<std::string>>()));
+
+        input.attrs.insert_or_assign("narHash", info->narHash.to_string(HashFormat::SRI, true));
+
+        return {{store.requireStoreObjectAccessor(*storePath), std::move(input)}};
+    }
+};
+
+static auto rFhResolveInputScheme = OnStartup([] { registerInputScheme(std::make_unique<FhResolveInputScheme>()); });
+
+} // namespace nix::fetchers

--- a/src/libfetchers/fh-resolve.cc
+++ b/src/libfetchers/fh-resolve.cc
@@ -1,8 +1,8 @@
 #include "nix/fetchers/fetchers.hh"
 #include "nix/fetchers/fetch-settings.hh"
+#include "nix/store/filetransfer.hh"
 #include "nix/store/store-api.hh"
 #include "nix/util/logging.hh"
-#include "nix/util/processes.hh"
 #include "nix/util/strings.hh"
 
 #include <nlohmann/json.hpp>
@@ -11,10 +11,13 @@ namespace nix::fetchers {
 
 /* A fetcher that resolves a FlakeHub output reference like
    `DeterminateSystems/nix-wasm-rust/^0#packages.x86_64-linux.default`
-   to a prebuilt store path, using the `fh` CLI. The store path is
-   substituted rather than fetched as a source tree, so this provides
-   a convenient way for flakes to depend on prebuilt binary artifacts
-   (such as WASM plugins). */
+   to a prebuilt store path by querying api.flakehub.com. The store
+   path is substituted rather than fetched as a source tree, so this
+   provides a convenient way for flakes to depend on prebuilt binary
+   artifacts (such as WASM plugins).
+
+   Access to private flakes uses the credentials for api.flakehub.com
+   in the user's netrc file. */
 struct FhResolveInputScheme : InputScheme
 {
     std::string_view schemeName() const override
@@ -152,16 +155,18 @@ struct FhResolveInputScheme : InputScheme
             if (fastOnly)
                 return std::nullopt;
 
-            auto fhRef =
-                fmt("%s/%s/%s#%s",
-                    getStrAttr(input.attrs, "org"),
-                    getStrAttr(input.attrs, "project"),
-                    getStrAttr(input.attrs, "version"),
-                    getStrAttr(input.attrs, "output"));
+            Activity act(
+                *logger, lvlTalkative, actUnknown, fmt("resolving FlakeHub reference '%s'", input.to_string()));
 
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("resolving FlakeHub reference '%s'", fhRef));
+            FileTransferRequest request(
+                fmt("https://api.flakehub.com/f/%s/%s/%s/output/%s",
+                    percentEncode(getStrAttr(input.attrs, "org")),
+                    percentEncode(getStrAttr(input.attrs, "project")),
+                    percentEncode(getStrAttr(input.attrs, "version")),
+                    percentEncode(getStrAttr(input.attrs, "output"))));
+            request.headers = {{"Accept", "application/json"}};
 
-            auto json = nlohmann::json::parse(runProgram("fh", true, {"resolve", "--json", fhRef}));
+            auto json = nlohmann::json::parse(getFileTransfer()->download(request).data);
 
             storePath = store.parseStorePath(json.at("store_path").get<std::string>());
             store.addTempRoot(*storePath);

--- a/src/libfetchers/fh-resolve.cc
+++ b/src/libfetchers/fh-resolve.cc
@@ -3,7 +3,6 @@
 #include "nix/store/filetransfer.hh"
 #include "nix/store/store-api.hh"
 #include "nix/util/logging.hh"
-#include "nix/util/strings.hh"
 
 #include <nlohmann/json.hpp>
 
@@ -177,16 +176,7 @@ struct FhResolveInputScheme : InputScheme
 
         auto info = store.queryPathInfo(*storePath);
 
-        input.checkNarHash(info->narHash, store.printStorePath(*storePath));
-
-        if (!info->references.empty())
-            throw Error(
-                "store path '%s' of input '%s' has references (%s), which is not supported by 'fh-resolve' inputs",
-                store.printStorePath(*storePath),
-                input.to_string(),
-                concatStringsSep(", ", info->references | std::views::transform([&](const StorePath & p) {
-                                           return store.printStorePath(p);
-                                       }) | std::ranges::to<std::vector<std::string>>()));
+        input.checkStorePath(store, *info);
 
         input.attrs.insert_or_assign("narHash", info->narHash.to_string(HashFormat::SRI, true));
 

--- a/src/libfetchers/include/nix/fetchers/fetchers.hh
+++ b/src/libfetchers/include/nix/fetchers/fetchers.hh
@@ -129,6 +129,17 @@ public:
     static void checkLocks(Input specified, Input & result);
 
     /**
+     * If this input has a `narHash` attribute, check that `narHash`
+     * matches it, and throw a NAR hash mismatch error (exit code 102)
+     * otherwise.
+     *
+     * @param storePath Optional printed store path of the object that
+     * was hashed, for the error message.
+     */
+    void checkNarHash(
+        const std::optional<Hash> & narHash, const std::optional<std::string> & storePath = std::nullopt) const;
+
+    /**
      * Return a `SourceAccessor` that allows access to files in the
      * input without copying it to the store. Also return a possibly
      * unlocked input.

--- a/src/libfetchers/include/nix/fetchers/fetchers.hh
+++ b/src/libfetchers/include/nix/fetchers/fetchers.hh
@@ -17,6 +17,7 @@ namespace nix {
 class Store;
 class StorePath;
 struct SourceAccessor;
+struct ValidPathInfo;
 } // namespace nix
 
 namespace nix::fetchers {
@@ -138,6 +139,13 @@ public:
      */
     void checkNarHash(
         const std::optional<Hash> & narHash, const std::optional<std::string> & storePath = std::nullopt) const;
+
+    /**
+     * Check that a store path has the NAR hash expected by this input
+     * (see `checkNarHash()`) and that it has no references (since
+     * references are not supported by fetcher trees).
+     */
+    void checkStorePath(Store & store, const ValidPathInfo & info) const;
 
     /**
      * Return a `SourceAccessor` that allows access to files in the

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -42,6 +42,7 @@ sources = files(
   'fetch-settings.cc',
   'fetch-to-store.cc',
   'fetchers.cc',
+  'fh-resolve.cc',
   'filtering-source-accessor.cc',
   'git-lfs-fetch.cc',
   'git-utils.cc',

--- a/tests/nixos/default.nix
+++ b/tests/nixos/default.nix
@@ -166,6 +166,8 @@ in
 
   githubFlakes = runNixOSTest ./github-flakes.nix;
 
+  fhResolve = runNixOSTest ./fh-resolve.nix;
+
   gitSubmodules = runNixOSTest ./git-submodules.nix;
 
   sourcehutFlakes = runNixOSTest ./sourcehut-flakes.nix;

--- a/tests/nixos/fh-resolve.nix
+++ b/tests/nixos/fh-resolve.nix
@@ -1,0 +1,171 @@
+{
+  lib,
+  config,
+  ...
+}:
+let
+  pkgs = config.nodes.machine.nixpkgs.pkgs;
+
+  # Generate a fake root CA and a fake api.flakehub.com certificate.
+  cert = pkgs.runCommand "cert" { nativeBuildInputs = [ pkgs.openssl ]; } ''
+    mkdir -p $out
+
+    openssl genrsa -out ca.key 2048
+    openssl req -new -x509 -days 36500 -key ca.key \
+      -subj "/C=NL/ST=Denial/L=Springfield/O=Dis/CN=Root CA" -out $out/ca.crt
+
+    openssl req -newkey rsa:2048 -nodes -keyout $out/server.key \
+      -subj "/C=CN/ST=Denial/L=Springfield/O=Dis/CN=api.flakehub.com" -out server.csr
+    openssl x509 -req -extfile <(printf "subjectAltName=DNS:api.flakehub.com") \
+      -days 36500 -in server.csr -CA $out/ca.crt -CAkey ca.key -CAcreateserial -out $out/server.crt
+  '';
+
+  # The prebuilt artifact that the fh-resolve input resolves to. It
+  # must not have references.
+  artifact = pkgs.runCommand "nix-wasm-rust-0.1.0" { } ''
+    mkdir -p $out
+    printf 'hello world' > $out/plugin.wasm
+  '';
+
+  # An artifact with references, which fh-resolve inputs must reject.
+  artifactWithRefs = pkgs.runCommand "has-refs-0.1.0" { } ''
+    mkdir -p $out
+    echo ${artifact} > $out/ref
+  '';
+
+  # Static responses for the FlakeHub resolve endpoint
+  # (/f/{org}/{project}/{version_req}/output/{attr_path}).
+  api = pkgs.runCommand "flakehub-api" { } ''
+    dir="$out/DeterminateSystems/nix-wasm-rust/^0/output"
+    mkdir -p "$dir"
+    cat > "$dir/packages.x86_64-linux.default" << EOF
+    ${builtins.toJSON {
+      attribute_path = "packages.x86_64-linux.default";
+      store_path = "${artifact}";
+      token = null;
+    }}
+    EOF
+
+    dir="$out/DeterminateSystems/has-refs/^0/output"
+    mkdir -p "$dir"
+    cat > "$dir/packages.x86_64-linux.default" << EOF
+    ${builtins.toJSON {
+      attribute_path = "packages.x86_64-linux.default";
+      store_path = "${artifactWithRefs}";
+      token = null;
+    }}
+    EOF
+  '';
+
+  flake = pkgs.writeTextFile {
+    name = "flake";
+    destination = "/flake.nix";
+    text = ''
+      {
+        inputs.artifact = {
+          type = "fh-resolve";
+          org = "DeterminateSystems";
+          project = "nix-wasm-rust";
+          version = "^0";
+          output = "packages.x86_64-linux.default";
+          flake = false;
+        };
+
+        outputs = { self, artifact }: {
+          content = builtins.readFile (artifact + "/plugin.wasm");
+        };
+      }
+    '';
+  };
+in
+
+{
+  name = "fh-resolve";
+
+  nodes = {
+    machine =
+      { config, pkgs, ... }:
+      {
+        virtualisation.writableStore = true;
+        virtualisation.additionalPaths = [
+          artifact
+          artifactWithRefs
+        ];
+        nix.settings.substituters = lib.mkForce [ ];
+        networking.hosts."127.0.0.1" = [ "api.flakehub.com" ];
+        security.pki.certificateFiles = [ "${cert}/ca.crt" ];
+
+        services.httpd.enable = true;
+        services.httpd.adminAddr = "foo@example.org";
+        services.httpd.extraConfig = ''
+          ErrorLog syslog:local6
+        '';
+        services.httpd.virtualHosts."api.flakehub.com" = {
+          forceSSL = true;
+          sslServerKey = "${cert}/server.key";
+          sslServerCert = "${cert}/server.crt";
+          servedDirs = [
+            {
+              urlPath = "/f";
+              dir = api;
+            }
+          ];
+        };
+      };
+  };
+
+  testScript =
+    { nodes }:
+    ''
+      # fmt: off
+      import json
+
+      start_all()
+
+      machine.wait_for_unit("httpd.service")
+      machine.wait_for_unit("multi-user.target")
+
+      # Check that the fake resolve endpoint works.
+      out = machine.succeed("curl --fail https://api.flakehub.com/f/DeterminateSystems/nix-wasm-rust/%5E0/output/packages.x86_64-linux.default")
+      print(out)
+      assert json.loads(out)["store_path"] == "${artifact}"
+
+      # Lock a flake with an fh-resolve input.
+      machine.succeed("cp -r ${flake} /tmp/flake && chmod -R u+w /tmp/flake")
+      machine.succeed("nix flake lock /tmp/flake")
+      lock = json.loads(machine.succeed("cat /tmp/flake/flake.lock"))
+      locked = lock["nodes"]["artifact"]["locked"]
+      print(locked)
+      assert locked["type"] == "fh-resolve"
+      assert locked["storePath"] == "${artifact}", "lock file does not record the resolved store path"
+      nar_hash = locked["narHash"]
+
+      # Evaluating the flake should yield the contents of the artifact.
+      out = machine.succeed("nix eval --raw /tmp/flake#content")
+      assert out == "hello world", f"unexpected artifact content: {out}"
+
+      # Test the URL syntax.
+      out = machine.succeed("""
+        nix eval --impure --raw --expr '(builtins.fetchTree "fh-resolve:DeterminateSystems/nix-wasm-rust/%5E0#packages.x86_64-linux.default").narHash'
+      """)
+      assert out == nar_hash, f"unexpected NAR hash: {out}"
+
+      # Fetching with an incorrect NAR hash should fail.
+      out = machine.fail("""
+        nix eval --impure --raw --expr '(builtins.fetchTree { type = "fh-resolve"; org = "DeterminateSystems"; project = "nix-wasm-rust"; version = "^0"; output = "packages.x86_64-linux.default"; narHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; }).narHash' 2>&1
+      """)
+      assert "NAR hash mismatch" in out, "NAR hash check did not fail with the expected error"
+
+      # Store paths with references should be rejected.
+      out = machine.fail("""
+        nix eval --impure --raw --expr '(builtins.fetchTree { type = "fh-resolve"; org = "DeterminateSystems"; project = "has-refs"; version = "^0"; output = "packages.x86_64-linux.default"; }).narHash' 2>&1
+      """)
+      assert "has references" in out, "fetching a store path with references did not fail with the expected error"
+
+      # Locked inputs should not require the API server.
+      machine.succeed("systemctl stop httpd.service")
+      machine.succeed("rm -rf /root/.cache/nix")
+      out = machine.succeed("nix eval --raw /tmp/flake#content")
+      assert out == "hello world", f"unexpected artifact content: {out}"
+    '';
+}


### PR DESCRIPTION
## Motivation

This adds a new fetcher `fh-resolve` that fetches trees from FlakeHub by resolving a flakehub org/project/version and fetching the store path of a flake output, similar to the `fh resolve` command. For example, the following flake input fetches the pre-built WASM plugins from the [nix-wasm-rust flake](https://github.com/DeterminateSystems/nix-wasm-rust/):

```nix
{
  type = "fh-resolve";
  org = "DeterminateSystems";
  project = "nix-wasm-rust";
  version = "^0";
  output = "packages.x86_64-linux.default";
}
```

This is useful because it avoids having to evaluate the `nix-wasm-rust` flake, so it's a lot cheaper/faster and does not require exposing the source of the input flake.

Note that the resolved store paths are not allowed to have references, since libfetchers trees have no concept of references.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for resolving FlakeHub output references via the `fh-resolve:` input scheme, producing substituted/prebuilt store paths.
  * Locking is supported when both `storePath` and `narHash` are provided, and the resolved `narHash` is persisted for reuse.
* **Bug Fixes**
  * Strengthened NAR hash consistency checks when reusing an existing `storePath`, with clearer “NAR hash mismatch” errors.
  * Improved handling of pre-resolved store paths, including rejecting paths with unsupported references.
* **Tests**
  * Added an end-to-end NixOS test covering `fh-resolve` resolution, locking behavior, and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->