### PR TITLE
Fix Ctrl-C handling when Sentry is enabled

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -186,15 +186,6 @@ void initNix(bool loadConfig)
     act.sa_handler = sigHandler;
     if (sigaction(NIX_SIG_MULTI_INT, &act, 0))
         throw SysError("handling multiplexed interrupt");
-
-    /* Reset SIGQUIT to its default disposition. In particular, this
-       unregisters any crash handler installed by `sentry_init()`
-       (which runs before us): SIGQUIT is a user-initiated "quit with
-       core dump" action (e.g. Ctrl-\ at a terminal), not a crash, so
-       it should not be reported. */
-    act.sa_handler = SIG_DFL;
-    if (sigaction(SIGQUIT, &act, 0))
-        throw SysError("handling SIGQUIT");
 #endif
 
 #ifdef __APPLE__

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -44,6 +44,7 @@
 #  include <ifaddrs.h>
 #  include <netdb.h>
 #  include <netinet/in.h>
+#  include <signal.h>
 #endif
 
 #ifdef __linux__
@@ -453,6 +454,27 @@ void mainWrapped(int argc, char ** argv)
     /* This must be called before Sentry since both initialize OpenSSL. */
     initLibUtil();
 
+    /* Set the build hook location
+
+       For builds we perform a self-invocation, so Nix has to be
+       self-aware. That is, it has to know where it is installed. We
+       don't think it's sentient.
+     */
+    settings.getWorkerSettings().buildHook.setDefault(
+        Strings{
+            getNixBin({}).string(),
+            "__build-remote",
+        });
+
+    initNix();
+
+    /* Initialize Sentry only after initNix(), i.e. after
+       startSignalHandlerThread() has blocked SIGINT etc. in the
+       calling thread. The worker threads spawned by `sentry_init()`
+       inherit that signal mask; if they were started earlier, the
+       kernel could deliver a Ctrl-C's SIGINT to one of them, where its
+       default disposition would kill the process immediately (without
+       printing an error or restoring the terminal cursor). */
     bool sentryEnabled = false;
 
 #if HAVE_SENTRY
@@ -481,6 +503,17 @@ void mainWrapped(int argc, char ** argv)
         setSentryTag("nix_command", argc > 0 ? std::string(baseNameOf(argv[0])).c_str() : "");
         std::set_terminate(terminateHandler);
         sentryEnabled = true;
+
+        /* Reset SIGQUIT, for which `sentry_init()` installed a crash
+           handler, to its default disposition: SIGQUIT is a
+           user-initiated "quit with core dump" action (e.g. Ctrl-\ at
+           a terminal), not a crash, so it should not be reported. */
+        struct sigaction act;
+        sigemptyset(&act.sa_mask);
+        act.sa_flags = 0;
+        act.sa_handler = SIG_DFL;
+        if (sigaction(SIGQUIT, &act, 0))
+            throw SysError("handling SIGQUIT");
     }
 
     Finally cleanupSentry([&]() {
@@ -492,19 +525,6 @@ void mainWrapped(int argc, char ** argv)
     if (!sentryEnabled)
         registerCrashHandler();
 
-    /* Set the build hook location
-
-       For builds we perform a self-invocation, so Nix has to be
-       self-aware. That is, it has to know where it is installed. We
-       don't think it's sentient.
-     */
-    settings.getWorkerSettings().buildHook.setDefault(
-        Strings{
-            getNixBin({}).string(),
-            "__build-remote",
-        });
-
-    initNix();
     initGC();
     flakeSettings.configureEvalSettings(evalSettings);
 


### PR DESCRIPTION
## Motivation

On Ctrl-C, Determinate Nix often dies instantly without printing `error: interrupted by the user` and leaves the terminal cursor hidden (upstream Nix behaves correctly). This happens whenever Sentry telemetry is enabled.

## Context

`sentry_init()` spawns worker threads. Since it ran before `initNix()` — and thus before `startSignalHandlerThread()` blocks SIGINT/SIGTERM/SIGHUP in the calling thread — those threads inherited a signal mask with SIGINT unblocked. The kernel is free to deliver a Ctrl-C's SIGINT to any thread that doesn't block it, so it often landed on a Sentry thread, where its default disposition killed the process on the spot: no `Interrupted` exception, no logger shutdown (cursor left hidden), no error message.

This moves Sentry initialization to after `initNix()`, so its threads inherit the blocked mask and SIGINT is only ever received by the signal handler thread via `sigwait()`, as intended. The SIGQUIT reset (which undoes the crash handler Sentry installs for it) moves along from `initNix()` to right after `sentry_init()`, since it must run after it.

The tradeoff is that crashes during `initNix()`/`initGC()` are no longer reported to Sentry, which seems acceptable for fixing interrupt handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup signal handling for more reliable interruption and shutdown behavior.
  * Preserved the intended default handling for quit signals after diagnostic services are initialized.
  * Reduced the risk of conflicting signal handlers during startup and improved error reporting when signal configuration fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->