### PR TITLE
Handle out-of-memory crashes better

### DIFF
--- a/src/libexpr/eval-gc.cc
+++ b/src/libexpr/eval-gc.cc
@@ -40,8 +40,7 @@ static_assert(sizeof(void *) * 2 == GC_GRANULE_BYTES, "Boehm GC must use GC_GRAN
 /* Called when the Boehm GC runs out of memory. */
 static void * oomHandler(size_t requested)
 {
-    /* Convert this to a proper C++ exception. */
-    throw std::bad_alloc();
+    outOfMemory();
 }
 
 static size_t getFreeMem()

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -70,7 +70,7 @@ static char * allocString(size_t size)
     char * t;
     t = (char *) GC_MALLOC_ATOMIC(size);
     if (!t)
-        throw std::bad_alloc();
+        outOfMemory();
     return t;
 }
 
@@ -96,7 +96,7 @@ StringData & StringData::alloc(EvalMemory & mem, size_t size)
 {
     void * t = mem.allocBytes(sizeof(StringData) + size + 1);
     if (!t)
-        throw std::bad_alloc();
+        outOfMemory();
     auto res = new (t) StringData(size);
     return *res;
 }

--- a/src/libexpr/include/nix/expr/eval-inline.hh
+++ b/src/libexpr/include/nix/expr/eval-inline.hh
@@ -22,7 +22,7 @@ inline void * EvalMemory::allocBytes(size_t n)
     p = calloc(n, 1);
 #endif
     if (!p)
-        throw std::bad_alloc();
+        outOfMemory();
     return p;
 }
 
@@ -42,7 +42,7 @@ Value * EvalMemory::allocValue()
     if (!*valueAllocCache) {
         *valueAllocCache = GC_malloc_many(sizeof(Value));
         if (!*valueAllocCache)
-            throw std::bad_alloc();
+            outOfMemory();
     }
 
     /* GC_NEXT is a convenience macro for accessing the first word of an object.
@@ -76,7 +76,7 @@ Env & EvalMemory::allocEnv(size_t size)
         if (!*env1AllocCache) {
             *env1AllocCache = GC_malloc_many(sizeof(Env) + sizeof(Value *));
             if (!*env1AllocCache)
-                throw std::bad_alloc();
+                outOfMemory();
         }
 
         void * p = *env1AllocCache;

--- a/src/libexpr/root-value.cc
+++ b/src/libexpr/root-value.cc
@@ -46,7 +46,7 @@ RootValue::RootValue(Value * v)
             constexpr size_t slabSize = 4096;
             auto slab = (Slot *) GC_MALLOC_UNCOLLECTABLE(slabSize * sizeof(Slot));
             if (!slab)
-                throw std::bad_alloc();
+                outOfMemory();
             for (size_t i = 0; i + 1 < slabSize; ++i)
                 slab[i].nextFree = &slab[i + 1];
             slab[slabSize - 1].nextFree = nullptr;

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -1178,10 +1178,6 @@ void processConnection(ref<Store> store, FdSource && from, FdSink && to, Trusted
                 tunnelLogger->stopWork(&e);
                 if (!errorAllowed)
                     throw;
-            } catch (std::bad_alloc & e) {
-                auto ex = Error("Nix daemon out of memory");
-                tunnelLogger->stopWork(&ex);
-                throw;
             }
 
             conn.to.flush();

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -246,7 +246,7 @@ struct curlFileTransfer : public FileTransfer
         {
             curlSList tmpSList = curlSList(::curl_slist_append(requestHeaders.get(), requireCString(header)));
             if (!tmpSList)
-                throw std::bad_alloc();
+                outOfMemory();
             requestHeaders.release();
             requestHeaders = std::move(tmpSList);
         }

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1417,7 +1417,7 @@ StorePath LocalStore::addToStoreFromDump(
             dumpBuffer.release();
             dumpBuffer.reset((char *) tmp);
         } else {
-            throw std::bad_alloc();
+            outOfMemory();
         }
         auto got = 0;
         Finally cleanup([&]() { dump = {dumpBuffer.get(), dump.size() + got}; });

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -470,6 +470,11 @@ void panic(std::string_view msg)
     std::terminate();
 }
 
+void outOfMemory()
+{
+    panic("ran out of memory");
+}
+
 void unreachable(std::source_location loc)
 {
     char buf[512];

--- a/src/libutil/include/nix/util/error.hh
+++ b/src/libutil/include/nix/util/error.hh
@@ -471,6 +471,16 @@ void throwExceptionSelfCheck();
 void panic(std::string_view msg);
 
 /**
+ * Print an error message and std::terminate(). Installed as the
+ * `std::new_handler` so that failing memory allocations produce a
+ * clear "out of memory" error instead of an opaque abort (in
+ * particular when `operator new` is overridden by mimalloc, which
+ * cannot throw `std::bad_alloc`).
+ */
+[[noreturn]]
+void outOfMemory();
+
+/**
  * Log the current exception (if any) and call abort().
  */
 [[noreturn]]

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cctype>
+#include <new>
 
 #include <openssl/crypto.h>
 #include <sodium.h>
@@ -63,6 +64,11 @@ void initLibUtil()
        effect. */
     if (OPENSSL_init_crypto(OPENSSL_INIT_NO_ATEXIT, nullptr) != 1)
         throw Error("could not initialise OpenSSL");
+
+    /* Make sure that failing memory allocations don't result in an
+       opaque abort() (e.g. from mimalloc's `operator new` override,
+       which cannot throw `std::bad_alloc`). */
+    std::set_new_handler(outOfMemory);
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -427,23 +427,31 @@ void mainWrapped(int argc, char ** argv)
     }
 #endif
 
-    /* This must be called before Sentry since both initialize OpenSSL. */
-    initLibUtil();
-
 #if HAVE_MIMALLOC
     /* Make allocation failures print a proper error message instead
        of aborting silently. Note that the `std::new_handler` installed
        by `initLibUtil()` does not suffice, since mimalloc's `operator
        new` override never sees it: libmimalloc is linked with
        `-Bsymbolic`, so its weak null stub of `std::get_new_handler()`
-       shadows the real one from libstdc++. */
+       shadows the real one from libstdc++. Register this before
+       `initLibUtil()` so allocation failures during initialization
+       are handled as well. */
     mi_register_error(
         [](int err, void *) {
             if (err == ENOMEM || err == EOVERFLOW)
                 outOfMemory();
+            /* EFAULT means mimalloc detected heap corruption (e.g. a
+               double free) in secure mode; don't continue with a
+               corrupted heap. EINVAL (bad pointer passed to
+               `mi_free()`) is non-fatal, so just return. */
+            if (err == EFAULT)
+                panic("mimalloc detected heap corruption");
         },
         nullptr);
 #endif
+
+    /* This must be called before Sentry since both initialize OpenSSL. */
+    initLibUtil();
 
     bool sentryEnabled = false;
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -35,6 +35,10 @@
 #  include <sentry.h>
 #endif
 
+#if HAVE_MIMALLOC
+#  include <mimalloc.h>
+#endif
+
 #ifndef _WIN32
 #  include <sys/socket.h>
 #  include <ifaddrs.h>
@@ -425,6 +429,21 @@ void mainWrapped(int argc, char ** argv)
 
     /* This must be called before Sentry since both initialize OpenSSL. */
     initLibUtil();
+
+#if HAVE_MIMALLOC
+    /* Make allocation failures print a proper error message instead
+       of aborting silently. Note that the `std::new_handler` installed
+       by `initLibUtil()` does not suffice, since mimalloc's `operator
+       new` override never sees it: libmimalloc is linked with
+       `-Bsymbolic`, so its weak null stub of `std::get_new_handler()`
+       shadows the real one from libstdc++. */
+    mi_register_error(
+        [](int err, void *) {
+            if (err == ENOMEM || err == EOVERFLOW)
+                outOfMemory();
+        },
+        nullptr);
+#endif
 
     bool sentryEnabled = false;
 

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -69,6 +69,8 @@ mandir = get_option('mandir')
 mandir = fs.is_absolute(mandir) ? mandir : prefix / mandir
 configdata.set_quoted('NIX_MAN_DIR', mandir)
 
+configdata.set('HAVE_MIMALLOC', mimalloc.found().to_int())
+
 sentry_required = get_option('sentry')
 configdata.set('HAVE_SENTRY', sentry_required.enabled().to_int())
 if sentry_required.enabled()


### PR DESCRIPTION
## Motivation

Previously, running out of memory resulted in an opaque SIGABRT (e.g. Sentry issue DETERMINATE-NIX-8P): mimalloc's `operator new` override is compiled as C, so it cannot throw `std::bad_alloc` and instead calls abort() when an allocation fails and no new handler is  installed.

So now we install a mimalloc error handler that prints a proper error message. Also, we now install a `std::new_handler` to avoid throwing `std::bad_alloc`, which we can't meaningfully handle and which can result in crashes if the exception is thrown in contexts (like destructors) where we're not allowed to throw.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of memory-allocation failures across evaluation, storage, file transfer, and service operations.
  - Out-of-memory conditions now produce a consistent, clear fatal error instead of opaque allocation exceptions or abrupt termination.
  - Daemon connections now receive allocation-related errors before shutting down cleanly.
  - Startup now detects and reports allocation failures from supported memory allocators consistently.
  - Improved detection and reporting of heap corruption during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->