### PR TITLE
fromJSON: Eliminate use of uncollectable containers 

### DIFF
--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -1534,13 +1534,6 @@ public:
 };
 
 typedef std::vector<Value *, traceable_allocator<Value *>> ValueVector;
-typedef boost::unordered_flat_map<
-    Symbol,
-    Value *,
-    std::hash<Symbol>,
-    std::equal_to<Symbol>,
-    traceable_allocator<std::pair<const Symbol, Value *>>>
-    ValueMap;
 
 void forceNoNullByte(std::string_view s, std::function<Pos()> = nullptr);
 } // namespace nix

--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -19,7 +19,18 @@ class JSONSax : nlohmann::json_sax<json>
     {
     protected:
         std::unique_ptr<JSONState> parent;
-        RootValue v;
+
+        /**
+         * The value being built by this state, or null. Kept alive by
+         * `JSONSax::rootValues`.
+         */
+        Value * v = nullptr;
+
+        /**
+         * Reference to `JSONSax::rootValues`.
+         */
+        ValueVector & rootValues;
+
     public:
         virtual std::unique_ptr<JSONState> resolve(EvalState &)
         {
@@ -28,11 +39,13 @@ class JSONSax : nlohmann::json_sax<json>
 
         explicit JSONState(std::unique_ptr<JSONState> && p)
             : parent(std::move(p))
+            , rootValues(parent->rootValues)
         {
         }
 
-        explicit JSONState(Value * v)
-            : v(RootValue(v))
+        JSONState(Value * v, ValueVector & rootValues)
+            : v(v)
+            , rootValues(rootValues)
         {
         }
 
@@ -40,9 +53,13 @@ class JSONSax : nlohmann::json_sax<json>
 
         Value & value(EvalState & state)
         {
-            if (!v)
-                v = RootValue(state.allocValue());
-            return **v;
+            if (!v) {
+                v = state.allocValue();
+                /* Root the value for the duration of the parse (see
+                   `JSONSax::rootValues`). */
+                rootValues.push_back(v);
+            }
+            return *v;
         }
 
         virtual ~JSONState() {}
@@ -53,7 +70,14 @@ class JSONSax : nlohmann::json_sax<json>
     class JSONObjectState : public JSONState
     {
         using JSONState::JSONState;
-        ValueMap attrs;
+
+        /**
+         * Note: deliberately not `ValueMap`: the values are rooted via
+         * `JSONSax::rootValues`, so there is no need for a GC-visible
+         * (uncollectable) container, whose allocations would take the
+         * global GC allocation lock.
+         */
+        boost::unordered_flat_map<Symbol, Value *, std::hash<Symbol>> attrs;
 
         std::unique_ptr<JSONState> resolve(EvalState & state) override
         {
@@ -66,7 +90,7 @@ class JSONSax : nlohmann::json_sax<json>
 
         void add() override
         {
-            v.reset();
+            v = nullptr;
         }
     public:
         void key(string_t & name, EvalState & state)
@@ -78,7 +102,11 @@ class JSONSax : nlohmann::json_sax<json>
 
     class JSONListState : public JSONState
     {
-        ValueVector values;
+        /**
+         * Note: deliberately not `ValueVector` (see
+         * `JSONObjectState::attrs`).
+         */
+        std::vector<Value *> values;
 
         std::unique_ptr<JSONState> resolve(EvalState & state) override
         {
@@ -91,8 +119,8 @@ class JSONSax : nlohmann::json_sax<json>
 
         void add() override
         {
-            values.push_back(*v);
-            v.reset();
+            values.push_back(v);
+            v = nullptr;
         }
     public:
         JSONListState(std::unique_ptr<JSONState> && p, std::size_t reserve)
@@ -103,12 +131,24 @@ class JSONSax : nlohmann::json_sax<json>
     };
 
     EvalState & state;
+
+    /**
+     * Keeps all values allocated during the parse alive. This is the
+     * only GC-visible container of the parser: the per-node containers
+     * in `JSONObjectState`/`JSONListState` use ordinary allocators,
+     * since GC-visible (uncollectable) allocations take the global GC
+     * allocation lock, and a big JSON document would otherwise do one
+     * or more of them per object/array node — a significant source of
+     * lock contention during parallel evaluation.
+     */
+    ValueVector rootValues;
+
     std::unique_ptr<JSONState> rs;
 
 public:
     JSONSax(EvalState & state, Value & v)
         : state(state)
-        , rs(new JSONState(&v)) {};
+        , rs(new JSONState(&v, rootValues)) {};
 
     bool null() override
     {

--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -3,6 +3,7 @@
 #include "nix/expr/eval.hh"
 
 #include <limits>
+#include <boost/container/small_vector.hpp>
 #include <nlohmann/json.hpp>
 
 using json = nlohmann::json;
@@ -75,9 +76,10 @@ class JSONSax : nlohmann::json_sax<json>
          * Note: deliberately not `ValueMap`: the values are rooted via
          * `JSONSax::rootValues`, so there is no need for a GC-visible
          * (uncollectable) container, whose allocations would take the
-         * global GC allocation lock.
+         * global GC allocation lock. The inline capacity avoids a heap
+         * allocation for small objects.
          */
-        std::vector<std::pair<Symbol, Value *>> attrs;
+        boost::container::small_vector<std::pair<Symbol, Value *>, 16> attrs;
 
         std::unique_ptr<JSONState> resolve(EvalState & state) override
         {
@@ -109,11 +111,13 @@ class JSONSax : nlohmann::json_sax<json>
 
     class JSONListState : public JSONState
     {
+        using JSONState::JSONState;
+
         /**
          * Note: deliberately not `ValueVector` (see
          * `JSONObjectState::attrs`).
          */
-        std::vector<Value *> values;
+        boost::container::small_vector<Value *, 16> values;
 
         std::unique_ptr<JSONState> resolve(EvalState & state) override
         {
@@ -128,12 +132,6 @@ class JSONSax : nlohmann::json_sax<json>
         {
             values.push_back(v);
             v = nullptr;
-        }
-    public:
-        JSONListState(std::unique_ptr<JSONState> && p, std::size_t reserve)
-            : JSONState(std::move(p))
-        {
-            values.reserve(reserve);
         }
     };
 
@@ -239,7 +237,7 @@ public:
 
     bool start_array(size_t len) override
     {
-        rs = std::make_unique<JSONListState>(std::move(rs), len != std::numeric_limits<size_t>::max() ? len : 128);
+        rs = std::make_unique<JSONListState>(std::move(rs));
         return true;
     }
 

--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -77,14 +77,21 @@ class JSONSax : nlohmann::json_sax<json>
          * (uncollectable) container, whose allocations would take the
          * global GC allocation lock.
          */
-        boost::unordered_flat_map<Symbol, Value *, std::hash<Symbol>> attrs;
+        std::vector<std::pair<Symbol, Value *>> attrs;
 
         std::unique_ptr<JSONState> resolve(EvalState & state) override
         {
+            /* JSON allows duplicate keys, and the last occurrence
+               wins. `Bindings` requires unique keys, so drop all but
+               the last entry of every run of equal keys. The stable
+               sort keeps equal keys in insertion order. */
+            std::stable_sort(
+                attrs.begin(), attrs.end(), [](const auto & a, const auto & b) { return a.first < b.first; });
             auto attrs2 = state.buildBindings(attrs.size());
-            for (auto & i : attrs)
-                attrs2.insert(i.first, i.second);
-            parent->value(state).mkAttrs(attrs2);
+            for (auto i = attrs.begin(); i != attrs.end(); ++i)
+                if (std::next(i) == attrs.end() || std::next(i)->first != i->first)
+                    attrs2.insert(i->first, i->second);
+            parent->value(state).mkAttrs(attrs2.alreadySorted());
             return std::move(parent);
         }
 
@@ -96,7 +103,7 @@ class JSONSax : nlohmann::json_sax<json>
         void key(string_t & name, EvalState & state)
         {
             forceNoNullByte(name);
-            attrs.insert_or_assign(state.symbols.create(name), &value(state));
+            attrs.emplace_back(state.symbols.create(name), &value(state));
         }
     };
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- AI/automation policy
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

`fromJSON` was responsible for something like 183K calls to `GC_MALLOC_UNCOLLECTABLE()` during `nix search nixpkgs`. This is bad for parallel eval because uncollectable allocations take the global allocator lock. So now we use a single `ValueVector` to keep values alive.

Also some other optimizations like replacing `unordered_flat_map` by a `small_vector`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON parsing reliability for objects with duplicate keys by consistently retaining the final value.
  * Improved handling of parsed JSON objects and arrays for more stable results.
* **Refactor**
  * Streamlined internal value management during JSON parsing without changing the user-facing JSON conversion workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->