### PR TITLE
tests/functional: skip the sentry test when Yama restricts ptrace

### DIFF
--- a/tests/functional/sentry.sh
+++ b/tests/functional/sentry.sh
@@ -15,6 +15,15 @@ if ! [[ -d $sentryDir ]]; then
     skipTest "not built with sentry support"
 fi
 
+# The crashpad handler captures a crash by ptrace-attaching to the crashing
+# process. Yama ptrace_scope >= 2 restricts ptrace to CAP_SYS_PTRACE, which an
+# unprivileged test run does not have (and PR_SET_PTRACER only helps at scope
+# 1), so no minidump can ever be written on such kernels — e.g. hardened hosts
+# or CI sandboxes.
+if [[ -r /proc/sys/kernel/yama/ptrace_scope && $(< /proc/sys/kernel/yama/ptrace_scope) -ge 2 ]]; then
+    skipTest "ptrace is restricted by Yama (kernel.yama.ptrace_scope >= 2)"
+fi
+
 waitForCrashDump() {
     local i
     for ((i = 0; i < 10; i++)); do


### PR DESCRIPTION
Afaik sentry has similar handling upstream: https://github.com/getsentry/sentry-native/blob/0.13.5/src/backends/sentry_backend_native.c#L372-L379


Observed as a deterministic nix-functional-tests:sentry failure when building determinate-nix inside an unprivileged CI sandbox on a hardened host (Talos Linux, ptrace_scope=2), while the same derivation builds clean on a workstation with ptrace_scope=1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sentry crash-test compatibility on systems with restrictive kernel tracing settings by skipping the test when crash dump capture is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->