### PR TITLE
Eval cache: make the second evaluation hit the cache

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -477,9 +477,13 @@ Value & AttrCursor::forceValue()
     }
 
     if (root->db && (!cachedValue || std::get_if<placeholder_t>(&cachedValue->second))) {
-        if (v.type() == nString)
-            cachedValue = {root->db->setString(getKey(), v.string_view(), v.context()), string_t{v.string_view(), {}}};
-        else if (v.type() == nPath) {
+        if (v.type() == nString) {
+            NixStringContext context;
+            copyContext(v, context);
+            cachedValue = {
+                root->db->setString(getKey(), v.string_view(), v.context()),
+                string_t{v.string_view(), std::move(context)}};
+        } else if (v.type() == nPath) {
             auto path = v.path().path;
             cachedValue = {root->db->setString(getKey(), path.abs()), string_t{path.abs(), {}}};
         } else if (v.type() == nBool)

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -58,6 +58,9 @@ struct AttrDb
         SQLiteStmt insertAttributeWithContext;
         SQLiteStmt queryAttribute;
         SQLiteStmt queryAttributes;
+        SQLiteStmt upsertAttribute;
+        SQLiteStmt insertAttributeIfNotExists;
+        SQLiteStmt deleteMissingChildren;
         std::unique_ptr<SQLiteTxn> txn;
     };
 
@@ -91,6 +94,17 @@ struct AttrDb
             state->db, "select rowid, type, value, context from Attributes where parent = ? and name = ?");
 
         state->queryAttributes.create(state->db, "select name from Attributes where parent = ?");
+
+        state->upsertAttribute.create(
+            state->db,
+            "insert into Attributes(parent, name, type, value) values (?, ?, ?, ?) "
+            "on conflict(parent, name) do update set type = excluded.type, value = excluded.value "
+            "returning rowid");
+
+        state->insertAttributeIfNotExists.create(
+            state->db, "insert or ignore into Attributes(parent, name, type, value) values (?, ?, ?, ?)");
+
+        state->deleteMissingChildren.create(state->db, "delete from Attributes where parent = ? and type = 3");
 
         state->txn = std::make_unique<SQLiteTxn>(state->db);
     }
@@ -126,18 +140,20 @@ struct AttrDb
         return doSQLite([&]() {
             auto state(_state->lock());
 
-            state->insertAttribute.use()
-                .apply(key.first)
-                .apply(symbols[key.second])
-                .apply(AttrType::FullAttrs)
-                .apply(0, false)
-                .exec();
-
-            AttrId rowId = state->db.getLastInsertedRowId();
+            // Seal the attribute names: we now know the complete set.
+            auto upsertAttribute(state->upsertAttribute.use()
+                                     .apply(key.first)
+                                     .apply(symbols[key.second])
+                                     .apply(AttrType::FullAttrs)
+                                     .apply(0, false));
+            upsertAttribute.next();
+            auto rowId = (AttrId) upsertAttribute.getInt(0);
             assert(rowId);
+            state->deleteMissingChildren.use().apply(rowId).exec();
 
+            // Insert children as placeholders, but don't replace existing entries
             for (auto & attr : attrs)
-                state->insertAttribute.use()
+                state->insertAttributeIfNotExists.use()
                     .apply(rowId)
                     .apply(symbols[attr])
                     .apply(AttrType::Placeholder)

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -54,6 +54,10 @@ deps_other += boost
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
 
+# eval-cache uses `INSERT ... RETURNING` which requires >= 3.35
+sqlite = dependency('sqlite3', 'sqlite', version : '>= 3.35')
+deps_private += sqlite
+
 bdw_gc_required = get_option('gc').disable_if(
   'address' in get_option('b_sanitize'),
   error_message : 'Building with Boehm GC and ASAN is not supported',

--- a/src/libexpr/package.nix
+++ b/src/libexpr/package.nix
@@ -13,6 +13,7 @@
   boost,
   boehmgc,
   nlohmann_json,
+  sqlite,
   toml11,
   wasmtime,
 
@@ -69,6 +70,7 @@ mkMesonLibrary (finalAttrs: {
   ];
 
   buildInputs = [
+    sqlite
     toml11
   ]
   ++ lib.optional enableWasm wasmtime;

--- a/tests/functional/flakes/eval-cache.sh
+++ b/tests/functional/flakes/eval-cache.sh
@@ -4,6 +4,42 @@ source ./common.sh
 
 requireGit
 
+# Test basic caching: trace should only appear on first evaluation
+basicCacheDir="$TEST_ROOT/basic-cache-flake"
+createGitRepo "$basicCacheDir" ""
+cp "${config_nix}" "$basicCacheDir/"
+git -C "$basicCacheDir" add config.nix
+git -C "$basicCacheDir" commit -m "config.nix"
+
+cat >"$basicCacheDir/flake.nix" <<EOF
+{
+  description = "Basic cache test";
+  outputs = { self }: let inherit (import ./config.nix) mkDerivation; in {
+    # Assert pure-eval is enabled (builtins.currentSystem is unavailable in pure mode)
+    packages.$system.default = assert builtins ? currentSystem -> throw "pure-eval not enabled";
+      builtins.trace "basic-test-evaluating" (mkDerivation {
+        name = "cached-build";
+        buildCommand = "echo hello > \\\$out";
+      });
+  };
+}
+EOF
+
+git -C "$basicCacheDir" add flake.nix
+git -C "$basicCacheDir" commit -m "Init"
+
+clearBinaryCache
+
+# First build should show trace
+nix build --no-link "$basicCacheDir" 2>&1 | grepQuiet 'trace: basic-test-evaluating'
+
+# Second build should use cache, no trace output
+nix build --no-link "$basicCacheDir" 2>&1 | grepQuietInverse 'trace: basic-test-evaluating'
+
+# Third build should also use cache, no trace output
+nix build --no-link "$basicCacheDir" 2>&1 | grepQuietInverse 'trace: basic-test-evaluating'
+
+# Test edge cases with separate flake
 flake1Dir="$TEST_ROOT/eval-cache-flake"
 
 createGitRepo "$flake1Dir" ""


### PR DESCRIPTION
## Motivation

The flake eval cache required *three* runs before an evaluation was fully cached: the first run evaluated and wrote the cache, but the second run was just as slow as the first, and only the third run was fast.

The cause: `setAttrs()` used `insert or replace`, and SQLite implements `REPLACE` as DELETE + INSERT, giving the replaced row a **new rowid**. Since child attributes are keyed by their parent's rowid, sealing an attrset that was previously written as a placeholder (e.g. `outputs`, replaced when a failed attrpath lookup computes suggestions via `getAttrs()`) orphaned the entire subtree already written under the old rowid — including the expensive `drvPath`/`meta` values evaluated during that run. The second run then re-evaluated everything and wrote it under the stable rowids, so only the third run hit the cache.

With this fix, e.g. `nix build --dry-run` on a flake goes from ~17s / ~17s / 0.2s across three runs to ~17s / 0.2s.

## Context

Cherry-picked from upstream https://github.com/NixOS/nix/pull/15288 (commits by Robert Hensing):

- `fix(eval-cache): preserve string context when caching` — the in-memory cached string value dropped its context even though it was written correctly to the database.
- `fix(eval-cache): preserve rowids when sealing attribute names` — replace `insert or replace` with an `on conflict do update ... returning rowid` upsert so existing rows keep their rowid, insert children with `insert or ignore` so cached values aren't clobbered back to placeholders, and delete stale `Missing` children once the attribute set is sealed. Adds an explicit sqlite ≥ 3.35 dependency for `RETURNING`.
- `test(eval-cache): add basic caching test` — asserts that the *second* evaluation already hits the cache.

Conflict resolutions for this fork: the upsert logic was ported from upstream's `SQLiteStmt` `use()(...)` call style to this repo's `.apply(...)` style, and the new test's `clearCache` helper call was renamed to this repo's `clearBinaryCache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved evaluation-cache updates to preserve complete attribute data and remove stale child entries.
  - Preserved string context when cached values are reused.
  - Ensured cached evaluations are reused consistently across subsequent builds.

- **Tests**
  - Added coverage verifying that initial evaluations are cached and later builds avoid reevaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->