### PR TITLE
Deduplicate `nix build --print-out-paths` output

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -535,19 +535,24 @@ std::vector<InstallableWithBuildResult> Installable::build2(
     if (mode == Realise::Nothing)
         settings.readOnlyMode = true;
 
-    struct Aux
+    struct Request
     {
+        DerivedPath path;
         ref<ExtraPathInfo> info;
         ref<Installable> installable;
     };
 
+    /* All requests in command-line order, which the results must
+       preserve; pathsToBuild holds each distinct derived path once. */
+    std::vector<Request> requests;
     std::vector<DerivedPath> pathsToBuild;
-    std::map<DerivedPath, std::vector<Aux>> backmap;
+    std::set<DerivedPath> seen;
 
     for (auto & i : installables) {
         for (auto b : i->toDerivedPaths()) {
-            pathsToBuild.push_back(b.path);
-            backmap[b.path].push_back({.info = b.info, .installable = i});
+            if (seen.insert(b.path).second)
+                pathsToBuild.push_back(b.path);
+            requests.push_back({.path = b.path, .info = b.info, .installable = i});
         }
     }
 
@@ -559,32 +564,30 @@ std::vector<InstallableWithBuildResult> Installable::build2(
     case Realise::Derivation:
         printMissing(store, pathsToBuild, lvlError);
 
-        for (auto & path : pathsToBuild) {
-            for (auto & aux : backmap[path]) {
-                std::visit(
-                    overloaded{
-                        [&](const DerivedPath::Built & bfd) {
-                            auto outputs = resolveDerivedPath(*store, bfd, &*evalStore);
-                            res.push_back(
-                                {.installable = aux.installable,
-                                 .result = InstallableWithBuildResult::Success{
-                                     .path =
-                                         BuiltPath::Built{
-                                             .drvPath = make_ref<SingleBuiltPath>(
-                                                 getBuiltPath(evalStore, store, *bfd.drvPath)),
-                                             .outputs = outputs,
-                                         },
-                                     .info = aux.info}});
-                        },
-                        [&](const DerivedPath::Opaque & bo) {
-                            res.push_back(
-                                {.installable = aux.installable,
-                                 .result = InstallableWithBuildResult::Success{
-                                     .path = BuiltPath::Opaque{bo.path}, .info = aux.info}});
-                        },
+        for (auto & req : requests) {
+            std::visit(
+                overloaded{
+                    [&](const DerivedPath::Built & bfd) {
+                        auto outputs = resolveDerivedPath(*store, bfd, &*evalStore);
+                        res.push_back(
+                            {.installable = req.installable,
+                             .result = InstallableWithBuildResult::Success{
+                                 .path =
+                                     BuiltPath::Built{
+                                         .drvPath =
+                                             make_ref<SingleBuiltPath>(getBuiltPath(evalStore, store, *bfd.drvPath)),
+                                         .outputs = outputs,
+                                     },
+                                 .info = req.info}});
                     },
-                    path.raw());
-            }
+                    [&](const DerivedPath::Opaque & bo) {
+                        res.push_back(
+                            {.installable = req.installable,
+                             .result = InstallableWithBuildResult::Success{
+                                 .path = BuiltPath::Opaque{bo.path}, .info = req.info}});
+                    },
+                },
+                req.path.raw());
         }
 
         break;
@@ -594,23 +597,25 @@ std::vector<InstallableWithBuildResult> Installable::build2(
             printMissing(store, pathsToBuild, lvlInfo);
 
         auto buildResults = store->buildPathsWithResults(pathsToBuild, bMode, evalStore);
-        for (auto & buildResult : buildResults) {
+
+        std::map<DerivedPath, KeyedBuildResult *> resultsByPath;
+        for (auto & buildResult : buildResults)
+            resultsByPath.emplace(buildResult.path, &buildResult);
+
+        for (auto & req : requests) {
+            auto & buildResult = *resultsByPath.at(req.path);
             if (buildResult.tryGetFailure()) {
-                for (auto & aux : backmap[buildResult.path]) {
-                    res.push_back({.installable = aux.installable, .result = buildResult});
-                }
+                res.push_back({.installable = req.installable, .result = buildResult});
                 continue;
             }
-            for (auto & aux : backmap[buildResult.path]) {
-                res.push_back({
-                    aux.installable,
-                    BuiltPathWithResult{
-                        .path = toBuiltPath(buildResult, evalStore, store),
-                        .info = aux.info,
-                        .result = buildResult,
-                    },
-                });
-            }
+            res.push_back({
+                req.installable,
+                BuiltPathWithResult{
+                    .path = toBuiltPath(buildResult, evalStore, store),
+                    .info = req.info,
+                    .result = buildResult,
+                },
+            });
         }
 
         break;

--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -17,6 +17,22 @@ nix build -f multiple-outputs.nix --json a b --no-link | jq --exit-status '
       (.out | match(".*multiple-outputs-b"))))
 '
 
+# Duplicate installables should yield one result per command-line
+# argument (not one per argument squared), in command-line order even
+# when duplicates are interleaved with other installables.
+[[ $(nix build -f multiple-outputs.nix --no-link --print-out-paths b b b | wc -l) = 3 ]]
+out=$(nix build -f multiple-outputs.nix --no-link --print-out-paths b nothing-to-install b)
+[[ $(echo "$out" | wc -l) = 3 ]]
+[[ $(echo "$out" | sed -n 1p) = $(echo "$out" | sed -n 3p) ]]
+echo "$out" | sed -n 1p | grepQuiet "multiple-outputs-b"
+echo "$out" | sed -n 2p | grepQuiet "nothing-to-install"
+nix build -f multiple-outputs.nix --no-link --json b nothing-to-install b | jq --exit-status '
+  length == 3
+  and (.[0].drvPath | match(".*multiple-outputs-b.drv"))
+  and (.[1].drvPath | match(".*nothing-to-install.drv"))
+  and (.[2].drvPath | match(".*multiple-outputs-b.drv"))
+'
+
 # Test output selection using the '^' syntax.
 nix build -f multiple-outputs.nix --json a^first --no-link | jq --exit-status '
   (.[0] |


### PR DESCRIPTION
## Motivation

`nix build --no-link --print-out-paths nixpkgs#hello nixpkgs#hello nixpkgs#hello` printed the output path 9 times instead of 3 — n installables of the same derived path produced n² results. The same blowup showed up in `--json` output and `--out-link` symlink numbering (`result`, `result-1`, … `result-8`).

## Context

In `Installable::build2()`, each installable pushed its `DerivedPath` into `pathsToBuild` while also recording itself in `backmap`. `buildPathsWithResults()` returns one result per request — duplicates included — so fanning each of the n duplicate results out to all n `backmap` entries yielded n² `BuiltPathWithResult`s. (The build itself was not duplicated, since the worker dedupes goals; only the result list was.)

The fix records all requests in a vector in command-line order and deduplicates `pathsToBuild` separately, then produces results by looking up each request's build result in a map keyed by `DerivedPath`. This yields exactly one result per command-line installable while preserving command-line order even when duplicates are interleaved: `nix build A B A` yields results for A, B, A rather than grouping the duplicates — which matters for `--print-out-paths` line order, `--json` entry order, and out-link numbering.

Added regression tests to `tests/functional/build.sh` covering both the count (three duplicate installables yield exactly 3 results) and the interleaved ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)