### PR TITLE
Fix "waiting for exclusive access" hangs during schema migrations

### DIFF
--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -507,12 +507,7 @@ private:
 
     void openDB(State & state, bool create);
 
-    /**
-     * Perform or check if a database schema upgrade is needed.
-     * @param dryRun only check if an upgrade is needed.
-     * @return true if an upgrade is needed or was performed, false otherwise.
-     */
-    bool upgradeDBSchema(State & state, bool dryRun);
+    void upgradeDBSchema(State & state);
 
     void makeStoreWritable();
 

--- a/src/libstore/include/nix/store/sqlite.hh
+++ b/src/libstore/include/nix/store/sqlite.hh
@@ -74,7 +74,16 @@ struct SQLite
      */
     void isCache();
 
+    /**
+     * Execute a statement. Retry if the database is busy. Do not call this inside a transaction; use execNoRetry()
+     * instead.
+     */
     void exec(const std::string & stmt);
+
+    /**
+     * Execute a statement.
+     */
+    void execNoRetry(const std::string & stmt);
 
     uint64_t getLastInsertedRowId();
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -144,6 +144,7 @@ struct LocalStore::State::Stmts
     SQLiteStmt QueryRealisedOutput;
     SQLiteStmt QueryPathFromHashPart;
     SQLiteStmt QueryValidPaths;
+    SQLiteStmt QuerySchemaMigration;
 };
 
 LocalStore::LocalStore(ref<const Config> config)
@@ -334,21 +335,17 @@ LocalStore::LocalStore(ref<const Config> config)
 
         if (curSchema < 8) {
             SQLiteTxn txn(state->db);
-            state->db.exec("alter table ValidPaths add column ultimate integer");
-            state->db.exec("alter table ValidPaths add column sigs text");
+            state->db.execNoRetry("alter table ValidPaths add column ultimate integer");
+            state->db.execNoRetry("alter table ValidPaths add column sigs text");
             txn.commit();
         }
 
         if (curSchema < 9) {
-            SQLiteTxn txn(state->db);
             state->db.exec("drop table FailedPaths");
-            txn.commit();
         }
 
         if (curSchema < 10) {
-            SQLiteTxn txn(state->db);
             state->db.exec("alter table ValidPaths add column ca text");
-            txn.commit();
         }
 
         writeFile(schemaPath, fmt("%1%", nixSchemaVersion), 0666, FsSync::Yes);
@@ -604,6 +601,8 @@ void LocalStore::upgradeDBSchema(State & state)
 {
     state.db.exec("create table if not exists SchemaMigrations (migration text primary key not null);");
 
+    state.stmts->QuerySchemaMigration.create(state.db, "select 1 from SchemaMigrations where migration = ?;");
+
     StringSet schemaMigrations;
 
     {
@@ -620,9 +619,18 @@ void LocalStore::upgradeDBSchema(State & state)
 
         notice("executing Nix database schema migration '%s'...", migrationName);
 
-        SQLiteTxn txn(state.db);
-        state.db.exec(stmt + fmt(";\ninsert or ignore into SchemaMigrations values('%s')", migrationName));
-        txn.commit();
+        retrySQLite<void>([&]() {
+            SQLiteTxn txn(state.db);
+
+            /* Another process may have executed this migration in the
+               meantime, so check for it again within the
+               transaction. */
+            if (state.stmts->QuerySchemaMigration.use().apply(migrationName).next())
+                return;
+
+            state.db.execNoRetry(stmt + fmt(";\ninsert or ignore into SchemaMigrations values('%s')", migrationName));
+            txn.commit();
+        });
 
         schemaMigrations.insert(migrationName);
     };

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -655,7 +655,7 @@ bool LocalStore::upgradeDBSchema(State & state, bool dryRun)
         if (dryRun)
             return;
 
-        debug("executing Nix database schema migration '%s'...", migrationName);
+        notice("executing Nix database schema migration '%s'...", migrationName);
 
         SQLiteTxn txn(state.db);
         state.db.exec(stmt + fmt(";\ninsert or ignore into SchemaMigrations values('%s')", migrationName));

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -293,17 +293,6 @@ LocalStore::LocalStore(ref<const Config> config)
                            : "database schema needs migrating, but this cannot be done in read-only mode");
     }
 
-    auto acquireWriteLock = [&]() {
-        if (!lockFile(globalLock.get(), ltWrite, false)) {
-            Activity act(*logger, lvlInfo, actUnknown, "waiting for exclusive access to the Nix store");
-            // We have acquired a shared lock; release it to prevent deadlocks.
-            // This can happen if someone else is trying to promote their read
-            // lock into a write lock.
-            lockFile(globalLock.get(), ltNone, false);
-            lockFile(globalLock.get(), ltWrite, true);
-        }
-    };
-
     if (curSchema > nixSchemaVersion)
         throw Error("current Nix store schema is version %1%, but I only support %2%", curSchema, nixSchemaVersion);
 
@@ -326,7 +315,12 @@ LocalStore::LocalStore(ref<const Config> config)
                 "which is no longer supported. To convert to the new format,\n"
                 "please upgrade Nix to version 1.11 first.");
 
-        acquireWriteLock();
+        if (!lockFile(globalLock.get(), ltWrite, false)) {
+            Activity act(*logger, lvlInfo, actUnknown, "waiting for exclusive access to the Nix store");
+            lockFile(
+                globalLock.get(), ltNone, false); // We have acquired a shared lock; release it to prevent deadlocks
+            lockFile(globalLock.get(), ltWrite, true);
+        }
 
         /* Get the schema version again, because another process may
            have performed the upgrade already. */
@@ -359,21 +353,13 @@ LocalStore::LocalStore(ref<const Config> config)
 
         writeFile(schemaPath, fmt("%1%", nixSchemaVersion), 0666, FsSync::Yes);
 
-        // Downgrade to a read lock and hold to prevent other processes from
-        // upgrading the schema while we're using the store
         lockFile(globalLock.get(), ltRead, true);
     }
 
     else
         openDB(*state, false);
 
-    if (!config->readOnly && upgradeDBSchema(*state, true)) {
-        acquireWriteLock();
-        upgradeDBSchema(*state, false);
-        // Downgrade to a read lock and hold to prevent other processes from
-        // upgrading the schema while we're using the store
-        lockFile(globalLock.get(), ltRead, true);
-    }
+    upgradeDBSchema(*state);
 
     /* Prepare SQL statements. */
     state->stmts->RegisterValidPath.create(
@@ -614,24 +600,9 @@ void LocalStore::openDB(State & state, bool create)
     }
 }
 
-bool LocalStore::upgradeDBSchema(State & state, bool dryRun)
+void LocalStore::upgradeDBSchema(State & state)
 {
-    bool ret = false;
-
-    {
-        SQLiteStmt queryHasSchemaMigrations;
-        queryHasSchemaMigrations.create(
-            state.db, "SELECT 1 FROM sqlite_master WHERE type='table' AND name='SchemaMigrations';");
-        auto useQueryHasSchemaMigrations(queryHasSchemaMigrations.use());
-        if (!useQueryHasSchemaMigrations.next()) {
-            if (dryRun)
-                return true;
-            else {
-                state.db.exec("create table SchemaMigrations (migration text primary key not null);");
-                ret = true;
-            }
-        }
-    }
+    state.db.exec("create table if not exists SchemaMigrations (migration text primary key not null);");
 
     StringSet schemaMigrations;
 
@@ -643,16 +614,8 @@ bool LocalStore::upgradeDBSchema(State & state, bool dryRun)
             schemaMigrations.insert(useQuerySchemaMigrations.getStr(0));
     }
 
-    auto needsMigration = [&](const std::string & migrationName) -> bool {
-        return !schemaMigrations.contains(migrationName);
-    };
-
-    auto maybeUpgrade = [&](const std::string & migrationName, const std::string & stmt) {
-        if (!needsMigration(migrationName))
-            return;
-
-        ret = true;
-        if (dryRun)
+    auto doUpgrade = [&](const std::string & migrationName, const std::string & stmt) {
+        if (schemaMigrations.contains(migrationName))
             return;
 
         notice("executing Nix database schema migration '%s'...", migrationName);
@@ -665,17 +628,15 @@ bool LocalStore::upgradeDBSchema(State & state, bool dryRun)
     };
 
     if (experimentalFeatureSettings.isEnabled(Xp::CaDerivations))
-        maybeUpgrade(
+        doUpgrade(
             "20251017-ca-derivations",
 #include "ca-specific-schema.sql.gen.hh"
         );
 
-    maybeUpgrade("20260309-drop-redundant-indexreferrer", "drop index if exists IndexReferrer");
+    doUpgrade("20260309-drop-redundant-indexreferrer", "drop index if exists IndexReferrer");
 
     if (experimentalFeatureSettings.isEnabled(Xp::Provenance))
-        maybeUpgrade("20241024-provenance", "alter table ValidPaths add column provenance text");
-
-    return ret;
+        doUpgrade("20241024-provenance", "alter table ValidPaths add column provenance text");
 }
 
 /* To improve purity, users may want to make the Nix store a read-only

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -295,7 +295,7 @@ LocalStore::LocalStore(ref<const Config> config)
 
     auto acquireWriteLock = [&]() {
         if (!lockFile(globalLock.get(), ltWrite, false)) {
-            printInfo("waiting for exclusive access to the Nix store...");
+            Activity act(*logger, lvlInfo, actUnknown, "waiting for exclusive access to the Nix store");
             // We have acquired a shared lock; release it to prevent deadlocks.
             // This can happen if someone else is trying to promote their read
             // lock into a write lock.

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -133,10 +133,13 @@ void SQLite::isCache()
 
 void SQLite::exec(const std::string & stmt)
 {
-    retrySQLite<void>([&]() {
-        if (sqlite3_exec(db, stmt.c_str(), 0, 0, 0) != SQLITE_OK)
-            SQLiteError::throw_(db, "executing SQLite statement '%s'", stmt);
-    });
+    retrySQLite<void>([&]() { execNoRetry(stmt); });
+}
+
+void SQLite::execNoRetry(const std::string & stmt)
+{
+    if (sqlite3_exec(db, stmt.c_str(), 0, 0, 0) != SQLITE_OK)
+        SQLiteError::throw_(db, "executing SQLite statement '%s'", stmt);
 }
 
 uint64_t SQLite::getLastInsertedRowId()


### PR DESCRIPTION
## Motivation

This reverts https://github.com/NixOS/nix/pull/15941, https://github.com/NixOS/nix/pull/15967 since we really don't want to acquire the global lock, as that can hang forever if there is another process holding it (e.g. a magic-nix-cache process in CI).

The new fix is to correctly handle SQLITE_BUSY errors when multiple processes do a schema migration. The problem was that we were using `SQLite::exec()` inside a transaction. This we should never do, because it  catches `SQLiteBusy` exceptions and retries the statement, which will  just fail again. It's the entire transaction that must be retried.
    
In addition, we now check inside the transaction whether the migration has already been done. Thus, on a retry, we will notice that another process has already done the migration.



<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database schema migration reliability and consistency.
  * Added safer handling for busy databases during migration operations.
  * Prevented retry behavior where database statements execute within transactions.

* **Internal Improvements**
  * Streamlined legacy schema migration and locking behavior.
  * Added direct SQL execution support when retries are not appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->