### PR TITLE
Use std::move_only_function for parallel evel work items

### DIFF
--- a/src/libexpr/include/nix/expr/parallel-eval.hh
+++ b/src/libexpr/include/nix/expr/parallel-eval.hh
@@ -7,6 +7,7 @@
 
 #include <boost/thread/thread.hpp>
 
+#include "nix/util/move-only-function.hh"
 #include "nix/util/sync.hh"
 #include "nix/util/logging.hh"
 #include "nix/util/environment-variables.hh"
@@ -21,7 +22,7 @@ namespace nix {
 
 struct Executor
 {
-    using work_t = std::move_only_function<void()>;
+    using work_t = MoveOnlyFunction<void()>;
 
     struct Item
     {

--- a/src/libexpr/include/nix/expr/parallel-eval.hh
+++ b/src/libexpr/include/nix/expr/parallel-eval.hh
@@ -21,8 +21,7 @@ namespace nix {
 
 struct Executor
 {
-    // FIXME: support std::moveable_function.
-    using work_t = std::function<void()>;
+    using work_t = std::move_only_function<void()>;
 
     struct Item
     {
@@ -84,7 +83,9 @@ struct FutureVector
 
     void spawn(uint8_t prioPrefix, Executor::work_t && work)
     {
-        spawn({{std::move(work), prioPrefix}});
+        Executor::WorkItems items;
+        items.emplace_back(std::move(work), prioPrefix);
+        spawn(std::move(items));
     }
 
     void finishAll();

--- a/src/libexpr/parallel-eval.cc
+++ b/src/libexpr/parallel-eval.cc
@@ -294,9 +294,7 @@ static void prim_parallel(EvalState & state, const PosIdx pos, Value ** args, Va
         Executor::WorkItems work;
         for (auto value : args[0]->listView())
             if (!value->isFinished())
-                state.addWork(work, 0, [value(std::make_shared<RootValue>(value)), &state, pos]() {
-                    state.forceValue(***value, pos);
-                });
+                state.addWork(work, 0, [value(RootValue(value)), &state, pos]() { state.forceValue(**value, pos); });
         state.executor->spawn(std::move(work));
     }
 

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -28,9 +28,8 @@ static void parallelForceDeep(EvalState & state, Value & v, PosIdx pos)
         if (v.attrs()->get(state.s.outPath))
             return;
         for (auto & a : *v.attrs())
-            state.addWork(work, 0, [value(std::make_shared<RootValue>(a.value)), pos(a.pos), &state]() {
-                parallelForceDeep(state, ***value, pos);
-            });
+            state.addWork(
+                work, 0, [value(RootValue(a.value)), pos(a.pos), &state]() { parallelForceDeep(state, **value, pos); });
         break;
     }
 

--- a/src/libutil/include/nix/util/meson.build
+++ b/src/libutil/include/nix/util/meson.build
@@ -64,6 +64,7 @@ headers = [ config_pub_h ] + files(
   'memo.hh',
   'memory-source-accessor.hh',
   'mounted-source-accessor.hh',
+  'move-only-function.hh',
   'muxable-pipe.hh',
   'nar-accessor.hh',
   'nar-cache.hh',

--- a/src/libutil/include/nix/util/move-only-function.hh
+++ b/src/libutil/include/nix/util/move-only-function.hh
@@ -1,0 +1,83 @@
+#pragma once
+///@file
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace nix {
+
+#ifdef __cpp_lib_move_only_function
+
+template<typename Sig>
+using MoveOnlyFunction = std::move_only_function<Sig>;
+
+#else
+
+/**
+ * Fallback implementation of `std::move_only_function` for standard
+ * libraries that don't provide it yet (e.g. libc++ as of version 21):
+ * a type-erased callable wrapper that, unlike `std::function`, only
+ * requires the callable to be move-constructible, so it can hold
+ * lambdas that capture move-only types.
+ */
+template<typename Sig>
+class MoveOnlyFunction;
+
+template<typename Ret, typename... Args>
+class MoveOnlyFunction<Ret(Args...)>
+{
+    struct Base
+    {
+        virtual Ret call(Args &&... args) = 0;
+        virtual ~Base() = default;
+    };
+
+    template<typename F>
+    struct Impl final : Base
+    {
+        F f;
+
+        template<typename G>
+            requires std::is_same_v<std::decay_t<G>, F>
+        Impl(G && g)
+            : f(std::forward<G>(g))
+        {
+        }
+
+        Ret call(Args &&... args) override
+        {
+            return f(std::forward<Args>(args)...);
+        }
+    };
+
+    std::unique_ptr<Base> impl;
+
+public:
+    MoveOnlyFunction() = default;
+
+    template<typename F>
+        requires(!std::is_same_v<std::decay_t<F>, MoveOnlyFunction> && std::is_invocable_r_v<Ret, F &, Args...>)
+    MoveOnlyFunction(F && f)
+        : impl(std::make_unique<Impl<std::decay_t<F>>>(std::forward<F>(f)))
+    {
+    }
+
+    MoveOnlyFunction(MoveOnlyFunction &&) noexcept = default;
+    MoveOnlyFunction & operator=(MoveOnlyFunction &&) noexcept = default;
+
+    Ret operator()(Args... args)
+    {
+        return impl->call(std::forward<Args>(args)...);
+    }
+
+    explicit operator bool() const
+    {
+        return (bool) impl;
+    }
+};
+
+#endif
+
+} // namespace nix


### PR DESCRIPTION
## Motivation

This avoids having to put `RootValue`s in `std::shared_ptr`s.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved efficiency during parallel evaluation and deep value processing.
  * Reduced overhead when handling concurrent tasks and recursively processing complex values.
  * Improved responsiveness for workloads involving extensive parallel computation or JSON conversion.
* **Reliability**
  * Enhanced handling of parallel work for safer execution.
  * Improved support for non-copyable tasks, reducing potential issues during concurrent processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->