### PR TITLE
nix eval: Add --drv-link flag to create symlinks to top-level derivations

### DIFF
--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -2,6 +2,7 @@
 #include "nix/main/common-args.hh"
 #include "nix/main/shared.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/local-fs-store.hh"
 #include "nix/expr/eval.hh"
 #include "nix/expr/eval-inline.hh"
 #include "nix/expr/value-to-json.hh"
@@ -15,6 +16,7 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
     bool raw = false;
     std::optional<std::string> apply;
     std::optional<std::filesystem::path> writeTo;
+    std::optional<std::filesystem::path> drvLink;
 
     CmdEval()
         : InstallableValueCommand()
@@ -37,6 +39,15 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
             .description = "Write a string or attrset of strings to *path*.",
             .labels = {"path"},
             .handler = {&writeTo},
+        });
+
+        addFlag({
+            .longName = "drv-link",
+            .description =
+                "Use *path* as prefix for symlinks to derivations produced by the evaluation at top-level. By default, no symlinks are created.",
+            .labels = {"path"},
+            .handler = {&drvLink},
+            .completer = completePath,
         });
     }
 
@@ -61,6 +72,9 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
     {
         if (raw && json)
             throw UsageError("--raw and --json are mutually exclusive");
+
+        if (drvLink && !raw && !json)
+            throw UsageError("--drv-link requires --raw or --json");
 
         auto state = getEvalState();
 
@@ -124,6 +138,31 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
 
         else {
             logger->cout("%s", ValuePrinter(*state, *v, PrintOptions{.force = true, .derivationPaths = true}));
+        }
+
+        if (drvLink) {
+            // Create out links for the store paths in `context`. Similar to createOutLinks(), except that for
+            // derivations, we create symlinks to the .drv files rather than the outputs (since we didn't build
+            // anything).
+            if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>()) {
+                std::set<StorePath> roots;
+                for (auto & c : context)
+                    std::visit(
+                        overloaded{
+                            [&](const NixStringContextElem::Opaque & o) { roots.insert(state->devirtualize(o.path)); },
+                            [&](const NixStringContextElem::DrvDeep & d) { roots.insert(d.drvPath); },
+                            [&](const NixStringContextElem::Built & b) { roots.insert(b.drvPath->getBaseStorePath()); },
+                            [&](const NixStringContextElem::Path &) {},
+                        },
+                        c.raw);
+                for (const auto & [i, path] : enumerate(roots)) {
+                    auto symlink = *drvLink;
+                    if (i)
+                        symlink += fmt("-%d", i);
+                    state->waitForPath(path);
+                    store2->addPermRoot(path, absPath(symlink).string());
+                }
+            }
         }
     }
 };

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -102,6 +102,16 @@ nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir"
 (cd "$flake1Dir" && nix build -o "$TEST_ROOT/result" "path:.")
 (cd "$flake1Dir" && nix build -o "$TEST_ROOT/result" "git+file:.")
 
+# Test 'nix eval --drv-link'.
+drvPath=$(nix eval --raw --drv-link "$TEST_ROOT/drv" flake1#foo.drvPath)
+[[ $(readlink "$TEST_ROOT/drv") = "$drvPath" ]]
+[[ $(nix path-info "$TEST_ROOT/drv") = "$drvPath" ]]
+rm "$TEST_ROOT/drv"
+
+# '--drv-link' requires '--raw' or '--json'.
+expectStderr 1 nix eval --drv-link "$TEST_ROOT/drv" flake1#foo.drvPath | grepQuiet -- "--drv-link requires --raw or --json"
+[[ ! -e "$TEST_ROOT/drv" ]]
+
 # Test explicit packages.default.
 nix build -o "$TEST_ROOT/result" "$flake1Dir#default"
 nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir#default"


### PR DESCRIPTION
## Motivation

This creates GC-rooted symlinks for the store paths in the string context of the result of `nix eval` (with `--raw` or `--json`). Unlike `nix build --out-link`, derivations are linked to their .drv files rather than their outputs, since nothing was built.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--drv-link` option to `nix eval`.
  * With raw or JSON output, creates numbered persistent links to relevant evaluated store and derivation paths.
  * Links use the supplied path prefix and are created after referenced paths are available.

* **Bug Fixes**
  * Rejects `--drv-link` when used without raw or JSON output, without creating a link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->