### PR TITLE
Fix randomly failing build.sh test

### DIFF
--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -205,7 +205,7 @@ fi
 # Only fast-fail should be reported as a failure.
 # Uses fifo for synchronization to ensure deterministic behavior.
 # Requires -j2 so slow and fast-fail run concurrently (fifo deadlocks if serialized).
-if isDaemonNewer "2.34pre" && canUseSandbox; then
+if isDaemonNewer "2.34pre" && canUseSandbox && unprivilegedUserNamespacesSupported; then
     fifoDir="$TEST_ROOT/cancelled-builds-fifo"
     mkdir -p "$fifoDir"
     mkfifo "$fifoDir/fifo"
@@ -218,7 +218,6 @@ if isDaemonNewer "2.34pre" && canUseSandbox; then
     if ! isTestOnNixOS; then
         sandboxPathsArg=(--option sandbox-paths "/nix/store")
     fi
-    cat /proc/sys/user/max_user_namespaces /proc/sys/user/max_pid_namespaces >&2 || true
     out="$(nix flake check ./cancelled-builds --no-sandbox-fallback --impure -L -j2 \
         --option sandbox true \
         "${sandboxPathsArg[@]}" \

--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -218,7 +218,8 @@ if isDaemonNewer "2.34pre" && canUseSandbox; then
     if ! isTestOnNixOS; then
         sandboxPathsArg=(--option sandbox-paths "/nix/store")
     fi
-    out="$(nix flake check ./cancelled-builds --impure -L -j2 \
+    cat /proc/sys/user/max_user_namespaces /proc/sys/user/max_pid_namespaces >&2 || true
+    out="$(nix flake check ./cancelled-builds --no-sandbox-fallback --impure -L -j2 \
         --option sandbox true \
         "${sandboxPathsArg[@]}" \
         --option sandbox-build-dir /build-tmp \
@@ -244,7 +245,7 @@ if isDaemonNewer "2.34pre" && canUseSandbox; then
         sandboxPathsArg=(--option sandbox-paths "/nix/store")
     fi
     system=$(nix eval --raw --impure --expr builtins.currentSystem)
-    out="$(nix build --impure -L -j2 \
+    out="$(nix build --no-sandbox-fallback --impure -L -j2 \
         --option sandbox true \
         "${sandboxPathsArg[@]}" \
         --option sandbox-build-dir /build-tmp \

--- a/tests/functional/common/functions.sh
+++ b/tests/functional/common/functions.sh
@@ -353,8 +353,14 @@ count() {
 
 trap onError ERR
 
+# Note: with newer AppArmor stacks, this restriction doesn't prevent *creating*
+# a user namespace, but denies mounting inside it, which Nix's sandbox needs.
+unprivilegedUserNamespacesSupported() {
+  ! { [[ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]] && [[ $(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns) -eq 1 ]]; }
+}
+
 requiresUnprivilegedUserNamespaces() {
-  if [[ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]] && [[ $(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns) -eq 1 ]]; then
+  if ! unprivilegedUserNamespacesSupported; then
     skipTest "Unprivileged user namespaces are disabled. Run 'sudo sysctl -w /proc/sys/kernel/apparmor_restrict_unprivileged_userns=0' to allow, and run these tests."
   fi
 }


### PR DESCRIPTION

## Motivation

Fix random failures in `build.sh` in GHA, e.g. https://github.com/DeterminateSystems/nix-src/actions/runs/30926645783/job/92052907077.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved functional test reliability in environments where sandboxing or unprivileged user namespaces are unavailable.
  - Tests now skip gracefully when required system capabilities are not supported.
  - Updated build and flake-check scenarios to avoid unintended sandbox fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->