### PR TITLE
doc: mention that flake metadata's `Path` field is absent with lazy-trees

### DIFF
--- a/src/nix/flake-metadata.md
+++ b/src/nix/flake-metadata.md
@@ -69,7 +69,7 @@ data. This includes:
 * `Description`: A one-line description of the flake, taken from the
   `description` field in `flake.nix`.
 
-* `Path`: The store path containing the source code of the flake.
+* `Path`: The store path containing the source code of the flake. This field is absent if the [`lazy-trees`](@docroot@/command-ref/conf-file.md#conf-lazy-trees) setting is enabled, since then the flake is not required to reside in the Nix store.
 
 * `Revision`: The Git or Mercurial commit hash of the locked flake.
 
@@ -97,7 +97,7 @@ With `--json`, the output is a JSON object with the following fields:
 
 * `description`: See `Description` above.
 
-* `path`: See `Path` above.
+* `path`: See `Path` above. This field is absent if the [`lazy-trees`](@docroot@/command-ref/conf-file.md#conf-lazy-trees) setting is enabled.
 
 * `revision`: See `Revision` above.
 


### PR DESCRIPTION
## Motivation

The `nix flake metadata` documentation unconditionally describes the `Path` field (and the JSON `path` field), but these are absent when the `lazy-trees` setting is enabled, since the flake is then not required to reside in the Nix store. This documents that behavior.

## Context

Fixes https://github.com/DeterminateSystems/nix-src/issues/589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `Path` and `path` metadata fields may be absent when the `lazy-trees` setting is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->