### PR TITLE
Fix crash when GC is interrupted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,5 @@ Observe the following rules when contributing to this repository:
 * Before committing, run ./maintainers/format.sh to detect/fix any formatting issues.
 
 * Use "Assisted-by:" instead of "Co-Authored-By:" for the Claude trailer in commits.
+
+* Do not create PRs unless prompted. Create PRs using `gh pr create --repo DeterminateSystems/nix-src --base main`, observing `.github/PULL_REQUEST_TEMPLATE.md`.

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -509,7 +509,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                             } else
                                 printError("received garbage instead of a root from client");
                             writeFull(fdClient.get(), "1", false);
-                        } catch (Error & e) {
+                        } catch (BaseError & e) {
                             debug("reading GC root from client: %s", e.msg());
                             break;
                         }


### PR DESCRIPTION
## Motivation

Fixes Sentry report DETERMINATE-NIX-31: the nix-daemon crashed with `std::terminate` (abort) when garbage collection was interrupted by the user.

## Context

The GC roots server's per-client thread only caught `Error`, but `Interrupted` derives from `BaseError`, not `Error` — they are siblings. So when the daemon was interrupted during garbage collection while a client thread was blocked in `readLine()`, the `Interrupted` exception thrown by `checkInterrupt()` escaped the thread, calling `std::terminate()` and crashing the daemon.

The fix is to catch `BaseError` instead, so the client thread logs the interruption and exits its loop cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage-collection client error handling to safely handle a broader range of connection errors when reading roots.
  * Improved store-roots daemon stability by handling client interruptions and preventing unexpected connection errors from terminating detached handlers.
  * Added clearer interruption logging to help diagnose interrupted root-discovery operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->