### PR TITLE
Fix `dir` attribute handling in nix-219-compat mode

### DIFF
--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -268,6 +268,42 @@ INSTANTIATE_TEST_SUITE_P(
         }),
     [](const ::testing::TestParamInfo<InputFromURLTestCase> & info) { return info.param.description; });
 
+TEST(parseFlakeRef, nix219CompatRetainsDirInUrlAttr)
+{
+    fetchers::Settings fetchSettings;
+    fetchSettings.nix219Compat = true;
+
+    /* Nix < 2.20 retained the `dir` query parameter in the `url`
+       attribute of input types that have one. */
+    {
+        auto flakeref = parseFlakeRef(fetchSettings, "git+https://example.org/repo?dir=sub");
+        ASSERT_EQ(flakeref.subdir, "sub");
+        ASSERT_EQ(flakeref.toAttrs().at("url"), Attr("https://example.org/repo?dir=sub"));
+    }
+
+    {
+        auto flakeref = parseFlakeRef(fetchSettings, "https://example.org/foo.tar.gz?dir=sub");
+        ASSERT_EQ(flakeref.subdir, "sub");
+        ASSERT_EQ(flakeref.toAttrs().at("url"), Attr("https://example.org/foo.tar.gz?dir=sub"));
+    }
+
+    /* But for input types that don't have a `url` attribute (such as
+       `github`), the `dir` parameter was never part of the input
+       attributes, so it should not cause a parse failure. */
+    {
+        auto flakeref = parseFlakeRef(fetchSettings, "github:NixOS/nix?dir=perl");
+        ASSERT_EQ(flakeref.subdir, "perl");
+        ASSERT_EQ(
+            flakeref.toAttrs(),
+            (fetchers::Attrs{
+                {"dir", Attr("perl")},
+                {"owner", Attr("NixOS")},
+                {"repo", Attr("nix")},
+                {"type", Attr("github")},
+            }));
+    }
+}
+
 TEST(to_string, doesntReencodeUrl)
 {
     fetchers::Settings fetchSettings;

--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -10,6 +10,7 @@
 #include "nix/util/configuration.hh"
 #include "nix/util/error.hh"
 #include "nix/util/experimental-features.hh"
+#include "nix/util/terminal.hh"
 
 namespace nix {
 
@@ -276,6 +277,24 @@ TEST(to_string, doesntReencodeUrl)
     auto expected = "http://localhost:8181/test/%2B3d.tar.gz";
 
     ASSERT_EQ(unparsed, expected);
+}
+
+TEST(parseFlakeRef, urlInterpretationErrorsAreNotMasked)
+{
+    fetchers::Settings fetchSettings;
+
+    // Errors that occur while interpreting a syntactically valid URL
+    // (such as an unsupported query parameter) should be shown to the
+    // user, rather than causing the flake ref to be reinterpreted as a
+    // path, leading to a confusing "not an absolute path" error.
+    try {
+        parseFlakeRef(fetchSettings, "github:foo/bar?xyzzy=1");
+        FAIL() << "expected parseFlakeRef to throw";
+    } catch (BadURL & e) {
+        auto msg = filterANSIEscapes(e.msg());
+        EXPECT_NE(msg.find("xyzzy"), std::string::npos) << msg;
+        EXPECT_EQ(msg.find("not an absolute path"), std::string::npos) << msg;
+    }
 }
 
 TEST(parseFlakeRef, malformedGithubUrlDoesNotCrash)

--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -250,18 +250,27 @@ std::optional<std::pair<FlakeRef, std::string>> parseURLFlakeRef(
     const std::optional<std::filesystem::path> & baseDir,
     bool isFlake)
 {
+    std::optional<ParsedURL> parsed;
     try {
-        auto parsed = parseURL(url, /*lenient=*/true);
-        if (baseDir && (parsed.scheme == "path" || parsed.scheme == "git+file")) {
-            /* Here we know that the path must not contain encoded '/' or NUL bytes. */
-            auto path = urlPathToPath(parsed.path);
-            if (!path.is_absolute())
-                parsed.path = pathToUrlPath(absPath(path, get(baseDir)));
-        }
-        return fromParsedURL(fetchSettings, std::move(parsed), isFlake);
+        parsed = parseURL(url, /*lenient=*/true);
     } catch (BadURL &) {
+        /* The string is not a URL, so try to interpret it as a path
+           instead (in the caller). Note that errors that occur while
+           *interpreting* a syntactically valid URL (such as an
+           unsupported query parameter) are not caught here; they
+           should be shown to the user rather than masked by a
+           confusing error about the flake ref not being a valid
+           path. */
         return std::nullopt;
     }
+
+    if (baseDir && (parsed->scheme == "path" || parsed->scheme == "git+file")) {
+        /* Here we know that the path must not contain encoded '/' or NUL bytes. */
+        auto path = urlPathToPath(parsed->path);
+        if (!path.is_absolute())
+            parsed->path = pathToUrlPath(absPath(path, get(baseDir)));
+    }
+    return fromParsedURL(fetchSettings, std::move(*parsed), isFlake);
 }
 
 std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(

--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -91,13 +91,38 @@ static std::pair<FlakeRef, std::string>
 fromParsedURL(const fetchers::Settings & fetchSettings, ParsedURL && parsedURL, bool isFlake)
 {
     auto dir = getOr(parsedURL.query, "dir", "");
-    if (!fetchSettings.nix219Compat)
-        parsedURL.query.erase("dir");
+    parsedURL.query.erase("dir");
 
     std::string fragment;
     std::swap(fragment, parsedURL.fragment);
 
-    return {FlakeRef(fetchers::Input::fromURL(fetchSettings, parsedURL, isFlake), dir), fragment};
+    auto input = fetchers::Input::fromURL(fetchSettings, parsedURL, isFlake);
+
+    /* Backward compatibility hack: Nix < 2.20 retained the `dir`
+       query parameter in the `url` attribute of input types that have
+       one (i.e. `git`, `hg`, `tarball` and `file`), resulting in lock
+       file entries like
+
+         "original": {
+           "dir": "subdir",
+           "type": "git",
+           "url": "https://foo/bar?dir=subdir"
+         }
+
+       In compat mode, reproduce that behavior so that we write lock
+       files that Nix < 2.20 considers up to date. Input types that
+       don't have a `url` attribute (such as `github`) never included
+       the `dir` parameter in their attributes, so they're left
+       alone. */
+    if (fetchSettings.nix219Compat && dir != "") {
+        if (auto url = fetchers::maybeGetStrAttr(input.attrs, "url")) {
+            auto parsedUrlAttr = parseURL(*url, /*lenient=*/true);
+            parsedUrlAttr.query.insert_or_assign("dir", dir);
+            input.attrs.insert_or_assign("url", parsedUrlAttr.to_string());
+        }
+    }
+
+    return {FlakeRef(std::move(input), dir), fragment};
 }
 
 std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fixes
```
$ nix --option nix-219-compat true eval --expr 'builtins.parseFlakeRef "github:NixOS/nix?dir=perl"'
error:
       … while calling the 'parseFlakeRef' builtin
         at «string»:1:1:
            1| builtins.parseFlakeRef "github:NixOS/nix?dir=perl"
             | ^

       error: flake reference 'github:NixOS/nix?dir=perl' is not an absolute path
```

Also improves the error message
```
$ nix eval --expr 'builtins.parseFlakeRef "github:NixOS/nix?xyzzy=1"'
error:
       … while calling the 'parseFlakeRef' builtin
         at «string»:1:1:
            1| builtins.parseFlakeRef "github:NixOS/nix?xyzzy=1"
             | ^

       error: flake reference 'github:NixOS/nix?xyzzy=1' is not an absolute path
```
to
```
error:
       … while calling the 'parseFlakeRef' builtin
         at «string»:1:1:
            1| builtins.parseFlakeRef "github:NixOS/nix?xyzzy=1"
             | ^

       error: URL 'github:NixOS/nix?xyzzy=1' contains unknown parameter 'xyzzy'
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with Nix 2.19 by preserving directory information for supported URL-based inputs.
  - Prevented directory metadata from being incorrectly retained for GitHub inputs.
  - Fixed URL handling so valid URLs with unsupported query parameters now report their errors instead of being misinterpreted as local paths.

- **Tests**
  - Added regression coverage for directory retention, GitHub behavior, and URL parsing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->