### PR TITLE
fix(store): propagate cpu time from derivation trampoline

### DIFF
--- a/src/libstore/build/derivation-trampoline-goal.cc
+++ b/src/libstore/build/derivation-trampoline-goal.cc
@@ -4,6 +4,7 @@
 
 #include <ranges>
 #include <algorithm>
+#include <chrono>
 
 namespace nix {
 
@@ -165,6 +166,19 @@ Goal::Co DerivationTrampolineGoal::haveDerivation(StorePath drvPath, Derivation 
     co_await await(concreteDrvGoals);
 
     trace("outer build done");
+
+    for (const auto & goal : concreteDrvGoals) {
+        const auto & inner = goal->buildResult;
+        buildResult.timesBuilt += inner.timesBuilt;
+        if (inner.startTime != 0 && (buildResult.startTime == 0 || inner.startTime < buildResult.startTime))
+            buildResult.startTime = inner.startTime;
+        buildResult.stopTime = std::max(buildResult.stopTime, inner.stopTime);
+        if (inner.cpuUser)
+            buildResult.cpuUser = buildResult.cpuUser.value_or(std::chrono::microseconds::zero()) + *inner.cpuUser;
+        if (inner.cpuSystem)
+            buildResult.cpuSystem =
+                buildResult.cpuSystem.value_or(std::chrono::microseconds::zero()) + *inner.cpuSystem;
+    }
 
     if (nrFailed != 0) {
         auto gi = std::ranges::find_if(concreteDrvGoals, [](const GoalPtr & goal) -> bool {


### PR DESCRIPTION
## Motivation

Right daemon doesn't report CPU time after build, build result has empty stats

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build result reporting by accurately aggregating completion times, CPU usage, and build counts across related build steps.
  * Build results now provide more consistent timing and resource-use information for composite builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->