### PR TITLE
nix copy: Don't register temp roots if the remote doesn't have AddTempRoots

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -62,9 +62,12 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
     if (!drv->type().hasKnownOutputPaths())
         experimentalFeatureSettings.require(Xp::CaDerivations);
 
+    StorePathSet outputPaths;
     for (auto & i : drv->outputsAndOptPaths(worker.store))
         if (i.second.second)
-            worker.store.addTempRoot(*i.second.second);
+            outputPaths.insert(*i.second.second);
+
+    worker.store.addTempRoots(outputPaths);
 
     /* We don't yet have any safe way to cache an impure derivation at
        this step. */

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -81,7 +81,7 @@ void LocalStore::createTempRootsFile()
     }
 }
 
-void LocalStore::addTempRoots(const StorePathSet & paths)
+void LocalStore::addTempRoots(const StorePathSet & paths, bool _skipIfSlow)
 {
     if (config->readOnly) {
         debug(

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -313,7 +313,7 @@ public:
         RepairFlag repair,
         std::shared_ptr<const Provenance> provenance) override;
 
-    void addTempRoots(const StorePathSet & paths) override;
+    void addTempRoots(const StorePathSet & paths, bool skipIfSlow) override;
 
 private:
 

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -136,7 +136,7 @@ public:
 
     void ensurePath(const StorePath & path) override;
 
-    void addTempRoots(const StorePathSet & paths) override;
+    void addTempRoots(const StorePathSet & paths, bool skipIfSlow) override;
 
     Roots findRoots(bool censor) override;
 

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -895,7 +895,7 @@ public:
      * Add multiple store paths as temporary roots of the garbage collector.
      * The roots disappears as soon as we exit.
      */
-    virtual void addTempRoots(const StorePathSet & paths)
+    virtual void addTempRoots(const StorePathSet & paths, bool skipIfSlow = false)
     {
         debug("not creating temporary roots, store doesn't support GC");
     }

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -747,7 +747,7 @@ void RemoteStore::ensurePath(const StorePath & path)
     readInt(conn->from);
 }
 
-void RemoteStore::addTempRoots(const StorePathSet & paths)
+void RemoteStore::addTempRoots(const StorePathSet & paths, bool skipIfSlow)
 {
     if (paths.empty())
         return;
@@ -760,6 +760,8 @@ void RemoteStore::addTempRoots(const StorePathSet & paths)
         conn.processStderr();
         readInt(conn->from);
     } else {
+        if (skipIfSlow)
+            return;
         /* Fallback for daemons that don't support the batched
            operation. Note that this is very slow for large sets of
            paths on high-latency links, due to a network round-trip per

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -759,8 +759,14 @@ void RemoteStore::addTempRoots(const StorePathSet & paths)
         WorkerProto::write(*this, *conn, paths);
         conn.processStderr();
         readInt(conn->from);
+    } else {
+        /* Fallback for daemons that don't support the batched
+           operation. Note that this is very slow for large sets of
+           paths on high-latency links, due to a network round-trip per
+           path. */
+        for (auto & path : paths)
+            conn->addTempRoot(*this, &conn.daemonException, path);
     }
-    /* Note: there is no fallback for old daemons to prevent performance regressions. */
 }
 
 Roots RemoteStore::findRoots(bool censor)

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -130,7 +130,7 @@ public:
         unsupported("buildDerivation");
     }
 
-    void addTempRoots(const StorePathSet & paths) override {}
+    void addTempRoots(const StorePathSet & paths, bool skipIfSlow) override {}
 
     void addIndirectRoot(const std::filesystem::path & path) override {}
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1066,7 +1066,9 @@ std::map<StorePath, StorePath> copyPaths(
     CheckSigsFlag checkSigs,
     SubstituteFlag substitute)
 {
-    dstStore.addTempRoots(storePaths);
+    /* This is optional to avoid a performance regression when talking to old daemons that don't have the AddTempRoots
+     * operation. */
+    dstStore.addTempRoots(storePaths, true);
 
     auto valid = dstStore.queryValidPaths(storePaths, substitute);
 


### PR DESCRIPTION
## Motivation

Reverts #598 which was kind of broken in that it disables all remote temp root registration on old daemons. Now we only disable that for `copyPaths()`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved temporary-root registration by batching paths into a single operation where supported.
  * Avoids slow fallback operations when communicating with older daemons during path copying.

* **Compatibility**
  * Maintains support for older daemon versions that do not provide batched temporary-root registration.
  * Preserves existing behavior when slow-operation skipping is not requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->