### PR TITLE
Don't let missing store paths abort 'nix store optimise'

### DIFF
--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -106,7 +106,14 @@ void LocalStore::optimisePath_(
 {
     checkInterrupt();
 
-    auto st = lstat(path);
+    /* Missing valid paths are a problem, but they should not prevent
+       store optimisation from finishing, so warn and skip them. */
+    auto optSt = maybeLstat(path);
+    if (!optSt) {
+        warn("skipping missing path %s", PathFmt(path));
+        return;
+    }
+    auto & st = *optSt;
 
 #ifdef __APPLE__
     /* HFS/macOS has some undocumented security feature disabling hardlinking for


### PR DESCRIPTION

## Motivation

Previously, a valid path that was missing from disk caused the whole optimisation pass to fail:

```
error: getting status of "/nix/store/0mqak3v82iwqz1v3d7v1r6nwrbw4pwij-gn-fd3d768.drv": No such file or directory
```

Missing valid paths are a problem, but they should not prevent store optimisation from finishing, so warn and skip them instead.

Assisted-by: Claude Fable 5 <noreply@anthropic.com>

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing files or directories during store optimization.
  * Optimization now continues with a warning instead of failing when a path cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->