### PR TITLE
Fix forwarding netrc-file to the daemon

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -291,9 +291,10 @@ struct ClientSettings
                     trusted || name == settings.getWorkerSettings().buildTimeout.name
                     || name == settings.getWorkerSettings().maxSilentTime.name
                     || name == settings.getWorkerSettings().pollInterval.name || name == "connect-timeout"
-                    || name == loggerSettings.sessionId.name || (name == "builders" && value == ""))
+                    || name == loggerSettings.sessionId.name || (name == "builders" && value == "")) {
                     settings.set(name, value);
-                else if (setSubstituters(settings.getWorkerSettings().substituters))
+                    fileTransferSettings.set(name, value);
+                } else if (setSubstituters(settings.getWorkerSettings().substituters))
                     ;
                 else
                     warn(


### PR DESCRIPTION

## Motivation

This was introduced by a bad merge.

Fixes #591.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trusted client overrides now correctly apply file transfer settings alongside general settings.
  * File transfer behavior is now kept consistent with permitted client configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->