### PR TITLE
Remove fallback behaviour for RemoteStore::addTempRoots()

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -62,12 +62,9 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
     if (!drv->type().hasKnownOutputPaths())
         experimentalFeatureSettings.require(Xp::CaDerivations);
 
-    StorePathSet outputPaths;
     for (auto & i : drv->outputsAndOptPaths(worker.store))
         if (i.second.second)
-            outputPaths.insert(*i.second.second);
-
-    worker.store.addTempRoots(outputPaths);
+            worker.store.addTempRoot(*i.second.second);
 
     /* We don't yet have any safe way to cache an impure derivation at
        this step. */

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -759,14 +759,8 @@ void RemoteStore::addTempRoots(const StorePathSet & paths)
         WorkerProto::write(*this, *conn, paths);
         conn.processStderr();
         readInt(conn->from);
-    } else {
-        /* Fallback for daemons that don't support the batched
-           operation. Note that this is very slow for large sets of
-           paths on high-latency links, due to a network round-trip per
-           path. */
-        for (auto & path : paths)
-            conn->addTempRoot(*this, &conn.daemonException, path);
     }
+    /* Note: there is no fallback for old daemons to prevent performance regressions. */
 }
 
 Roots RemoteStore::findRoots(bool censor)


### PR DESCRIPTION
## Motivation

The fallback makes `nix copy` very slow when copying to a older daemon that doesn't support the AddTempRoots worker protocol operation. Of course, this is less correct, but it's the behaviour we've had for years prior to 7beda55f66a4cef7780a46a93ca975313fcbbc74.

Fixes the issue mentioned in https://github.com/DeterminateSystems/nix-src/issues/533#issuecomment-4940593460.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary roots for optional derivation outputs.
  * Enhanced compatibility with daemons that do not support batched temporary-root registration.
  * Avoided unnecessary fallback requests when the batched operation is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->